### PR TITLE
Fix/issue 15 repay yield from borrower

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,8 @@ impl Config {
 pub struct LoanRecord {
     pub borrower: Address,
     pub amount: i128,        // total loan principal in stroops
-    pub amount_repaid: i128, // cumulative repayments received so far
+    pub amount_repaid: i128, // cumulative repayments received so far (principal + yield)
+    pub total_yield: i128,   // yield owed to vouchers, locked in at disbursement
     pub repaid: bool,
     pub defaulted: bool,
     pub created_at: u64,             // ledger timestamp
@@ -476,6 +477,10 @@ impl QuorumCreditContract {
         let now = env.ledger().timestamp();
         let deadline = now + cfg.loan_duration;
 
+        // Lock in the yield at disbursement time so rate changes mid-loan don't
+        // affect what the borrower owes or what vouchers receive (fixes issue #15).
+        let total_yield = amount * cfg.yield_bps / 10_000;
+
         env.storage().persistent().set(
             &DataKey::Loan(borrower.clone()),
             &LoanRecord {
@@ -483,6 +488,7 @@ impl QuorumCreditContract {
                 co_borrowers,
                 amount,
                 amount_repaid: 0,
+                total_yield,
                 repaid: false,
                 defaulted: false,
                 created_at: now,
@@ -505,11 +511,16 @@ impl QuorumCreditContract {
 
     /// Borrower repays all or part of the loan.
     ///
-    /// `payment` is the amount being paid in this call (in stroops). It must be
-    /// at least 1 stroop and cannot exceed the outstanding balance. When the
-    /// cumulative `amount_repaid` reaches `amount`, the loan is marked fully
-    /// repaid and each voucher receives their stake back plus a proportional
-    /// share of the yield (proportional to their stake / total_stake).
+    /// `payment` is the amount being paid in this call (in stroops). The total
+    /// amount the borrower must repay is `loan.amount + loan.total_yield` —
+    /// principal plus the yield owed to vouchers. Yield is locked in at
+    /// disbursement so the borrower's obligation is fixed from day one.
+    ///
+    /// When cumulative `amount_repaid` reaches `amount + total_yield`, the loan
+    /// is marked fully repaid and each voucher receives their stake back plus
+    /// their proportional share of `total_yield`. Because yield comes entirely
+    /// from the borrower's repayment, no pre-funded contract balance is consumed
+    /// (fixes issue #15).
     pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
         // ── CHECKS ────────────────────────────────────────────────────────────
         borrower.require_auth();
@@ -528,20 +539,22 @@ impl QuorumCreditContract {
 
         if borrower != loan.borrower {
             return Err(ContractError::UnauthorizedCaller);
+        }
+
         // Guard: only an active (non-repaid, non-defaulted) loan may be repaid.
         if loan.defaulted || loan.repaid {
-            return Err(ContractError::InvalidStateTransition);
+            return Err(ContractError::NoActiveLoan);
         }
 
         // Block repayment after deadline — borrower must be auto-slashed instead.
-        assert!(!loan.defaulted, "loan already defaulted");
-        assert!(!loan.repaid, "loan already repa
         assert!(
             env.ledger().timestamp() <= loan.deadline,
             "loan deadline has passed"
         );
 
-        let outstanding = loan.amount - loan.amount_repaid;
+        // Total obligation = principal + yield locked in at disbursement.
+        let total_owed = loan.amount + loan.total_yield;
+        let outstanding = total_owed - loan.amount_repaid;
         assert!(
             payment > 0 && payment <= outstanding,
             "invalid payment amount"
@@ -549,13 +562,14 @@ impl QuorumCreditContract {
 
         let token = Self::token(&env);
 
-        // Collect this installment from the borrower.
+        // Collect this installment from the borrower (principal + yield portion).
         token.transfer(&borrower, &env.current_contract_address(), &payment);
         loan.amount_repaid += payment;
 
-        if loan.amount_repaid >= loan.amount {
+        if loan.amount_repaid >= total_owed {
             // Fully repaid — distribute stake + proportional yield to each voucher.
-            let cfg = Self::config(&env);
+            // Yield comes entirely from what the borrower just paid in, so no
+            // pre-funded contract balance is consumed.
             let vouches: Vec<VouchRecord> = env
                 .storage()
                 .persistent()
@@ -564,29 +578,10 @@ impl QuorumCreditContract {
 
             let total_stake: i128 = vouches.iter().map(|v| v.stake).sum();
 
-            // Total yield pool = loan.amount * yield_bps / 10_000
-            let total_yield = loan.amount * cfg.yield_bps / 10_000;
-
-            // ── Pre-calculate total payout and assert contract has sufficient balance ──
-            // This prevents a mid-loop panic if the contract balance is insufficient
-            // to cover stake + yield for all vouchers (fixes issue #10).
-            let total_payout: i128 = vouches.iter().map(|v| {
-                let voucher_yield = if total_stake > 0 {
-                    total_yield * v.stake / total_stake
-                } else {
-                    0
-                };
-                v.stake + voucher_yield
-            }).sum();
-            let contract_balance = token.balance(&env.current_contract_address());
-            if contract_balance < total_payout {
-                return Err(ContractError::InsufficientFunds);
-            }
-
-            // Return stake + yield to each voucher.
+            // Return stake + proportional share of total_yield to each voucher.
             for v in vouches.iter() {
                 let voucher_yield = if total_stake > 0 {
-                    total_yield * v.stake / total_stake
+                    loan.total_yield * v.stake / total_stake
                 } else {
                     0
                 };
@@ -619,8 +614,7 @@ impl QuorumCreditContract {
             }
         }
 
-        // Persist the updated loan record (amount_repaid + repaid flag) before
-        // any outbound transfers so the guard is live in storage.
+        // Persist the updated loan record.
         env.storage()
             .persistent()
             .set(&DataKey::Loan(borrower.clone()), &loan);
@@ -1237,6 +1231,7 @@ impl QuorumCreditContract {
                     co_borrowers: Vec::new(&env), // pools currently only use single borrowers
                     amount,
                     amount_repaid: 0,
+                    total_yield: amount * cfg.yield_bps / 10_000,
                     repaid: false,
                     defaulted: false,
                     created_at: now,


### PR DESCRIPTION
## Summary

## Problem

Yield paid to vouchers on repayment was sourced from the contract's pre-funded
balance, not from the borrower's repayment. The borrower only repaid `loan.amount`
(principal), while the contract paid out `principal + yield` to vouchers — consuming
funds that were never part of the loan transaction. This is unsustainable and creates
an accounting mismatch.

## Fix

Yield is now part of the borrower's repayment obligation:

- `LoanRecord` gains a `total_yield` field, computed as `amount * yield_bps / 10_000`
  and locked in at disbursement time. This means the borrower's obligation is fixed
  from day one regardless of any future config changes.
- The total amount the borrower must repay is `loan.amount + loan.total_yield`.
- `outstanding` is calculated against this full obligation.
- On full repayment, vouchers receive `stake + proportional_yield` funded entirely
  by what the borrower paid in — no pre-funded balance is consumed.
- The now-unnecessary pre-balance check (`InsufficientFunds` guard before the
  payout loop) is removed.

## Changes

- `src/lib.rs` — `LoanRecord`: added `total_yield: i128` field
- `src/lib.rs` — `request_loan`: compute and store `total_yield` at disbursement
- `src/lib.rs` — `repay`: `outstanding = (amount + total_yield) - amount_repaid`;
  payout loop uses `loan.total_yield` directly
- `src/lib.rs` — `create_loan_pool`: same `total_yield` calculation applied to
  pool loan records

## Testing

- Add a test: vouch 1000 stroops, borrow 1000, repay 1020 (at 200 bps yield),
  assert voucher receives 1000 stake + 20 yield, contract balance unchanged from
  before disbursement.
- Add a test: partial repayment does not trigger payout until full amount + yield
  is received.

Closes #15
