### PR TITLE
feat: fix(issue-4): reject zero-stake vouches to prevent threshold inflation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,7 @@ impl QuorumCreditContract {
         Self::require_not_paused(&env)?;
 
         assert!(voucher != borrower, "voucher cannot vouch for self");
+        assert!(stake > 0, "stake must be greater than zero");
 
         // Enforce minimum stake if configured.
         let min_stake: i128 = env
@@ -1608,6 +1609,18 @@ mod tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         client.vouch(&borrower, &borrower, &1_000_000);
+    }
+
+    /// Issue 4: a zero-stake vouch must be rejected to prevent inflating the
+    /// vouch count without contributing to the loan threshold.
+    #[test]
+    #[should_panic(expected = "stake must be greater than zero")]
+    fn test_vouch_zero_stake_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &0);
     }
 
     #[test]


### PR DESCRIPTION
Body:
Category: Smart Contract - Bug
Priority: Medium
Estimated Time: 30 minutes

Description:
vouch accepts stake = 0, inflating the vouch count without contributing to the threshold.
closes #4 