### PR TITLE
feat: add credit-score spec (requirements, design, tasks)

### DIFF
--- a/.kiro/specs/credit-score/.config.kiro
+++ b/.kiro/specs/credit-score/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "c9c32f4f-c752-4797-8fdb-e08d5bf52668", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/credit-score/design.md
+++ b/.kiro/specs/credit-score/design.md
@@ -1,0 +1,182 @@
+# Design Document: Credit Score
+
+## Overview
+
+The credit score feature adds a deterministic, on-chain reputation signal to the QuorumCredit lending protocol. It derives a single `u32` score from two counters already maintained in persistent storage — `RepaymentCount` and `DefaultCount` — and exposes it through a new read-only contract function `get_credit_score(borrower)`.
+
+The score formula is:
+
+```
+CreditScore = (repayment_count * 10).saturating_sub(default_count * 20)
+```
+
+Because both counters are already incremented by the existing `repay` and `execute_slash` / `vote_slash` paths, the implementation is purely additive: no existing logic changes, only a new view function and its test module are introduced.
+
+## Architecture
+
+The feature sits entirely within the existing `QuorumCreditContract` Soroban smart contract. No new contracts, cross-contract calls, or off-chain components are required.
+
+```mermaid
+flowchart LR
+    subgraph Existing paths
+        A[repay()] -->|increments| RC[DataKey::RepaymentCount]
+        B[execute_slash()] -->|increments| DC[DataKey::DefaultCount]
+    end
+    subgraph New read path
+        RC --> CS[get_credit_score()]
+        DC --> CS
+    end
+    CS -->|returns u32| Caller
+```
+
+The two counters are already written by:
+- `loan::repay` — increments `RepaymentCount` on full repayment.
+- `governance::execute_slash` (internal) — increments `DefaultCount` on slash execution.
+
+`get_credit_score` only reads these counters; it never writes.
+
+## Components and Interfaces
+
+### New public function: `get_credit_score`
+
+Added to `QuorumCreditContract` in `src/lib.rs`, delegating to a helper in `src/loan.rs` (alongside the existing `repayment_count` and `default_count` helpers).
+
+```rust
+// src/lib.rs
+pub fn get_credit_score(env: Env, borrower: Address) -> u32 {
+    loan::get_credit_score(env, borrower)
+}
+```
+
+```rust
+// src/loan.rs
+pub fn get_credit_score(env: Env, borrower: Address) -> u32 {
+    let repayments: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RepaymentCount(borrower.clone()))
+        .unwrap_or(0);
+    let defaults: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DefaultCount(borrower))
+        .unwrap_or(0);
+    (repayments * 10).saturating_sub(defaults * 20)
+}
+```
+
+### Existing counter writers (unchanged)
+
+| Function | Storage key written | Trigger |
+|---|---|---|
+| `loan::repay` | `DataKey::RepaymentCount(borrower)` | Full repayment |
+| `governance::execute_slash` | `DataKey::DefaultCount(borrower)` | Slash quorum reached or timelock executed |
+
+### Existing counter readers (unchanged)
+
+`repayment_count(borrower)` and `default_count(borrower)` already exist in `lib.rs` and `loan.rs`.
+
+## Data Models
+
+No new storage keys are introduced. The feature reuses:
+
+| Key | Type | Semantics |
+|---|---|---|
+| `DataKey::RepaymentCount(Address)` | `u32` | Total fully-repaid loans for a borrower. Defaults to 0. |
+| `DataKey::DefaultCount(Address)` | `u32` | Total slashed/defaulted loans for a borrower. Defaults to 0. |
+
+Both keys live in **persistent** storage, consistent with the rest of the borrower-scoped data.
+
+The computed score is **not stored** — it is derived on every call to `get_credit_score`. This avoids any possibility of the stored score drifting out of sync with the underlying counters.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Score formula fidelity
+
+*For any* borrower address, `get_credit_score(borrower)` must equal `(repayment_count(borrower) * 10).saturating_sub(default_count(borrower) * 20)`.
+
+**Validates: Requirements 3.2, 4.1**
+
+### Property 2: Zero-history score is zero
+
+*For any* borrower address that has never repaid or defaulted (both counters are 0), `get_credit_score` must return 0.
+
+**Validates: Requirements 3.3**
+
+### Property 3: Saturation floor — no underflow
+
+*For any* combination of repayment count `r` and default count `d` where `d * 20 > r * 10`, `get_credit_score` must return 0 rather than wrapping or panicking.
+
+**Validates: Requirements 3.4**
+
+### Property 4: Read-only — no state mutation
+
+*For any* borrower address, calling `get_credit_score` must leave `RepaymentCount`, `DefaultCount`, and all other storage keys unchanged.
+
+**Validates: Requirements 3.5**
+
+### Property 5: Repayment increments score by 10
+
+*For any* borrower, after a full repayment the score must increase by exactly 10 compared to the score before that repayment (subject to the saturation floor).
+
+**Validates: Requirements 1.1, 4.2**
+
+### Property 6: Default decrements score by 20 (floored at 0)
+
+*For any* borrower, after a slash the score must decrease by exactly 20 compared to the score before the slash, floored at 0.
+
+**Validates: Requirements 2.1, 4.3**
+
+## Error Handling
+
+`get_credit_score` has no failure modes:
+
+- Missing storage keys are treated as 0 via `unwrap_or(0)` — consistent with the existing `repayment_count` and `default_count` helpers.
+- Arithmetic uses `saturating_sub`, so the result is always a valid `u32` with no possibility of panic or wrap-around.
+- The function takes no auth, requires no active loan, and reads only persistent storage.
+
+## Testing Strategy
+
+### Dual testing approach
+
+Both unit tests (specific examples and edge cases) and property-based tests (universal properties across generated inputs) are required.
+
+### Unit tests
+
+Located in a new test module `src/credit_score_test.rs`, registered under `#[cfg(test)]` in `lib.rs`.
+
+Specific cases to cover:
+
+- `get_credit_score` returns 0 for a fresh borrower (no history). *(Req 5.1)*
+- Score increases by 10 after each successful repayment. *(Req 5.2)*
+- Score decreases by 20 after each default, floored at 0. *(Req 5.3)*
+- `RepaymentCount` and `DefaultCount` are each incremented exactly once per qualifying event. *(Req 5.4)*
+- Score is 0 when defaults dominate (e.g. 0 repayments, 1 default → score = 0). *(Req 3.4)*
+
+### Property-based tests
+
+Use the [`proptest`](https://github.com/proptest-rs/proptest) crate (already common in Rust ecosystems; add to `[dev-dependencies]` in `Cargo.toml`).
+
+Each property test must run a minimum of **100 iterations**.
+
+Tag format for each test: `// Feature: credit-score, Property <N>: <property_text>`
+
+| Property | Test description |
+|---|---|
+| P1 — Formula fidelity | Generate arbitrary `(r: u32, d: u32)`, set counters directly in storage, assert `get_credit_score == (r*10).saturating_sub(d*20)`. |
+| P2 — Zero history | Generate arbitrary borrower address with no storage entries, assert score == 0. |
+| P3 — Saturation floor | Generate `(r, d)` where `d*20 > r*10`, assert score == 0. |
+| P4 — Read-only | Snapshot all relevant storage keys before and after calling `get_credit_score`, assert no change. |
+| P5 — Repayment delta | Generate a borrower with arbitrary prior history, record score, simulate a repayment increment, assert new score == old score + 10 (or capped at u32::MAX). |
+| P6 — Default delta | Generate a borrower with arbitrary prior history, record score, simulate a default increment, assert new score == max(0, old score - 20). |
+
+Properties P5 and P6 are comprehensive and subsume the unit-test examples for those cases, but the unit tests are retained for readability and regression anchoring.
+
+**`Cargo.toml` addition:**
+
+```toml
+[dev-dependencies]
+proptest = "1"
+```

--- a/.kiro/specs/credit-score/requirements.md
+++ b/.kiro/specs/credit-score/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds an on-chain credit score to the QuorumCredit lending protocol. Each borrower accumulates a credit history derived from their repayment and default events. The score is computed deterministically from `repayment_count` and `default_count` fields stored in persistent contract storage, and is exposed as a read-only view function `get_credit_score(borrower)`. The goal is to give lenders, vouchers, and integrators a single numeric signal of borrower trustworthiness without relying on off-chain data.
+
+## Glossary
+
+- **Contract**: The `QuorumCreditContract` Soroban smart contract.
+- **Borrower**: An `Address` that has requested at least one loan through the Contract.
+- **CreditScore**: A `u32` value computed from a Borrower's on-chain repayment history. Higher is better.
+- **RepaymentCount**: A `u32` counter stored under `DataKey::RepaymentCount(borrower)` that records the total number of loans fully repaid by a Borrower.
+- **DefaultCount**: A `u32` counter stored under `DataKey::DefaultCount(borrower)` that records the total number of loans that ended in a slash or expiry default for a Borrower.
+- **Slash**: The governance action that marks a loan as defaulted and penalises vouchers.
+- **ScoreFormula**: The deterministic function `CreditScore = RepaymentCount * 10 - DefaultCount * 20`, floored at 0.
+
+---
+
+## Requirements
+
+### Requirement 1: Track Repayment Count
+
+**User Story:** As a voucher, I want the Contract to record every successful full repayment so that I can assess a Borrower's reliability before staking.
+
+#### Acceptance Criteria
+
+1. WHEN a Borrower fully repays an active loan, THE Contract SHALL increment `RepaymentCount` for that Borrower by exactly 1.
+2. THE Contract SHALL initialise `RepaymentCount` to 0 for any Borrower that has never repaid a loan.
+3. WHEN `repayment_count(borrower)` is called, THE Contract SHALL return the current `RepaymentCount` for that Borrower.
+4. WHILE a loan is only partially repaid, THE Contract SHALL NOT increment `RepaymentCount`.
+
+---
+
+### Requirement 2: Track Default Count
+
+**User Story:** As a voucher, I want the Contract to record every default event so that I can avoid staking on repeat defaulters.
+
+#### Acceptance Criteria
+
+1. WHEN a Borrower's loan is slashed via the governance slash path, THE Contract SHALL increment `DefaultCount` for that Borrower by exactly 1.
+2. THE Contract SHALL initialise `DefaultCount` to 0 for any Borrower that has never defaulted.
+3. WHEN `default_count(borrower)` is called, THE Contract SHALL return the current `DefaultCount` for that Borrower.
+
+---
+
+### Requirement 3: Compute and Expose Credit Score
+
+**User Story:** As an integrator, I want a single numeric credit score per Borrower so that I can rank borrowers without reading multiple storage keys.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL expose a read-only function `get_credit_score(borrower: Address) -> u32`.
+2. WHEN `get_credit_score(borrower)` is called, THE Contract SHALL return `(RepaymentCount * 10).saturating_sub(DefaultCount * 20)` as a `u32`.
+3. WHEN a Borrower has no repayment or default history, THE Contract SHALL return a `CreditScore` of 0.
+4. IF `DefaultCount * 20` exceeds `RepaymentCount * 10`, THEN THE Contract SHALL return 0 rather than underflowing.
+5. WHEN `get_credit_score(borrower)` is called, THE Contract SHALL NOT modify any contract state.
+
+---
+
+### Requirement 4: Score Consistency Invariants
+
+**User Story:** As a protocol auditor, I want the credit score to remain consistent with the underlying counters so that the score cannot be manipulated independently.
+
+#### Acceptance Criteria
+
+1. THE Contract SHALL ensure that for all Borrowers, `get_credit_score(borrower)` equals `(repayment_count(borrower) * 10).saturating_sub(default_count(borrower) * 20)` at all times.
+2. WHEN `RepaymentCount` is incremented, THE Contract SHALL reflect the updated value in the next call to `get_credit_score`.
+3. WHEN `DefaultCount` is incremented, THE Contract SHALL reflect the updated value in the next call to `get_credit_score`.
+
+---
+
+### Requirement 5: Test Coverage
+
+**User Story:** As a developer, I want automated tests for the credit score feature so that regressions are caught before deployment.
+
+#### Acceptance Criteria
+
+1. THE test suite SHALL include a test that verifies `get_credit_score` returns 0 for a Borrower with no history.
+2. THE test suite SHALL include a test that verifies `get_credit_score` increases by 10 after each successful repayment.
+3. THE test suite SHALL include a test that verifies `get_credit_score` decreases by 20 after each default, floored at 0.
+4. THE test suite SHALL include a test that verifies `RepaymentCount` and `DefaultCount` are incremented exactly once per qualifying event.
+5. THE test suite SHALL include a property test verifying that for any sequence of repayments `r` and defaults `d`, `get_credit_score` equals `(r * 10).saturating_sub(d * 20)`.

--- a/.kiro/specs/credit-score/tasks.md
+++ b/.kiro/specs/credit-score/tasks.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Credit Score
+
+## Overview
+
+Purely additive implementation: add `get_credit_score()` to `src/loan.rs` and expose it via `src/lib.rs`, then write unit and property-based tests in a new `src/credit_score_test.rs` module. No existing logic changes.
+
+## Tasks
+
+- [ ] 1. Add `proptest` to dev-dependencies in `Cargo.toml`
+  - Append `proptest = "1"` under `[dev-dependencies]`
+  - _Requirements: 5.5_
+
+- [ ] 2. Implement `get_credit_score` in `src/loan.rs`
+  - [ ] 2.1 Add the `get_credit_score(env: Env, borrower: Address) -> u32` function
+    - Read `DataKey::RepaymentCount(borrower.clone())` with `unwrap_or(0)`
+    - Read `DataKey::DefaultCount(borrower)` with `unwrap_or(0)`
+    - Return `(repayments * 10).saturating_sub(defaults * 20)`
+    - Place alongside the existing `repayment_count` and `default_count` helpers
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+
+- [ ] 3. Expose `get_credit_score` on `QuorumCreditContract` in `src/lib.rs`
+  - [ ] 3.1 Add the public contract method delegating to `loan::get_credit_score`
+    - Add `pub fn get_credit_score(env: Env, borrower: Address) -> u32` to `#[contractimpl]`
+    - Place it alongside `repayment_count` and `default_count`
+    - _Requirements: 3.1_
+
+- [ ] 4. Create `src/credit_score_test.rs` with unit tests
+  - [ ] 4.1 Write unit test: score is 0 for a fresh borrower with no history
+    - Use `soroban_sdk::testutils` to set up a minimal env with no storage entries
+    - Assert `get_credit_score` returns 0
+    - _Requirements: 3.3, 5.1_
+  - [ ] 4.2 Write unit test: score increases by 10 after each successful repayment
+    - Manually set `DataKey::RepaymentCount` to 1, 2, 3 and assert scores 10, 20, 30
+    - _Requirements: 1.1, 5.2_
+  - [ ] 4.3 Write unit test: score decreases by 20 after each default, floored at 0
+    - Set `DataKey::DefaultCount` to 1 with 0 repayments → assert score 0
+    - Set repayments=3, defaults=2 → assert score `(30).saturating_sub(40)` = 0
+    - Set repayments=5, defaults=1 → assert score 30
+    - _Requirements: 2.1, 3.4, 5.3_
+  - [ ] 4.4 Write unit test: `RepaymentCount` and `DefaultCount` are each incremented exactly once per qualifying event
+    - Simulate a full repayment via `loan::repay` in a test env and assert `repayment_count` goes from 0 to 1
+    - Simulate a slash via `governance::vote_slash` reaching quorum and assert `default_count` goes from 0 to 1
+    - _Requirements: 1.1, 2.1, 5.4_
+
+- [ ] 5. Checkpoint — ensure all unit tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 6. Add property-based tests to `src/credit_score_test.rs`
+  - [ ]* 6.1 Write property test for formula fidelity (Property 1)
+    - **Property 1: Score formula fidelity**
+    - **Validates: Requirements 3.2, 4.1**
+    - Generate arbitrary `(r: u32, d: u32)`, write them directly to storage, call `get_credit_score`, assert result equals `(r * 10).saturating_sub(d * 20)`
+    - Tag: `// Feature: credit-score, Property 1: Score formula fidelity`
+  - [ ]* 6.2 Write property test for zero-history score (Property 2)
+    - **Property 2: Zero-history score is zero**
+    - **Validates: Requirements 3.3**
+    - Generate arbitrary borrower address with no storage entries, assert score == 0
+    - Tag: `// Feature: credit-score, Property 2: Zero-history score is zero`
+  - [ ]* 6.3 Write property test for saturation floor (Property 3)
+    - **Property 3: Saturation floor — no underflow**
+    - **Validates: Requirements 3.4**
+    - Generate `(r, d)` where `d * 20 > r * 10` (i.e. `d > r / 2`), assert score == 0
+    - Tag: `// Feature: credit-score, Property 3: Saturation floor — no underflow`
+  - [ ]* 6.4 Write property test for read-only behaviour (Property 4)
+    - **Property 4: Read-only — no state mutation**
+    - **Validates: Requirements 3.5**
+    - Snapshot `RepaymentCount` and `DefaultCount` before calling `get_credit_score`, assert both are unchanged after the call
+    - Tag: `// Feature: credit-score, Property 4: Read-only — no state mutation`
+  - [ ]* 6.5 Write property test for repayment delta (Property 5)
+    - **Property 5: Repayment increments score by 10**
+    - **Validates: Requirements 1.1, 4.2**
+    - Generate arbitrary prior `(r, d)`, record score, increment `RepaymentCount` by 1, assert new score == `old_score.saturating_add(10)`
+    - Tag: `// Feature: credit-score, Property 5: Repayment increments score by 10`
+  - [ ]* 6.6 Write property test for default delta (Property 6)
+    - **Property 6: Default decrements score by 20 (floored at 0)**
+    - **Validates: Requirements 2.1, 4.3**
+    - Generate arbitrary prior `(r, d)`, record score, increment `DefaultCount` by 1, assert new score == `old_score.saturating_sub(20)`
+    - Tag: `// Feature: credit-score, Property 6: Default decrements score by 20 (floored at 0)`
+
+- [ ] 7. Register `credit_score_test` module in `src/lib.rs`
+  - Add `#[cfg(test)] mod credit_score_test;` alongside the other test module declarations
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+
+- [ ] 8. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- Property tests require `proptest = "1"` in `[dev-dependencies]` (Task 1)
+- All implementation is additive — no existing functions are modified
+- `saturating_sub` on `u32` guarantees the floor-at-0 behaviour without any explicit `if` branch


### PR DESCRIPTION
closes #32
Description:
Track each borrower's repayment history to build an on-chain credit score.

Tasks:

Add repayment_count and default_count fields to borrower record
Increment on repay/slash
Expose get_credit_score(borrower) view
Add tests