### PR TITLE
Security/upgrade mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,50 @@ stellar contract deploy \
   --source $DEPLOYER_SECRET_KEY
 ```
 
+### Upgrading the Contract
+
+The `upgrade` function allows the admin (or multisig quorum) to replace the contract WASM after deployment. This is the only path to patching a live vulnerability.
+
+**Upgrade process:**
+
+```
+Step 1: Build the new WASM
+Step 2: (Recommended) Pause the contract to halt user activity
+Step 3: Upload the new WASM and obtain its hash
+Step 4: Call upgrade() — requires admin_threshold signatures
+Step 5: Unpause the contract
+```
+
+```bash
+# Step 1 — Build
+cargo build --target wasm32-unknown-unknown --release
+
+# Step 2 — Pause (recommended)
+stellar contract invoke \
+  --id $CONTRACT_ID --fn pause --network testnet --source $ADMIN_SECRET_KEY \
+  -- --admin_signers '["'$ADMIN_ADDRESS'"]'
+
+# Step 3 — Upload new WASM, capture the returned hash
+NEW_WASM_HASH=$(stellar contract install \
+  --wasm target/wasm32-unknown-unknown/release/quorum_credit.wasm \
+  --network testnet \
+  --source $ADMIN_SECRET_KEY)
+
+# Step 4 — Upgrade (admin_threshold admins must sign)
+stellar contract invoke \
+  --id $CONTRACT_ID --fn upgrade --network testnet --source $ADMIN_SECRET_KEY \
+  -- \
+  --admin_signers '["'$ADMIN_ADDRESS'"]' \
+  --new_wasm_hash $NEW_WASM_HASH
+
+# Step 5 — Unpause
+stellar contract invoke \
+  --id $CONTRACT_ID --fn unpause --network testnet --source $ADMIN_SECRET_KEY \
+  -- --admin_signers '["'$ADMIN_ADDRESS'"]'
+```
+
+> ⚠️ The `upgrade` call requires `admin_threshold` distinct admin signatures — the same multisig quorum used for all other admin operations. A single compromised key cannot unilaterally upgrade the contract.
+
 ---
 
 ## Architecture

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2748,6 +2748,32 @@ mod tests {
         assert!(client.get_loan_pool(&999u64).is_none());
     }
 
+    // ── Upgrade Tests ─────────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_upgrade_rejected_without_admin_approval() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let outsider = Address::generate(&env);
+        let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.upgrade(&single_admin_signers(&env, &outsider), &fake_hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_upgrade_multisig_rejects_single_signer() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin_one, _admin_two, _admin_three, _borrower, _voucher) =
+            setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.upgrade(&single_admin_signers(&env, &admin_one), &fake_hash);
+    }
+
     // ── Rate Limiting: vouch cooldown ─────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION

Title: security: add WASM upgrade mechanism with admin-multisig guard

Body:

## Problem

No documented or tested upgrade path existed. A critical vulnerability discovered post-deploy could not be patched — 
the contract would be permanently broken.

## What's here

The upgrade() function was already wired up in the contract but untested and undocumented. This PR completes the 
feature.

### Contract (upgrade function)

rust
pub fn upgrade(env: Env, admin_signers: Vec<Address>, new_wasm_hash: BytesN<32>) {
    Self::require_admin_approval(&env, &admin_signers);
    env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
    env.events().publish((symbol_short!("upgrade"),), new_wasm_hash);
}


- Requires admin_threshold distinct admin signatures — the same multisig quorum used for slash, pause, set_config, 
etc.
- A single compromised admin key cannot unilaterally upgrade the contract.
- Emits an upgrade event with the new WASM hash for on-chain auditability.

### Tests added

| Test | Verifies |
|---|---|
| test_upgrade_rejected_without_admin_approval | Non-admin signer is rejected before any WASM operation |
| test_upgrade_multisig_rejects_single_signer | Single signer rejected when threshold is 2 |

### Docs added (README)

Full upgrade runbook:
1. Build new WASM
2. Pause the contract
3. stellar contract install → get WASM hash
4. Call upgrade() with admin_threshold signatures
5. Unpause

## Security notes

- Pausing before upgrading is recommended but not enforced — you need to be able to upgrade even if the contract is 
stuck in a bad state that prevents pausing.
- The WASM hash is committed on-chain before the upgrade call, so the exact bytecode being deployed is auditable.
closes #98