### PR TITLE
feat: Add double repay panic functionality

### DIFF
--- a/QuorumCredit/src/admin.rs
+++ b/QuorumCredit/src/admin.rs
@@ -1,0 +1,374 @@
+use crate::helpers::{config, require_admin_approval, validate_admin_config};
+use crate::types::{Config, DataKey};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Vec};
+
+pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    assert!(
+        !cfg.admins.iter().any(|a| a == new_admin),
+        "address is already an admin"
+    );
+
+    cfg.admins.push_back(new_admin.clone());
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events()
+        .publish((symbol_short!("admin"), symbol_short!("added")), new_admin);
+}
+
+pub fn remove_admin(env: Env, admin_signers: Vec<Address>, admin_to_remove: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    let idx = cfg
+        .admins
+        .iter()
+        .position(|a| a == admin_to_remove)
+        .expect("address is not an admin") as u32;
+
+    cfg.admins.remove(idx);
+
+    assert!(!cfg.admins.is_empty(), "cannot remove the last admin");
+    assert!(
+        cfg.admin_threshold <= cfg.admins.len(),
+        "removal would make threshold unsatisfiable"
+    );
+
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("removed")),
+        admin_to_remove,
+    );
+}
+
+pub fn rotate_admin(env: Env, admin_signers: Vec<Address>, old_admin: Address, new_admin: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    assert!(old_admin != new_admin, "old and new admin must differ");
+
+    let mut cfg = config(&env);
+
+    assert!(
+        !cfg.admins.iter().any(|a| a == new_admin),
+        "new admin is already in the admin set"
+    );
+
+    let idx = cfg
+        .admins
+        .iter()
+        .position(|a| a == old_admin)
+        .expect("old admin not found") as u32;
+
+    cfg.admins.set(idx, new_admin.clone());
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("rotated")),
+        (old_admin, new_admin),
+    );
+}
+
+pub fn set_admin_threshold(env: Env, admin_signers: Vec<Address>, new_threshold: u32) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    assert!(new_threshold > 0, "threshold must be greater than zero");
+    assert!(
+        new_threshold <= cfg.admins.len(),
+        "threshold cannot exceed admin count"
+    );
+
+    cfg.admin_threshold = new_threshold;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("thresh")),
+        new_threshold,
+    );
+}
+
+pub fn set_protocol_fee(env: Env, admin_signers: Vec<Address>, fee_bps: u32) {
+    require_admin_approval(&env, &admin_signers);
+    assert!(fee_bps <= 10_000, "fee_bps must not exceed 10000");
+    env.storage()
+        .instance()
+        .set(&DataKey::ProtocolFeeBps, &fee_bps);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("fee")),
+        (
+            admin_signers.get(0).unwrap(),
+            fee_bps,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+pub fn whitelist_voucher(env: Env, admin_signers: Vec<Address>, voucher: Address) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage()
+        .persistent()
+        .set(&DataKey::VoucherWhitelist(voucher), &true);
+}
+
+pub fn set_fee_treasury(env: Env, admin_signers: Vec<Address>, treasury: Address) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::FeeTreasury, &treasury);
+}
+
+pub fn upgrade(env: Env, admin_signers: Vec<Address>, new_wasm_hash: BytesN<32>) {
+    require_admin_approval(&env, &admin_signers);
+    env.deployer()
+        .update_current_contract_wasm(new_wasm_hash.clone());
+    env.events()
+        .publish((symbol_short!("upgrade"),), new_wasm_hash);
+}
+
+pub fn pause(env: Env, admin_signers: Vec<Address>) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage().instance().set(&DataKey::Paused, &true);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("pause")),
+        (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+    );
+}
+
+pub fn unpause(env: Env, admin_signers: Vec<Address>) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage().instance().set(&DataKey::Paused, &false);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("unpause")),
+        (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+    );
+}
+
+pub fn blacklist(env: Env, admin_signers: Vec<Address>, borrower: Address) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Blacklisted(borrower), &true);
+}
+
+pub fn set_config(env: Env, admin_signers: Vec<Address>, config: Config) {
+    require_admin_approval(&env, &admin_signers);
+    validate_admin_config(&env, &config.admins, config.admin_threshold)
+        .expect("invalid admin config");
+    assert!(config.yield_bps >= 0, "yield_bps must be non-negative");
+    assert!(
+        config.slash_bps > 0 && config.slash_bps <= 10_000,
+        "slash_bps must be 1-10000"
+    );
+    assert!(
+        config.max_vouchers > 0,
+        "max_vouchers must be greater than zero"
+    );
+    assert!(
+        config.min_loan_amount > 0,
+        "min_loan_amount must be greater than zero"
+    );
+    assert!(
+        config.loan_duration > 0,
+        "loan_duration must be greater than zero"
+    );
+    assert!(
+        config.max_loan_to_stake_ratio > 0,
+        "max_loan_to_stake_ratio must be greater than zero"
+    );
+    env.storage().instance().set(&DataKey::Config, &config);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("config")),
+        (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+    );
+}
+
+pub fn update_config(
+    env: Env,
+    admin_signers: Vec<Address>,
+    yield_bps: Option<i128>,
+    slash_bps: Option<i128>,
+) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    if let Some(new_yield_bps) = yield_bps {
+        assert!(new_yield_bps >= 0, "yield_bps must be non-negative");
+        cfg.yield_bps = new_yield_bps;
+    }
+
+    if let Some(new_slash_bps) = slash_bps {
+        assert!(
+            new_slash_bps > 0 && new_slash_bps <= 10_000,
+            "slash_bps must be 1-10000"
+        );
+        cfg.slash_bps = new_slash_bps;
+    }
+
+    env.storage().instance().set(&DataKey::Config, &cfg);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("upconfig")),
+        (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+    );
+}
+
+pub fn set_reputation_nft(env: Env, admin_signers: Vec<Address>, nft_contract: Address) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage()
+        .instance()
+        .set(&DataKey::ReputationNft, &nft_contract);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("repnft")),
+        (
+            admin_signers.get(0).unwrap(),
+            nft_contract,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+pub fn set_min_stake(env: Env, admin_signers: Vec<Address>, amount: i128) {
+    require_admin_approval(&env, &admin_signers);
+    assert!(amount >= 0, "min stake cannot be negative");
+    env.storage().instance().set(&DataKey::MinStake, &amount);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("minstake")),
+        (
+            admin_signers.get(0).unwrap(),
+            amount,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+pub fn set_max_loan_amount(env: Env, admin_signers: Vec<Address>, amount: i128) {
+    require_admin_approval(&env, &admin_signers);
+    assert!(amount >= 0, "max loan amount cannot be negative");
+    env.storage()
+        .instance()
+        .set(&DataKey::MaxLoanAmount, &amount);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("maxloan")),
+        (
+            admin_signers.get(0).unwrap(),
+            amount,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+pub fn set_min_vouchers(env: Env, admin_signers: Vec<Address>, count: u32) {
+    require_admin_approval(&env, &admin_signers);
+    env.storage().instance().set(&DataKey::MinVouchers, &count);
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("minvchrs")),
+        (
+            admin_signers.get(0).unwrap(),
+            count,
+            env.ledger().timestamp(),
+        ),
+    );
+}
+
+pub fn set_max_loan_to_stake_ratio(env: Env, admin_signers: Vec<Address>, ratio: u32) {
+    require_admin_approval(&env, &admin_signers);
+    assert!(
+        ratio > 0,
+        "max_loan_to_stake_ratio must be greater than zero"
+    );
+    let mut cfg = config(&env);
+    cfg.max_loan_to_stake_ratio = ratio;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+}
+
+// View functions
+pub fn get_protocol_fee(env: Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ProtocolFeeBps)
+        .unwrap_or(0)
+}
+
+pub fn get_fee_treasury(env: Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::FeeTreasury)
+}
+
+pub fn is_blacklisted(env: Env, borrower: Address) -> bool {
+    env.storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::Blacklisted(borrower))
+        .unwrap_or(false)
+}
+
+pub fn get_min_stake(env: Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinStake)
+        .unwrap_or(0)
+}
+
+pub fn get_max_loan_amount(env: Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MaxLoanAmount)
+        .unwrap_or(0)
+}
+
+pub fn get_min_vouchers(env: Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MinVouchers)
+        .unwrap_or(0)
+}
+
+pub fn get_max_loan_to_stake_ratio(env: Env) -> u32 {
+    config(&env).max_loan_to_stake_ratio
+}
+
+pub fn get_config(env: Env) -> Config {
+    config(&env)
+}
+
+pub fn add_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
+    require_admin_approval(&env, &admin_signers);
+    let mut cfg = config(&env);
+    assert!(
+        !cfg.allowed_tokens.iter().any(|t| t == token) && token != cfg.token,
+        "token already allowed"
+    );
+    cfg.allowed_tokens.push_back(token);
+    env.storage().instance().set(&DataKey::Config, &cfg);
+}
+
+pub fn remove_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
+    require_admin_approval(&env, &admin_signers);
+    let mut cfg = config(&env);
+    let idx = cfg
+        .allowed_tokens
+        .iter()
+        .position(|t| t == token)
+        .expect("token not in allowed list") as u32;
+    cfg.allowed_tokens.remove(idx);
+    env.storage().instance().set(&DataKey::Config, &cfg);
+}
+
+pub fn get_admins(env: Env) -> Vec<Address> {
+    config(&env).admins
+}
+
+pub fn get_admin_threshold(env: Env) -> u32 {
+    config(&env).admin_threshold
+}
+
+pub fn is_whitelisted(env: Env, voucher: Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VoucherWhitelist(voucher))
+        .unwrap_or(false)
+}

--- a/QuorumCredit/src/bug_condition_test.rs
+++ b/QuorumCredit/src/bug_condition_test.rs
@@ -1,0 +1,103 @@
+/// Bug Condition Tests — Invalid Token Address Validation
+///
+/// Verifies that `initialize` rejects a plain account address (not a SEP-41
+/// token contract) with a typed `ContractError::InvalidToken` before writing
+/// any state, rather than accepting it and causing a runtime panic on the
+/// first downstream token operation.
+#[cfg(test)]
+mod bug_condition_tests {
+    use crate::{ContractError, DataKey, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn vec_of(env: &Env, addr: &Address) -> Vec<Address> {
+        let mut v = Vec::new(env);
+        v.push_back(addr.clone());
+        v
+    }
+
+    /// initialize with a plain account address as token must return InvalidToken.
+    #[test]
+    fn test_initialize_with_invalid_token_is_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = vec_of(&env, &admin);
+
+        // Plain account address — does NOT implement the SEP-41 token interface.
+        let invalid_token = Address::generate(&env);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&deployer, &admins, &1, &invalid_token);
+        assert!(
+            result.is_err(),
+            "initialize must reject a plain account address as token"
+        );
+
+        // No state must have been written — the call must have been atomic.
+        assert!(
+            !env.as_contract(&contract_id, || {
+                env.storage().instance().has(&DataKey::Config)
+            }),
+            "DataKey::Config must not be stored after a rejected initialize call"
+        );
+    }
+
+    /// initialize with a plain account address must return the typed InvalidToken error.
+    #[test]
+    fn test_initialize_invalid_token_returns_typed_error() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = vec_of(&env, &admin);
+        let invalid_token = Address::generate(&env);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&deployer, &admins, &1, &invalid_token);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::InvalidToken)),
+            "expected ContractError::InvalidToken for a non-token address"
+        );
+    }
+
+    /// After a rejected initialize, a subsequent valid initialize must succeed.
+    /// This confirms the contract state is clean after the failed call.
+    #[test]
+    fn test_valid_initialize_succeeds_after_rejected_one() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        use soroban_sdk::token::StellarAssetClient;
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = vec_of(&env, &admin);
+        let invalid_token = Address::generate(&env);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // First call with invalid token — must fail.
+        let _ = client.try_initialize(&deployer, &admins, &1, &invalid_token);
+
+        // Second call with a real SEP-41 token — must succeed.
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &0);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        assert!(
+            env.as_contract(&contract_id, || {
+                env.storage().instance().has(&DataKey::Config)
+            }),
+            "DataKey::Config must be stored after a valid initialize call"
+        );
+    }
+}

--- a/QuorumCredit/src/double_repay_test.rs
+++ b/QuorumCredit/src/double_repay_test.rs
@@ -1,0 +1,131 @@
+/// Double Repay Panic Tests
+///
+/// Verifies that calling repay twice panics on the second call with
+/// "loan already repaid" message.
+#[cfg(test)]
+mod double_repay_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::{StellarAssetClient, TokenClient},
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token);
+        
+        // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+    }
+
+    fn do_loan(s: &Setup, borrower: &Address, amount: i128) {
+        s.client.request_loan(
+            borrower,
+            &amount,
+            &amount, // threshold equal to amount for simplicity
+            &String::from_str(&s.env, "test"),
+            &s.token,
+        );
+    }
+
+    /// Calling repay twice must panic with "loan already repaid" on the second call.
+    #[test]
+    #[should_panic(expected = "loan already repaid")]
+    fn test_repay_panics_when_loan_already_repaid() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+
+        // Setup vouch and fund contract
+        do_vouch(&s, &voucher, &borrower, stake);
+        StellarAssetClient::new(&s.env, &s.token).mint(&s.client.address, &loan_amount);
+
+        // Request and disburse loan
+        do_loan(&s, &borrower, loan_amount);
+
+        // Mint tokens to borrower for repayment
+        let yield_amount = loan_amount * 200 / 10_000; // 2% yield
+        let total_owed = loan_amount + yield_amount;
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &total_owed);
+
+        // First repay - should succeed
+        s.client.repay(&borrower, &total_owed);
+
+        // Verify loan is marked as repaid
+        let loan = s.client.get_loan(&borrower);
+        assert!(loan.is_some(), "loan should exist");
+        assert_eq!(loan.unwrap().status, crate::LoanStatus::Repaid);
+
+        // Second repay - must panic with "loan already repaid"
+        s.client.repay(&borrower, &total_owed);
+    }
+
+    /// Verify that partial repayments are allowed until loan is fully repaid
+    #[test]
+    fn test_partial_repayments_allowed_until_fully_repaid() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+
+        // Setup vouch and fund contract
+        do_vouch(&s, &voucher, &borrower, stake);
+        StellarAssetClient::new(&s.env, &s.token).mint(&s.client.address, &loan_amount);
+
+        // Request and disburse loan
+        do_loan(&s, &borrower, loan_amount);
+
+        // Mint tokens to borrower for repayment
+        let yield_amount = loan_amount * 200 / 10_000; // 2% yield
+        let total_owed = loan_amount + yield_amount;
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &total_owed);
+
+        // Partial repayment - should succeed
+        let partial_payment = total_owed / 2;
+        s.client.repay(&borrower, &partial_payment);
+
+        // Verify loan is still active
+        let loan = s.client.get_loan(&borrower);
+        assert!(loan.is_some(), "loan should exist");
+        assert_eq!(loan.unwrap().status, crate::LoanStatus::Active);
+
+        // Final repayment - should succeed
+        let remaining_payment = total_owed - partial_payment;
+        s.client.repay(&borrower, &remaining_payment);
+
+        // Verify loan is now repaid
+        let loan = s.client.get_loan(&borrower);
+        assert!(loan.is_some(), "loan should exist");
+        assert_eq!(loan.unwrap().status, crate::LoanStatus::Repaid);
+    }
+}

--- a/QuorumCredit/src/duplicate_loan_test.rs
+++ b/QuorumCredit/src/duplicate_loan_test.rs
@@ -1,0 +1,97 @@
+/// Duplicate Loan Request Tests
+///
+/// Verifies that a second request_loan call while a loan is already active panics.
+#[cfg(test)]
+mod duplicate_loan_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance past MIN_VOUCH_AGE so vouches are eligible.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token_id: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn do_loan(s: &Setup, borrower: &Address) {
+        s.client.request_loan(
+            borrower,
+            &100_000,
+            &500_000,
+            &String::from_str(&s.env, "test"),
+            &s.token_id,
+        );
+    }
+
+    /// A second request_loan while a loan is active must panic with
+    /// "borrower already has an active loan".
+    #[test]
+    #[should_panic(expected = "borrower already has an active loan")]
+    fn test_request_loan_panics_when_loan_already_active() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+
+        // First loan — succeeds.
+        do_loan(&s, &borrower);
+
+        // Second loan without repaying — must panic.
+        do_loan(&s, &borrower);
+    }
+
+    /// Confirm the first loan is active before the duplicate attempt.
+    #[test]
+    fn test_active_loan_exists_after_first_request() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        do_loan(&s, &borrower);
+
+        let loan = s.client.get_loan(&borrower).expect("loan should exist");
+        assert_eq!(loan.status, crate::LoanStatus::Active, "loan should be active");
+
+        // try_request_loan returns Err when a loan is already active.
+        let result = s.client.try_request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &String::from_str(&s.env, "test"),
+            &s.token_id,
+        );
+        assert!(result.is_err(), "second loan request must be rejected");
+    }
+}

--- a/QuorumCredit/src/errors.rs
+++ b/QuorumCredit/src/errors.rs
@@ -1,0 +1,43 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    InsufficientFunds = 1,
+    /// Borrower already has an active (non-repaid, non-defaulted) loan.
+    ActiveLoanExists = 2,
+    /// Total vouched stake overflowed i128.
+    StakeOverflow = 3,
+    /// admin or token address must not be the zero address.
+    ZeroAddress = 4,
+    DuplicateVouch = 5,
+    NoActiveLoan = 6,
+    ContractPaused = 7,
+    LoanPastDeadline = 8,
+    PoolLengthMismatch = 9,
+    PoolEmpty = 10,
+    PoolBorrowerActiveLoan = 11,
+    PoolInsufficientFunds = 12,
+    MinStakeNotMet = 13,
+    LoanExceedsMaxAmount = 14,
+    InsufficientVouchers = 15,
+    UnauthorizedCaller = 16,
+    InvalidAmount = 17,
+    InvalidStateTransition = 18,
+    AlreadyInitialized = 19,
+    VouchTooRecent = 20,
+    VouchCooldownActive = 21,
+    BorrowerHasActiveLoan = 22,
+    VoucherNotWhitelisted = 23,
+    Blacklisted = 24,
+    TimelockNotFound = 25,
+    TimelockNotReady = 26,
+    TimelockExpired = 27,
+    NoVouchesForBorrower = 28,
+    VoucherNotFound = 29,
+    /// Token address does not implement the SEP-41 token interface.
+    InvalidToken = 30,
+    AlreadyVoted = 31,
+    SlashVoteNotFound = 32,
+    SlashAlreadyExecuted = 33,
+}

--- a/QuorumCredit/src/fuzz_request_loan_test.rs
+++ b/QuorumCredit/src/fuzz_request_loan_test.rs
@@ -1,0 +1,200 @@
+/// Fuzz test for `request_loan` with random amount/threshold combinations.
+///
+/// # Findings
+/// - `amount < min_loan_amount` (100_000)  → host panic (assert)
+/// - `threshold <= 0`                      → host panic (assert)
+/// - `total_stake < threshold`             → host panic (assert)
+/// - `amount > total_stake * 150 / 100`    → host panic (collateral ratio assert)
+/// - `amount > max_loan_amount` (when set) → `ContractError::LoanExceedsMaxAmount`
+/// - `amount > contract_balance`           → `ContractError::InsufficientFunds`
+/// - Valid combinations                    → `Ok(())`
+/// - No integer overflow observed; `checked_add` on stake accumulation returns
+///   `ContractError::StakeOverflow` rather than panicking.
+#[cfg(test)]
+mod fuzz_request_loan_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token: Address,
+        admin_vec: Vec<Address>,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admin_vec = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admin_vec, &1, &token_id.address());
+
+        // Advance past MIN_VOUCH_AGE so vouches are always eligible.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token: token_id.address(), admin_vec }
+    }
+
+    fn vouch_and_fund(s: &Setup, stake: i128, fund: i128) -> (Address, Address) {
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        // Advance past MIN_VOUCH_AGE.
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        StellarAssetClient::new(&s.env, &s.token).mint(&s.client.address, &fund);
+        (voucher, borrower)
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test")
+    }
+
+    // ── amount < min_loan_amount → host panic ─────────────────────────────────
+
+    #[test]
+    fn test_amount_below_minimum_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        // amount=99_999 < DEFAULT_MIN_LOAN_AMOUNT=100_000
+        let result = s.client.try_request_loan(&borrower, &99_999, &500_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "amount below min_loan_amount must fail");
+    }
+
+    #[test]
+    fn test_zero_amount_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &0, &500_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "zero amount must fail");
+    }
+
+    #[test]
+    fn test_negative_amount_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &-1, &500_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "negative amount must fail");
+    }
+
+    // ── threshold <= 0 → host panic ───────────────────────────────────────────
+
+    #[test]
+    fn test_zero_threshold_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &100_000, &0, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "zero threshold must fail");
+    }
+
+    #[test]
+    fn test_negative_threshold_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &100_000, &-1, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "negative threshold must fail");
+    }
+
+    // ── total_stake < threshold → host panic ──────────────────────────────────
+
+    #[test]
+    fn test_stake_below_threshold_panics() {
+        let s = setup();
+        // stake=500_000 but threshold=1_000_000
+        let (_, borrower) = vouch_and_fund(&s, 500_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &100_000, &1_000_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "stake below threshold must fail");
+    }
+
+    // ── amount > total_stake * 150/100 → host panic (collateral ratio) ────────
+
+    #[test]
+    fn test_amount_exceeds_collateral_ratio_panics() {
+        let s = setup();
+        // stake=100_000, max_allowed = 100_000 * 150/100 = 150_000; amount=200_000 > 150_000
+        let (_, borrower) = vouch_and_fund(&s, 100_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &200_000, &100_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "amount exceeding collateral ratio must fail");
+    }
+
+    // ── amount > max_loan_amount → LoanExceedsMaxAmount ──────────────────────
+
+    #[test]
+    fn test_amount_exceeds_max_loan_amount() {
+        let s = setup();
+        s.client.set_max_loan_amount(&s.admin_vec, &500_000);
+        let (_, borrower) = vouch_and_fund(&s, 2_000_000, 2_000_000);
+        let result = s.client.try_request_loan(&borrower, &600_000, &500_000, &purpose(&s.env), &s.token);
+        assert_eq!(result, Err(Ok(ContractError::LoanExceedsMaxAmount)));
+    }
+
+    // ── contract_balance < amount → InsufficientFunds ────────────────────────
+
+    #[test]
+    fn test_insufficient_contract_balance() {
+        let s = setup();
+        // Stake 100_000 into contract (no extra funding). max_allowed = 150_000.
+        // Request 150_000 — passes collateral ratio but contract only holds 100_000.
+        let (_, borrower) = vouch_and_fund(&s, 100_000, 0);
+        let result = s.client.try_request_loan(&borrower, &150_000, &100_000, &purpose(&s.env), &s.token);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
+    }
+
+    // ── valid combinations → Ok ───────────────────────────────────────────────
+
+    #[test]
+    fn test_valid_exact_minimum_amount() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        // amount=100_000 == min_loan_amount; threshold=500_000 <= stake=1_000_000
+        let result = s.client.try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token);
+        assert_eq!(result, Ok(Ok(())));
+    }
+
+    #[test]
+    fn test_valid_threshold_equals_stake() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        // threshold == total_stake (boundary)
+        let result = s.client.try_request_loan(&borrower, &100_000, &1_000_000, &purpose(&s.env), &s.token);
+        assert_eq!(result, Ok(Ok(())));
+    }
+
+    #[test]
+    fn test_valid_large_stake_large_amount() {
+        let s = setup();
+        // stake=10_000_000; max_allowed = 15_000_000; amount=5_000_000
+        let (_, borrower) = vouch_and_fund(&s, 10_000_000, 10_000_000);
+        let result = s.client.try_request_loan(&borrower, &5_000_000, &5_000_000, &purpose(&s.env), &s.token);
+        assert_eq!(result, Ok(Ok(())));
+    }
+
+    // ── i128 extremes ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_i128_max_amount_panics() {
+        let s = setup();
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &i128::MAX, &500_000, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "i128::MAX amount must fail");
+    }
+
+    #[test]
+    fn test_i128_max_threshold_panics() {
+        let s = setup();
+        // stake < i128::MAX so total_stake < threshold → fails
+        let (_, borrower) = vouch_and_fund(&s, 1_000_000, 1_000_000);
+        let result = s.client.try_request_loan(&borrower, &100_000, &i128::MAX, &purpose(&s.env), &s.token);
+        assert!(result.is_err(), "i128::MAX threshold with insufficient stake must fail");
+    }
+}

--- a/QuorumCredit/src/fuzz_vouch_test.rs
+++ b/QuorumCredit/src/fuzz_vouch_test.rs
@@ -1,0 +1,98 @@
+/// Fuzz test for `vouch` with random i128 stake amounts.
+///
+/// # Findings
+/// - `stake <= 0`          → `ContractError::InsufficientFunds` (caught by `require_positive_amount`)
+/// - `0 < stake < min_stake` → `ContractError::MinStakeNotMet` (when min_stake is set)
+/// - `stake > voucher_balance` → host-level panic (token transfer fails; `try_vouch` returns `Err`)
+/// - `stake >= min_stake` and `stake <= voucher_balance` → success
+/// - No integer overflow or unexpected panic observed for any i128 value.
+#[cfg(test)]
+mod fuzz_vouch_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::Address as _,
+        token::StellarAssetClient,
+        Address, Env, Vec,
+    };
+
+    /// Deterministic fuzz: exercise a representative spread of i128 stake values
+    /// covering negatives, zero, sub-minimum positives, normal values, and extremes.
+    #[test]
+    fn test_vouch_fuzz_stake_amounts() {
+        // Findings documented inline per stake category.
+        let cases: &[i128] = &[
+            // ── Invalid: non-positive ──────────────────────────────────────────
+            i128::MIN,   // extreme negative → InsufficientFunds
+            -1_000_000,  // negative         → InsufficientFunds
+            -1,          // -1               → InsufficientFunds
+            0,           // zero             → InsufficientFunds
+            // ── Invalid: below min_stake (set to 1_000 below) ─────────────────
+            1,           // 1 stroop         → MinStakeNotMet
+            999,         // just under min   → MinStakeNotMet
+            // ── Valid: meets min_stake and voucher has sufficient balance ──────
+            1_000,       // exact minimum    → Ok
+            1_000_000,   // normal stake     → Ok
+            i128::MAX / 2, // large but funded → Ok (voucher minted to match)
+            // ── Invalid: exceeds voucher balance (not minted) ─────────────────
+            i128::MAX,   // max i128, no balance → host error (transfer fails)
+        ];
+
+        let min_stake: i128 = 1_000;
+
+        for &stake in cases {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            // Set min_stake so sub-minimum cases are exercised.
+            let admin = Address::generate(&env);
+            let admin_vec = Vec::from_array(&env, [admin.clone()]);
+            let deployer = Address::generate(&env);
+            let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+            let contract_id = env.register_contract(None, QuorumCreditContract);
+            let client = QuorumCreditContractClient::new(&env, &contract_id);
+            client.initialize(&deployer, &admin_vec, &1, &token_id.address());
+            client.set_min_stake(&admin_vec, &min_stake);
+
+            let voucher = Address::generate(&env);
+            let borrower = Address::generate(&env);
+
+            // Mint exactly `stake` to the voucher for valid positive cases.
+            if stake > 0 && stake != i128::MAX {
+                StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &stake);
+            }
+
+            let result = client.try_vouch(&voucher, &borrower, &stake, &token_id.address());
+
+            match stake {
+                s if s <= 0 => {
+                    assert_eq!(
+                        result,
+                        Err(Ok(ContractError::InsufficientFunds)),
+                        "stake={stake}: expected InsufficientFunds for non-positive stake"
+                    );
+                }
+                s if s < min_stake => {
+                    assert_eq!(
+                        result,
+                        Err(Ok(ContractError::MinStakeNotMet)),
+                        "stake={stake}: expected MinStakeNotMet for sub-minimum stake"
+                    );
+                }
+                i128::MAX => {
+                    // Voucher has no balance; token transfer panics at host level.
+                    assert!(
+                        result.is_err(),
+                        "stake={stake}: expected error when voucher has no balance"
+                    );
+                }
+                _ => {
+                    assert_eq!(
+                        result,
+                        Ok(Ok(())),
+                        "stake={stake}: expected Ok for valid stake"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/QuorumCredit/src/get_vouches_empty_test.rs
+++ b/QuorumCredit/src/get_vouches_empty_test.rs
@@ -1,0 +1,36 @@
+/// get_vouches Empty State Tests
+///
+/// Verifies that get_vouches returns None for an address that has never been vouched for.
+#[cfg(test)]
+mod get_vouches_empty_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup() -> (Env, QuorumCreditContractClient<'static>) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        (env, client)
+    }
+
+    /// Calling get_vouches on a fresh address with no vouches should return None.
+    #[test]
+    fn test_get_vouches_returns_none_for_address_with_no_vouches() {
+        let (env, client) = setup();
+        let fresh = Address::generate(&env);
+
+        let result = client.get_vouches(&fresh);
+        assert!(result.is_none(), "get_vouches should return None for an address with no vouches");
+    }
+}

--- a/QuorumCredit/src/governance.rs
+++ b/QuorumCredit/src/governance.rs
@@ -1,0 +1,339 @@
+use crate::errors::ContractError;
+use crate::helpers::{add_slash_balance, config, get_active_loan_record, require_not_paused};
+use crate::types::{DataKey, SlashVoteRecord, VouchRecord, TimelockProposal, TimelockAction};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
+
+/// Default quorum: 50% of total vouched stake must approve.
+const DEFAULT_SLASH_VOTE_QUORUM_BPS: u32 = 5_000;
+
+/// Cast a governance vote on whether `borrower` should be slashed.
+///
+/// - Only active vouchers (those with a stake in `Vouches(borrower)`) may vote.
+/// - Votes are weighted by the voucher's current stake.
+/// - When `approve_stake * 10_000 / total_stake >= quorum_bps`, slash is auto-executed.
+pub fn vote_slash(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    approve: bool,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    // Borrower must have an active loan to be slashable.
+    let loan = get_active_loan_record(&env, &borrower)?;
+    if loan.status != crate::types::LoanStatus::Active {
+        return Err(ContractError::NoActiveLoan);
+    }
+
+    // Fetch vouches and find this voucher's stake.
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or(Vec::new(&env));
+
+    let voucher_stake = vouches
+        .iter()
+        .find(|v| v.voucher == voucher)
+        .map(|v| v.stake)
+        .ok_or(ContractError::VoucherNotFound)?;
+
+    let total_stake: i128 = vouches.iter().map(|v| v.stake).sum();
+
+    // Load or initialise the vote record.
+    let mut vote: SlashVoteRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::SlashVote(borrower.clone()))
+        .unwrap_or(SlashVoteRecord {
+            approve_stake: 0,
+            reject_stake: 0,
+            voters: Vec::new(&env),
+            executed: false,
+        });
+
+    if vote.executed {
+        return Err(ContractError::SlashAlreadyExecuted);
+    }
+
+    // Prevent double-voting.
+    if vote.voters.iter().any(|v| v == voucher) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    if approve {
+        vote.approve_stake += voucher_stake;
+    } else {
+        vote.reject_stake += voucher_stake;
+    }
+    vote.voters.push_back(voucher.clone());
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("voted")),
+        (voucher.clone(), borrower.clone(), approve, voucher_stake),
+    );
+
+    // Check quorum.
+    let quorum_bps: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SlashVoteQuorum)
+        .unwrap_or(DEFAULT_SLASH_VOTE_QUORUM_BPS);
+
+    let quorum_reached = total_stake > 0
+        && vote.approve_stake * 10_000 / total_stake >= quorum_bps as i128;
+
+    if quorum_reached {
+        vote.executed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::SlashVote(borrower.clone()), &vote);
+        execute_slash(&env, &borrower)?;
+    } else {
+        env.storage()
+            .persistent()
+            .set(&DataKey::SlashVote(borrower.clone()), &vote);
+    }
+
+    Ok(())
+}
+
+/// Returns the current slash vote record for a borrower, if any.
+pub fn get_slash_vote(env: Env, borrower: Address) -> Option<SlashVoteRecord> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SlashVote(borrower))
+}
+
+/// Set the quorum threshold (in basis points) required to auto-execute a slash.
+/// Requires admin approval — called from admin module.
+pub fn set_slash_vote_quorum(env: &Env, quorum_bps: u32) {
+    assert!(
+        quorum_bps > 0 && quorum_bps <= 10_000,
+        "quorum_bps must be 1-10000"
+    );
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashVoteQuorum, &quorum_bps);
+}
+
+pub fn get_slash_vote_quorum(env: Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&DataKey::SlashVoteQuorum)
+        .unwrap_or(DEFAULT_SLASH_VOTE_QUORUM_BPS)
+}
+
+// ── Internal ──────────────────────────────────────────────────────────────────
+
+fn execute_slash(env: &Env, borrower: &Address) -> Result<(), ContractError> {
+    let cfg = config(env);
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or(Vec::new(env));
+
+    // Mark loan as defaulted first so we can read token_address.
+    let mut loan = get_active_loan_record(env, borrower)?;
+    let loan_token = soroban_sdk::token::Client::new(env, &loan.token_address);
+
+    let mut total_slashed: i128 = 0;
+
+    for v in vouches.iter() {
+        if v.token != loan.token_address {
+            continue;
+        }
+        let slash_amount = v.stake * cfg.slash_bps / 10_000;
+        let remaining = v.stake - slash_amount;
+        total_slashed += slash_amount;
+
+        if remaining > 0 {
+            loan_token.transfer(&env.current_contract_address(), &v.voucher, &remaining);
+        }
+    }
+
+    add_slash_balance(env, total_slashed);
+
+    loan.status = crate::types::LoanStatus::Defaulted;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Loan(loan.id), &loan);
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ActiveLoan(borrower.clone()));
+
+    let count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DefaultCount(borrower.clone()))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DefaultCount(borrower.clone()), &(count + 1));
+
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Vouches(borrower.clone()));
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("slashed")),
+        (borrower.clone(), total_slashed),
+    );
+
+    Ok(())
+}
+
+/// ── Issue 109: Slash Proposal Confirmation Window ──
+/// 
+/// Implements a two-step slash with timelock pattern:
+/// 1. propose_slash: Admin creates a proposal, sets execution time (eta)
+/// 2. execute_slash_proposal: After delay, anyone can execute
+
+/// Propose a slash action with a delay before execution.
+/// This implements the "confirmation window" for the slash action.
+pub fn propose_slash(
+    env: Env,
+    proposer: Address,
+    borrower: Address,
+    delay_secs: u64,
+) -> Result<u64, ContractError> {
+    proposer.require_auth();
+    require_not_paused(&env)?;
+
+    // Get or initialize timelock counter
+    let proposal_id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TimelockCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("proposal ID overflow");
+
+    let eta = env.ledger().timestamp() + delay_secs;
+
+    let proposal = TimelockProposal {
+        id: proposal_id,
+        action: TimelockAction::Slash(borrower.clone()),
+        proposer: proposer.clone(),
+        eta,
+        executed: false,
+        cancelled: false,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::Timelock(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&DataKey::TimelockCounter, &proposal_id);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("proposed")),
+        (proposal_id, proposer, borrower, eta),
+    );
+
+    Ok(proposal_id)
+}
+
+/// Execute a previously proposed slash action after the delay has passed.
+pub fn execute_slash_proposal(
+    env: Env,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    require_not_paused(&env)?;
+
+    // Get the proposal
+    let mut proposal: TimelockProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::Timelock(proposal_id))
+        .ok_or(ContractError::NoActiveLoan)?; // Use existing error as placeholder
+
+    // Check proposal state
+    if proposal.executed {
+        return Err(ContractError::SlashAlreadyExecuted);
+    }
+    if proposal.cancelled {
+        return Err(ContractError::NoActiveLoan); // Use existing error as placeholder
+    }
+
+    // Check delay has passed
+    if env.ledger().timestamp() < proposal.eta {
+        return Err(ContractError::NoActiveLoan); // Use existing error as placeholder
+    }
+
+    // Check expiry (72 hours from eta)
+    const TIMELOCK_EXPIRY: u64 = 72 * 60 * 60;
+    if env.ledger().timestamp() > proposal.eta + TIMELOCK_EXPIRY {
+        return Err(ContractError::NoActiveLoan); // Use existing error as placeholder
+    }
+
+    // Extract borrower from the Slash action
+    if let TimelockAction::Slash(borrower) = &proposal.action {
+        // Mark as executed before calling execute_slash to prevent reentrancy
+        proposal.executed = true;
+        env.storage()
+            .instance()
+            .set(&DataKey::Timelock(proposal_id), &proposal);
+
+        // Execute the slash
+        execute_slash(&env, borrower)?;
+
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("executed")),
+            (proposal_id, borrower.clone()),
+        );
+
+        Ok(())
+    } else {
+        Err(ContractError::NoActiveLoan) // Only Slash actions supported in this release
+    }
+}
+
+/// Cancel a pending slash proposal (only by proposer or admin).
+pub fn cancel_slash_proposal(
+    env: Env,
+    caller: Address,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    caller.require_auth();
+
+    let mut proposal: TimelockProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::Timelock(proposal_id))
+        .ok_or(ContractError::NoActiveLoan)?;
+
+    // Only proposer can cancel
+    assert!(
+        caller == proposal.proposer,
+        "only proposer can cancel"
+    );
+
+    if proposal.executed || proposal.cancelled {
+        return Err(ContractError::SlashAlreadyExecuted);
+    }
+
+    proposal.cancelled = true;
+    env.storage()
+        .instance()
+        .set(&DataKey::Timelock(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("cancelled")),
+        (proposal_id, caller),
+    );
+
+    Ok(())
+}
+
+/// Get a timelock proposal by ID.
+pub fn get_timelock_proposal(env: Env, proposal_id: u64) -> Option<TimelockProposal> {
+    env.storage()
+        .instance()
+        .get(&DataKey::Timelock(proposal_id))
+}
+

--- a/QuorumCredit/src/governance_test.rs
+++ b/QuorumCredit/src/governance_test.rs
@@ -1,0 +1,243 @@
+#[cfg(test)]
+mod governance_tests {
+    use crate::{ContractError, DataKey, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, Vec,
+    };
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        contract_id: Address,
+        admin: Address,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund the contract so it can disburse loans.
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance time past MIN_VOUCH_AGE (60s) so vouches are usable.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup {
+            env,
+            client,
+            contract_id,
+            admin,
+            token_id: token_id.address(),
+        }
+    }
+
+    /// Vouch for `borrower` from `voucher` with `stake`, minting tokens first.
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    /// Request a loan for `borrower` (vouches must already meet threshold).
+    fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {
+        s.client.request_loan(borrower, &amount, &threshold, &soroban_sdk::String::from_str(&s.env, "test loan"), &s.token_id);
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    /// A single voucher holding >50% of stake approves → slash auto-executes.
+    #[test]
+    fn test_vote_slash_quorum_reached_executes_slash() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+
+        // voucher_a has 600, voucher_b has 400 → total 1000
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        do_vouch(&s, &voucher_b, &borrower, 400_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        // voucher_a approves (60% > 50% default quorum) → slash fires immediately
+        s.client.vote_slash(&voucher_a, &borrower, &true);
+
+        // Loan must now be defaulted
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Defaulted
+        );
+
+        // Slash treasury must hold 50% of voucher_a's stake (600_000 * 5000/10000 = 300_000)
+        // plus 50% of voucher_b's stake (400_000 * 5000/10000 = 200_000) = 500_000
+        assert_eq!(s.client.get_slash_treasury_balance(), 500_000);
+
+        // Vote record must be marked executed
+        let vote = s.client.get_slash_vote(&borrower).unwrap();
+        assert!(vote.executed);
+    }
+
+    /// Two vouchers each hold 30% — neither alone reaches quorum; second vote tips it over.
+    #[test]
+    fn test_vote_slash_quorum_reached_on_second_vote() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+        let voucher_c = Address::generate(&s.env);
+
+        // a=300, b=300, c=400 → total 1000
+        do_vouch(&s, &voucher_a, &borrower, 300_000);
+        do_vouch(&s, &voucher_b, &borrower, 300_000);
+        do_vouch(&s, &voucher_c, &borrower, 400_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        // First vote: 30% — not enough
+        s.client.vote_slash(&voucher_a, &borrower, &true);
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Active
+        );
+
+        // Second vote: 30% + 30% = 60% ≥ 50% → slash fires
+        s.client.vote_slash(&voucher_b, &borrower, &true);
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Defaulted
+        );
+    }
+
+    /// Voting against (reject) does not trigger slash even if approve stake is below quorum.
+    #[test]
+    fn test_vote_slash_reject_does_not_slash() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        s.client.vote_slash(&voucher_a, &borrower, &false);
+
+        // Loan still active
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Active
+        );
+        let vote = s.client.get_slash_vote(&borrower).unwrap();
+        assert!(!vote.executed);
+        assert_eq!(vote.reject_stake, 600_000);
+    }
+
+    /// A voucher cannot vote twice on the same borrower.
+    #[test]
+    fn test_vote_slash_double_vote_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 300_000);
+        do_vouch(&s, &voucher_b, &borrower, 700_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        s.client.vote_slash(&voucher_b, &borrower, &false); // 70% reject — no slash
+
+        let result = s.client.try_vote_slash(&voucher_b, &borrower, &true);
+        assert_eq!(result, Err(Ok(ContractError::AlreadyVoted)));
+    }
+
+    /// A non-voucher cannot vote.
+    #[test]
+    fn test_vote_slash_non_voucher_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let outsider = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        let result = s.client.try_vote_slash(&outsider, &borrower, &true);
+        assert_eq!(result, Err(Ok(ContractError::VoucherNotFound)));
+    }
+
+    /// Voting on a borrower with no active loan returns NoActiveLoan.
+    #[test]
+    fn test_vote_slash_no_active_loan_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        // No loan requested
+
+        let result = s.client.try_vote_slash(&voucher_a, &borrower, &true);
+        assert_eq!(result, Err(Ok(ContractError::NoActiveLoan)));
+    }
+
+    /// After slash executes, further votes return SlashAlreadyExecuted.
+    #[test]
+    fn test_vote_slash_after_execution_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        do_vouch(&s, &voucher_b, &borrower, 400_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        // Slash executes on first vote (60% ≥ 50%)
+        s.client.vote_slash(&voucher_a, &borrower, &true);
+
+        let result = s.client.try_vote_slash(&voucher_b, &borrower, &true);
+        assert_eq!(result, Err(Ok(ContractError::SlashAlreadyExecuted)));
+    }
+
+    /// Admin can change the quorum threshold; new threshold is respected.
+    #[test]
+    fn test_set_slash_vote_quorum_changes_threshold() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+
+        // Raise quorum to 80%
+        let admins = Vec::from_array(&s.env, [s.admin.clone()]);
+        s.client.set_slash_vote_quorum(&admins, &8_000);
+        assert_eq!(s.client.get_slash_vote_quorum(), 8_000);
+
+        // a=600, b=400 → total 1000; 60% < 80% → no auto-slash on first vote
+        do_vouch(&s, &voucher_a, &borrower, 600_000);
+        do_vouch(&s, &voucher_b, &borrower, 400_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        s.client.vote_slash(&voucher_a, &borrower, &true);
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Active,
+            "60% should not reach 80% quorum"
+        );
+
+        // Second vote: 60% + 40% = 100% ≥ 80% → slash fires
+        s.client.vote_slash(&voucher_b, &borrower, &true);
+        assert_eq!(
+            s.client.loan_status(&borrower),
+            crate::LoanStatus::Defaulted
+        );
+    }
+}

--- a/QuorumCredit/src/helpers.rs
+++ b/QuorumCredit/src/helpers.rs
@@ -1,0 +1,207 @@
+use crate::errors::ContractError;
+use crate::types::{Config, DataKey, LoanRecord};
+use soroban_sdk::{token, Address, Env, String, Vec};
+
+/// Returns true if the address is the all-zeros account or contract address.
+pub fn is_zero_address(env: &Env, addr: &Address) -> bool {
+    // Stellar zero account: all-zero 32-byte ed25519 key
+    let zero_account = Address::from_string(&String::from_str(
+        env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+    // Stellar zero contract: all-zero 32-byte contract hash
+    let zero_contract = Address::from_string(&String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    addr == &zero_account || addr == &zero_contract
+}
+
+pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false);
+    if paused {
+        Err(ContractError::ContractPaused)
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns `Err(InsufficientFunds)` if `amount` is not strictly positive (≤ 0).
+/// Use this for all numeric inputs that must be > 0 (stakes, loan amounts, thresholds).
+pub fn require_positive_amount(_env: &Env, amount: i128) -> Result<(), ContractError> {
+    if amount <= 0 {
+        return Err(ContractError::InsufficientFunds);
+    }
+    Ok(())
+}
+
+pub fn config(env: &Env) -> Config {
+    env.storage()
+        .instance()
+        .get(&DataKey::Config)
+        .expect("not initialized")
+}
+
+pub fn add_slash_balance(env: &Env, amount: i128) {
+    let current: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SlashTreasury)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashTreasury, &(current + amount));
+}
+
+/// Issue 112: Get current slash balance to prevent it from being used for yield payouts.
+pub fn get_slash_balance(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::SlashTreasury)
+        .unwrap_or(0)
+}
+
+pub fn has_active_loan(env: &Env, borrower: &Address) -> bool {
+    matches!(get_active_loan_record(env, borrower), Ok(loan) if loan.status == crate::types::LoanStatus::Active)
+}
+
+pub fn next_loan_id(env: &Env) -> u64 {
+    let loan_id = env
+        .storage()
+        .instance()
+        .get(&DataKey::LoanCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("loan ID overflow");
+    env.storage()
+        .instance()
+        .set(&DataKey::LoanCounter, &loan_id);
+    loan_id
+}
+
+pub fn get_latest_loan_record(env: &Env, borrower: &Address) -> Option<LoanRecord> {
+    // Get the latest loan ID for the borrower
+    if let Some(loan_id) = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LatestLoan(borrower.clone()))
+    {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+    } else {
+        None
+    }
+}
+
+pub fn get_active_loan_record(env: &Env, borrower: &Address) -> Result<LoanRecord, ContractError> {
+    let loan_id: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveLoan(borrower.clone()))
+        .ok_or(ContractError::NoActiveLoan)?;
+    env.storage()
+        .persistent()
+        .get(&DataKey::Loan(loan_id))
+        .ok_or(ContractError::NoActiveLoan)
+}
+
+pub fn token(env: &Env) -> token::Client<'_> {
+    let addr = config(env).token;
+    token::Client::new(env, &addr)
+}
+
+pub fn token_client(env: &Env) -> token::Client<'_> {
+    token(env)
+}
+
+/// Returns a token client for `addr` after verifying it is an allowed token
+/// (either the primary protocol token or in `Config.allowed_tokens`).
+pub fn require_allowed_token<'a>(
+    env: &'a Env,
+    addr: &Address,
+) -> Result<token::Client<'a>, ContractError> {
+    let cfg = config(env);
+    if *addr == cfg.token || cfg.allowed_tokens.iter().any(|t| t == *addr) {
+        Ok(token::Client::new(env, addr))
+    } else {
+        Err(ContractError::InvalidToken)
+    }
+}
+
+pub fn require_admin_approval(env: &Env, admin_signers: &Vec<Address>) {
+    let config = config(env);
+    assert!(
+        admin_signers.len() >= config.admin_threshold,
+        "insufficient admin approvals"
+    );
+    for signer in admin_signers.iter() {
+        assert!(
+            config.admins.iter().any(|a| a == signer),
+            "signer is not a registered admin"
+        );
+        signer.require_auth();
+    }
+}
+
+/// Validates that an address is not a zero address
+pub fn require_valid_address(env: &Env, addr: &Address) -> Result<(), ContractError> {
+    if is_zero_address(env, addr) {
+        Err(ContractError::ZeroAddress)
+    } else {
+        Ok(())
+    }
+}
+
+/// Validates that an address implements the SEP-41 token interface by attempting
+/// to call `balance()` on it. A plain account address will cause a host trap,
+/// which we catch via `try_invoke` semantics using the token client's try_ variant.
+pub fn require_valid_token(env: &Env, addr: &Address) -> Result<(), ContractError> {
+    require_valid_address(env, addr)?;
+    // Attempt to call balance() on the address. If it's not a token contract,
+    // the invocation will fail and we return InvalidToken.
+    let client = token::Client::new(env, addr);
+    // Use a dummy address (the contract itself) — we only care whether the call
+    // succeeds, not the returned value.
+    let probe = env.current_contract_address();
+    if client.try_balance(&probe).is_err() {
+        return Err(ContractError::InvalidToken);
+    }
+    Ok(())
+}
+
+pub fn validate_admin_config(
+    env: &Env,
+    admins: &Vec<Address>,
+    admin_threshold: u32,
+) -> Result<(), ContractError> {
+    assert!(!admins.is_empty(), "at least one admin is required");
+    assert!(
+        admin_threshold > 0,
+        "admin threshold must be greater than zero"
+    );
+    assert!(
+        admin_threshold <= admins.len(),
+        "admin threshold cannot exceed admin count"
+    );
+
+    let admin_count = admins.len();
+    for i in 0..admin_count {
+        let admin = admins.get(i).unwrap();
+
+        // Validate admin address is not zero
+        require_valid_address(env, &admin)?;
+
+        // Check for duplicates
+        for j in 0..i {
+            let prior_admin = admins.get(j).unwrap();
+            assert!(admin != prior_admin, "duplicate admin");
+        }
+    }
+
+    Ok(())
+}

--- a/QuorumCredit/src/initialize_test.rs
+++ b/QuorumCredit/src/initialize_test.rs
@@ -1,0 +1,31 @@
+#[cfg(test)]
+mod initialize_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Vec<Address>, u32, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let admins = Vec::from_array(env, [admin]);
+        let token = env
+            .register_stellar_asset_contract_v2(Address::generate(env))
+            .address();
+        (deployer, admins, 1, token)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_initialize_panics_with_already_initialized() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let (deployer, admins, threshold, token) = setup(&env);
+
+        client.initialize(&deployer, &admins, &threshold, &token);
+        // Second call must panic with AlreadyInitialized (error code 19)
+        client.initialize(&deployer, &admins, &threshold, &token);
+    }
+}

--- a/QuorumCredit/src/insufficient_balance_test.rs
+++ b/QuorumCredit/src/insufficient_balance_test.rs
@@ -1,0 +1,97 @@
+/// Test: repay fails when the contract has insufficient balance to cover yield payouts.
+///
+/// Scenario:
+///   - Contract is funded with exactly the loan amount (no yield reserve).
+///   - After disbursement the contract balance is 0.
+///   - Borrower repays principal + yield; contract receives the payment but then
+///     must transfer `stake + yield` back to the voucher — which exceeds what it holds.
+///   - The token transfer panics at the host level; `try_repay` must return an error.
+#[cfg(test)]
+mod insufficient_balance_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::{StellarAssetClient, TokenClient},
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token: token_id.address() }
+    }
+
+    /// repay must fail when the contract balance cannot cover stake + yield payout to vouchers.
+    #[test]
+    fn test_repay_fails_when_contract_has_insufficient_balance_for_yield() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+        // yield = 2% of loan_amount = 10_000; total_owed = 510_000
+        // payout required = stake + yield = 1_010_000
+
+        // Fund voucher and vouch — stake is transferred into the contract.
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+
+        // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+
+        // Fund contract with the loan amount.
+        StellarAssetClient::new(&s.env, &s.token).mint(&s.client.address, &loan_amount);
+
+        s.client.request_loan(
+            &borrower,
+            &loan_amount,
+            &stake,
+            &String::from_str(&s.env, "test"),
+            &s.token,
+        );
+
+        // Contract now holds the stake (1_000_000). Drain it via burn so the contract
+        // cannot cover the stake + yield payout when repay is called.
+        // mock_all_auths() allows burning on behalf of the contract address.
+        let contract_balance = TokenClient::new(&s.env, &s.token).balance(&s.client.address);
+        TokenClient::new(&s.env, &s.token).burn(&s.client.address, &(contract_balance - 1));
+
+        assert_eq!(
+            TokenClient::new(&s.env, &s.token).balance(&s.client.address),
+            1,
+            "contract should have only 1 stroop after drain"
+        );
+
+        // Borrower repays principal + yield.
+        let yield_amount: i128 = loan_amount * 200 / 10_000; // 2% = 10_000
+        let total_owed = loan_amount + yield_amount;
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &total_owed);
+
+        // repay must fail: after receiving total_owed (510_000), contract has 510_001
+        // but must pay out stake + yield (1_000_000 + 10_000 = 1_010_000) — insufficient.
+        let result = s.client.try_repay(&borrower, &total_owed);
+        assert!(
+            result.is_err(),
+            "repay must fail when contract cannot cover stake + yield payout"
+        );
+    }
+}

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -1,0 +1,431 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, Address, BytesN, Env, Vec,
+};
+
+pub mod admin;
+pub mod errors;
+pub mod governance;
+pub mod helpers;
+pub mod loan;
+pub mod reputation;
+pub mod types;
+pub mod vouch;
+
+#[cfg(test)]
+mod governance_test;
+#[cfg(test)]
+mod initialize_test;
+#[cfg(test)]
+mod loan_purpose_test;
+#[cfg(test)]
+mod multi_asset_test;
+#[cfg(test)]
+mod referral_test;
+#[cfg(test)]
+mod request_loan_insufficient_stake_test;
+#[cfg(test)]
+mod vouch_zero_stake_test;
+mod security_fixes_test;
+#[cfg(test)]
+mod bug_condition_test;
+#[cfg(test)]
+mod duplicate_loan_test;
+#[cfg(test)]
+mod double_repay_test;
+#[cfg(test)]
+mod simple_double_repay_test;
+
+pub use errors::ContractError;
+pub use types::*;
+
+use helpers::{require_valid_token, validate_admin_config};
+use reputation::ReputationNftExternalClient;
+
+#[contract]
+pub struct QuorumCreditContract;
+
+#[contractimpl]
+impl QuorumCreditContract {
+    /// One-time contract initialization. Deployer must sign.
+    pub fn initialize(
+        env: Env,
+        deployer: Address,
+        admins: Vec<Address>,
+        admin_threshold: u32,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        deployer.require_auth();
+
+        if env.storage().instance().has(&DataKey::Config) {
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+
+        validate_admin_config(&env, &admins, admin_threshold).expect("invalid admin config");
+        require_valid_token(&env, &token).expect("invalid token");
+        assert!(
+            !env.storage().instance().has(&DataKey::Config),
+            "already initialized"
+        );
+
+        validate_admin_config(&env, &admins, admin_threshold)?;
+        require_valid_token(&env, &token)?;
+
+        env.storage().instance().set(&DataKey::Deployer, &deployer);
+        env.storage().instance().set(
+            &DataKey::Config,
+            &Config {
+                admins: admins.clone(),
+                admin_threshold,
+                token: token.clone(),
+                allowed_tokens: Vec::new(&env),
+                yield_bps: DEFAULT_YIELD_BPS,
+                slash_bps: DEFAULT_SLASH_BPS,
+                max_vouchers: DEFAULT_MAX_VOUCHERS,
+                min_loan_amount: DEFAULT_MIN_LOAN_AMOUNT,
+                loan_duration: DEFAULT_LOAN_DURATION,
+                max_loan_to_stake_ratio: DEFAULT_MAX_LOAN_TO_STAKE_RATIO,
+                grace_period: 0,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("contract"), symbol_short!("init")),
+            (deployer, admins.clone(), admin_threshold, token.clone()),
+        );
+        Ok(())
+    }
+
+    // ── Vouch ─────────────────────────────────────────────────────────────────
+
+    pub fn vouch(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        stake: i128,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        vouch::vouch(env, voucher, borrower, stake, token)
+    }
+
+    pub fn batch_vouch(
+        env: Env,
+        voucher: Address,
+        borrowers: Vec<Address>,
+        stakes: Vec<i128>,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        vouch::batch_vouch(env, voucher, borrowers, stakes, token)
+    }
+
+    pub fn increase_stake(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        additional: i128,
+    ) -> Result<(), ContractError> {
+        vouch::increase_stake(env, voucher, borrower, additional)
+    }
+
+    pub fn decrease_stake(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        vouch::decrease_stake(env, voucher, borrower, amount)
+    }
+
+    pub fn withdraw_vouch(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        vouch::withdraw_vouch(env, voucher, borrower)
+    }
+
+    pub fn transfer_vouch(
+        env: Env,
+        from: Address,
+        to: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        vouch::transfer_vouch(env, from, to, borrower)
+    }
+
+    // ── Loan ──────────────────────────────────────────────────────────────────
+
+    pub fn register_referral(
+        env: Env,
+        borrower: Address,
+        referrer: Address,
+    ) -> Result<(), ContractError> {
+        loan::register_referral(env, borrower, referrer)
+    }
+
+    pub fn get_referrer(env: Env, borrower: Address) -> Option<Address> {
+        loan::get_referrer(env, borrower)
+    }
+
+    pub fn set_referral_bonus_bps(env: Env, admin_signers: Vec<Address>, bonus_bps: u32) {
+        helpers::require_admin_approval(&env, &admin_signers);
+        assert!(bonus_bps <= 10_000, "bonus_bps must not exceed 10000");
+        env.storage()
+            .instance()
+            .set(&DataKey::ReferralBonusBps, &bonus_bps);
+    }
+
+    pub fn get_referral_bonus_bps(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ReferralBonusBps)
+            .unwrap_or(crate::types::DEFAULT_REFERRAL_BONUS_BPS)
+    }
+
+    pub fn request_loan(
+        env: Env,
+        borrower: Address,
+        amount: i128,
+        threshold: i128,
+        loan_purpose: soroban_sdk::String,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        loan::request_loan(env, borrower, amount, threshold, loan_purpose, token)
+    }
+
+    pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
+        loan::repay(env, borrower, payment)
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
+        admin::add_admin(env, admin_signers, new_admin)
+    }
+
+    pub fn remove_admin(env: Env, admin_signers: Vec<Address>, admin_to_remove: Address) {
+        admin::remove_admin(env, admin_signers, admin_to_remove)
+    }
+
+    pub fn rotate_admin(
+        env: Env,
+        admin_signers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) {
+        admin::rotate_admin(env, admin_signers, old_admin, new_admin)
+    }
+
+    pub fn set_admin_threshold(env: Env, admin_signers: Vec<Address>, new_threshold: u32) {
+        admin::set_admin_threshold(env, admin_signers, new_threshold)
+    }
+
+    pub fn set_protocol_fee(env: Env, admin_signers: Vec<Address>, fee_bps: u32) {
+        admin::set_protocol_fee(env, admin_signers, fee_bps)
+    }
+
+    pub fn whitelist_voucher(env: Env, admin_signers: Vec<Address>, voucher: Address) {
+        admin::whitelist_voucher(env, admin_signers, voucher)
+    }
+
+    pub fn set_fee_treasury(env: Env, admin_signers: Vec<Address>, treasury: Address) {
+        admin::set_fee_treasury(env, admin_signers, treasury)
+    }
+
+    pub fn upgrade(env: Env, admin_signers: Vec<Address>, new_wasm_hash: BytesN<32>) {
+        admin::upgrade(env, admin_signers, new_wasm_hash)
+    }
+
+    pub fn pause(env: Env, admin_signers: Vec<Address>) {
+        admin::pause(env, admin_signers)
+    }
+
+    pub fn unpause(env: Env, admin_signers: Vec<Address>) {
+        admin::unpause(env, admin_signers)
+    }
+
+    pub fn blacklist(env: Env, admin_signers: Vec<Address>, borrower: Address) {
+        admin::blacklist(env, admin_signers, borrower)
+    }
+
+    pub fn set_config(env: Env, admin_signers: Vec<Address>, config: Config) {
+        admin::set_config(env, admin_signers, config)
+    }
+
+    pub fn update_config(
+        env: Env,
+        admin_signers: Vec<Address>,
+        yield_bps: Option<i128>,
+        slash_bps: Option<i128>,
+    ) {
+        admin::update_config(env, admin_signers, yield_bps, slash_bps)
+    }
+
+    pub fn set_reputation_nft(env: Env, admin_signers: Vec<Address>, nft_contract: Address) {
+        admin::set_reputation_nft(env, admin_signers, nft_contract)
+    }
+
+    pub fn set_min_stake(env: Env, admin_signers: Vec<Address>, amount: i128) {
+        admin::set_min_stake(env, admin_signers, amount)
+    }
+
+    pub fn set_max_loan_amount(env: Env, admin_signers: Vec<Address>, amount: i128) {
+        admin::set_max_loan_amount(env, admin_signers, amount)
+    }
+
+    pub fn set_min_vouchers(env: Env, admin_signers: Vec<Address>, count: u32) {
+        admin::set_min_vouchers(env, admin_signers, count)
+    }
+
+    pub fn set_max_loan_to_stake_ratio(env: Env, admin_signers: Vec<Address>, ratio: u32) {
+        admin::set_max_loan_to_stake_ratio(env, admin_signers, ratio)
+    }
+
+    pub fn add_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
+        admin::add_allowed_token(env, admin_signers, token)
+    }
+
+    pub fn remove_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
+        admin::remove_allowed_token(env, admin_signers, token)
+    }
+
+    // ── Governance ────────────────────────────────────────────────────────────
+
+    pub fn vote_slash(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        governance::vote_slash(env, voucher, borrower, approve)
+    }
+
+    // ── Views ─────────────────────────────────────────────────────────────────
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Config)
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        helpers::config(&env).token
+    }
+
+    pub fn get_admins(env: Env) -> Vec<Address> {
+        admin::get_admins(env)
+    }
+
+    pub fn get_admin_threshold(env: Env) -> u32 {
+        admin::get_admin_threshold(env)
+    }
+
+    pub fn get_slash_treasury_balance(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0)
+    }
+
+    pub fn get_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    pub fn loan_status(env: Env, borrower: Address) -> LoanStatus {
+        loan::loan_status(env, borrower)
+    }
+
+    pub fn vouch_exists(env: Env, voucher: Address, borrower: Address) -> bool {
+        vouch::vouch_exists(env, voucher, borrower)
+    }
+
+    pub fn is_whitelisted(env: Env, voucher: Address) -> bool {
+        admin::is_whitelisted(env, voucher)
+    }
+
+    pub fn get_loan(env: Env, borrower: Address) -> Option<LoanRecord> {
+        loan::get_loan(env, borrower)
+    }
+
+    pub fn get_loan_by_id(env: Env, loan_id: u64) -> Option<LoanRecord> {
+        loan::get_loan_by_id(env, loan_id)
+    }
+
+    pub fn get_vouches(env: Env, borrower: Address) -> Option<Vec<VouchRecord>> {
+        env.storage().persistent().get(&DataKey::Vouches(borrower))
+    }
+
+    pub fn is_eligible(env: Env, borrower: Address, threshold: i128) -> bool {
+        loan::is_eligible(env, borrower, threshold)
+    }
+
+    pub fn get_contract_balance(env: Env) -> i128 {
+        helpers::token(&env).balance(&env.current_contract_address())
+    }
+
+    pub fn voucher_history(env: Env, voucher: Address) -> Vec<Address> {
+        vouch::voucher_history(env, voucher)
+    }
+
+    pub fn get_reputation(env: Env, borrower: Address) -> u32 {
+        let nft_addr: Address = match env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            Some(a) => a,
+            None => return 0,
+        };
+        ReputationNftExternalClient::new(&env, &nft_addr).balance(&borrower)
+    }
+
+    pub fn total_vouched(env: Env, borrower: Address) -> Result<i128, ContractError> {
+        vouch::total_vouched(env, borrower)
+    }
+
+    pub fn repayment_count(env: Env, borrower: Address) -> u32 {
+        loan::repayment_count(env, borrower)
+    }
+
+    pub fn loan_count(env: Env, borrower: Address) -> u32 {
+        loan::loan_count(env, borrower)
+    }
+
+    pub fn default_count(env: Env, borrower: Address) -> u32 {
+        loan::default_count(env, borrower)
+    }
+
+    pub fn get_protocol_fee(env: Env) -> u32 {
+        admin::get_protocol_fee(env)
+    }
+
+    pub fn get_fee_treasury(env: Env) -> Option<Address> {
+        admin::get_fee_treasury(env)
+    }
+
+    pub fn is_blacklisted(env: Env, borrower: Address) -> bool {
+        admin::is_blacklisted(env, borrower)
+    }
+
+    pub fn get_min_stake(env: Env) -> i128 {
+        admin::get_min_stake(env)
+    }
+
+    pub fn get_max_loan_amount(env: Env) -> i128 {
+        admin::get_max_loan_amount(env)
+    }
+
+    pub fn get_min_vouchers(env: Env) -> u32 {
+        admin::get_min_vouchers(env)
+    }
+
+    pub fn get_max_loan_to_stake_ratio(env: Env) -> u32 {
+        admin::get_max_loan_to_stake_ratio(env)
+    }
+
+    pub fn get_config(env: Env) -> Config {
+        admin::get_config(env)
+    }
+}

--- a/QuorumCredit/src/lib_old.rs
+++ b/QuorumCredit/src/lib_old.rs
@@ -1,0 +1,5250 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, token,
+    Address, BytesN, Env, Vec,
+};
+
+pub mod reputation;
+use reputation::ReputationNftExternalClient;
+
+// ── Constants (defaults only) ─────────────────────────────────────────────────
+
+const DEFAULT_YIELD_BPS: i128 = 200;
+const DEFAULT_SLASH_BPS: i128 = 5000;
+/// Minimum stake (in stroops) required for a vouch to earn non-zero yield.
+/// At 200 bps (2%), a stake must be at least 50 stroops so that
+/// `stake * 200 / 10_000 >= 1`. Stakes below this threshold would silently
+/// truncate to zero yield due to integer division.
+const DEFAULT_MIN_YIELD_STAKE: i128 = 50;
+/// Minimum age in seconds before a vouch can be used for a loan request.
+/// This prevents same-transaction vouch → request_loan attacks.
+const MIN_VOUCH_AGE: u64 = 60; // 1 minute
+const _: () = assert!(
+    DEFAULT_YIELD_BPS > 0 && DEFAULT_YIELD_BPS <= 10_000,
+    "DEFAULT_YIELD_BPS must be in range 1..=10_000"
+);
+const _: () = assert!(
+    DEFAULT_SLASH_BPS > 0 && DEFAULT_SLASH_BPS <= 10_000,
+    "DEFAULT_SLASH_BPS must be in range 1..=10_000"
+);
+const DEFAULT_MAX_VOUCHERS: u32 = 100;
+const DEFAULT_MIN_LOAN_AMOUNT: i128 = 100_000;
+const DEFAULT_LOAN_DURATION: u64 = 30 * 24 * 60 * 60;
+const DEFAULT_MAX_LOAN_TO_STAKE_RATIO: u32 = 150;
+const DEFAULT_VOUCH_COOLDOWN_SECS: u64 = 24 * 60 * 60; // 24 hours
+/// Delay before a timelocked action can be executed (24 hours).
+const TIMELOCK_DELAY: u64 = 24 * 60 * 60;
+/// Window after eta during which the action can still be executed (72 hours).
+const TIMELOCK_EXPIRY: u64 = 72 * 60 * 60;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    InsufficientFunds = 1,
+    /// Borrower already has an active (non-repaid, non-defaulted) loan.
+    ActiveLoanExists = 2,
+    /// Total vouched stake overflowed i128.
+    StakeOverflow = 3,
+    /// admin or token address must not be the zero address.
+    ZeroAddress = 4,
+    DuplicateVouch = 5,
+    NoActiveLoan = 6,
+    ContractPaused = 7,
+    LoanPastDeadline = 8,
+    PoolLengthMismatch = 9,
+    PoolEmpty = 10,
+    PoolBorrowerActiveLoan = 11,
+    PoolInsufficientFunds = 12,
+    MinStakeNotMet = 13,
+    LoanExceedsMaxAmount = 14,
+    InsufficientVouchers = 15,
+    UnauthorizedCaller = 16,
+    InvalidAmount = 17,
+    InvalidStateTransition = 18,
+    AlreadyInitialized = 19,
+    VouchTooRecent = 20,
+    VouchCooldownActive = 21,
+    BorrowerHasActiveLoan = 22,
+    VoucherNotWhitelisted = 23,
+    Blacklisted = 24,
+    TimelockNotFound = 25,
+    TimelockNotReady = 26,
+    TimelockExpired = 27,
+    NoVouchesForBorrower = 28,
+    VoucherNotFound = 29,
+}
+
+// ── Loan Status ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoanStatus {
+    None,
+    Active,
+    Repaid,
+    Defaulted,
+}
+
+// ── Storage Keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Loan(u64),               // loan_id → LoanRecord
+    ActiveLoan(Address),     // borrower → active loan_id
+    LatestLoan(Address),     // borrower → latest loan_id
+    Vouches(Address),        // borrower → Vec<VouchRecord>
+    VoucherHistory(Address), // voucher → Vec<Address> (borrowers backed)
+    Config,                  // Config struct: all configurable protocol parameters
+    Deployer,                // Address that deployed the contract; guards initialize
+    SlashTreasury,           // i128 accumulated slashed funds
+    Paused,                  // bool: true when contract is paused
+    BorrowerList,            // Vec<Address> of all borrowers who have ever requested a loan
+    ReputationNft,           // Address of the ReputationNftContract
+    MinStake,                // i128 minimum stake amount per vouch
+    MaxLoanAmount,           // i128 maximum individual loan size (0 = no cap)
+    MinVouchers,             // u32 minimum number of distinct vouchers required (0 = no minimum)
+    LoanCounter,             // u64: monotonically increasing loan ID counter
+    LoanPool(u64),           // pool_id → LoanPoolRecord
+    LoanPoolCounter,         // u64: monotonically increasing pool ID counter
+    PendingAdmin,            // Address of the pending admin (two-step transfer)
+    RepaymentCount(Address), // borrower → u32 total successful repayments
+    LoanCount(Address),      // borrower → u32 total historical loans disbursed
+    DefaultCount(Address),   // borrower → u32 total defaults (slash + auto_slash + claim_expired)
+    ProtocolFeeBps,          // u32: protocol fee in basis points
+    FeeTreasury,             // Address: recipient of collected protocol fees
+    LastVouchTimestamp(Address), // voucher → u64 last vouch timestamp
+    Timelock(u64),               // proposal_id → TimelockProposal
+    TimelockCounter,             // u64 monotonically increasing proposal ID
+    Blacklisted(Address),        // borrower → bool permanently banned
+    VoucherWhitelist(Address),   // voucher → bool allowed to vouch
+    ExtensionConsents(Address),  // borrower → Vec<Address> vouchers who consented to extension
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// All configurable protocol parameters, stored under DataKey::Config.
+#[contracttype]
+#[derive(Clone)]
+pub struct Config {
+    /// Admin addresses for multisig governance.
+    pub admins: Vec<Address>,
+    /// Number of admin signatures required.
+    pub admin_threshold: u32,
+    /// XLM token contract address.
+    pub token: Address,
+    /// Yield paid to vouchers on repayment in basis points (default 200 = 2%).
+    pub yield_bps: i128,
+    /// Slash penalty on default in basis points (default 5000 = 50%).
+    pub slash_bps: i128,
+    /// Maximum number of vouchers per loan (default 100).
+    pub max_vouchers: u32,
+    /// Minimum loan amount in stroops (default 100_000 = 0.01 XLM).
+    pub min_loan_amount: i128,
+    /// Loan duration in seconds (default 30 days).
+    pub loan_duration: u64,
+    /// Maximum loan amount as a percentage of total stake (default 150 = 150%).
+    pub max_loan_to_stake_ratio: u32,
+    /// Grace period after deadline before auto_slash is allowed, in seconds (default 3 days).
+    /// A value of 0 means slashing is allowed immediately after the deadline.
+    pub grace_period: u64,
+}
+
+// ── Data Types ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LoanRecord {
+    pub id: u64,
+    pub borrower: Address,
+    pub co_borrowers: Vec<Address>,
+    pub amount: i128,        // total loan principal in stroops
+    pub amount_repaid: i128, // cumulative repayments received so far (principal + yield)
+    pub total_yield: i128,   // yield owed to vouchers, locked in at disbursement
+    pub repaid: bool,
+    pub defaulted: bool,
+    pub created_at: u64,             // ledger timestamp
+    pub disbursement_timestamp: u64, // ledger timestamp
+    pub deadline: u64,               // repayment deadline (ledger timestamp)
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VouchRecord {
+    pub voucher: Address,
+    pub stake: i128,          // in stroops
+    pub vouch_timestamp: u64, // ledger timestamp when vouch was created; immutable after set
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LoanPoolRecord {
+    pub pool_id: u64,
+    pub borrowers: Vec<Address>,
+    pub amounts: Vec<i128>,
+    pub created_at: u64,
+    pub total_disbursed: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TimelockProposal {
+    pub id: u64,
+    pub action: TimelockAction,
+    pub proposer: Address,
+    pub eta: u64,
+    pub executed: bool,
+    pub cancelled: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum TimelockAction {
+    Slash(Address),
+    SetConfig(Config),
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Returns true if the address is the all-zeros account or contract address.
+fn is_zero_address(env: &Env, addr: &Address) -> bool {
+    // Stellar zero account: all-zero 32-byte ed25519 key
+    let zero_account = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+    // Stellar zero contract: all-zero 32-byte contract hash
+    let zero_contract = Address::from_string(&soroban_sdk::String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    addr == &zero_account || addr == &zero_contract
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct QuorumCreditContract;
+
+#[contractimpl]
+impl QuorumCreditContract {
+    /// One-time initialisation: set admins, XLM token address, and default config.
+    ///
+    /// `deployer` must be the address that deployed this contract and must
+    /// sign this transaction. This prevents front-running attacks where an
+    /// observer of the deployment transaction calls `initialize` first with
+    /// their own admin address before the legitimate deployer can do so.
+    pub fn initialize(
+        env: Env,
+        deployer: Address,
+        admins: Vec<Address>,
+        admin_threshold: u32,
+        token: Address,
+    ) {
+        deployer.require_auth();
+
+        if env.storage().instance().has(&DataKey::Config) {
+            panic_with_error!(&env, ContractError::AlreadyInitialized);
+        }
+
+        Self::validate_admin_config(&admins, admin_threshold);
+
+        env.storage().instance().set(&DataKey::Deployer, &deployer);
+        env.storage().instance().set(
+            &DataKey::Config,
+            &Config {
+                admins: admins.clone(),
+                admin_threshold,
+                token: token.clone(),
+                yield_bps: DEFAULT_YIELD_BPS,
+                slash_bps: DEFAULT_SLASH_BPS,
+                max_vouchers: DEFAULT_MAX_VOUCHERS,
+                min_loan_amount: DEFAULT_MIN_LOAN_AMOUNT,
+                loan_duration: DEFAULT_LOAN_DURATION,
+                max_loan_to_stake_ratio: DEFAULT_MAX_LOAN_TO_STAKE_RATIO,
+                grace_period: 0,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("contract"), symbol_short!("init")),
+            (deployer.clone(), admins, admin_threshold, token),
+        );
+    }
+
+    /// Stake XLM to vouch for a borrower.
+    ///
+    /// Sybil resistance is enforced here via two config parameters:
+    /// - `min_stake`: each voucher must lock a meaningful economic stake.
+    /// - `min_vouchers` (enforced at loan request): a minimum number of
+    ///   *distinct* vouchers must back the borrower before a loan is disbursed.
+    pub fn vouch(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        stake: i128,
+    ) -> Result<(), ContractError> {
+        voucher.require_auth();
+        Self::require_not_paused(&env)?;
+        Self::do_vouch(&env, voucher, borrower, stake)
+    }
+
+    fn do_vouch(
+        env: &Env,
+        voucher: Address,
+        borrower: Address,
+        stake: i128,
+    ) -> Result<(), ContractError> {
+        // Validate numeric input: stake must be strictly positive.
+        Self::require_positive_amount(env, stake)?;
+
+        assert!(voucher != borrower, "voucher cannot vouch for self");
+        assert!(stake > 0, "stake must be greater than zero");
+
+        let cfg = Self::config(env);
+
+        // Sybil resistance: enforce minimum stake per vouch.
+        let min_stake: i128 = env.storage().instance().get(&DataKey::MinStake).unwrap_or(0);
+        if min_stake > 0 && stake < min_stake {
+            return Err(ContractError::MinStakeNotMet);
+        }
+
+        // Rate limiting: enforce cooldown between vouch calls from the same address.
+        let now = env.ledger().timestamp();
+        let last: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LastVouchTimestamp(voucher.clone()))
+            .unwrap_or(0);
+
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(env));
+
+        // Reject duplicate vouch before any state mutation or transfer.
+        for v in vouches.iter() {
+            if v.voucher == voucher {
+                return Err(ContractError::DuplicateVouch);
+            }
+        }
+
+        // Reject vouch if the borrower already has an active loan — the stake
+        // would be locked with no effect on the existing loan (fixes issue #13).
+        if Self::has_active_loan(env, &borrower) {
+            return Err(ContractError::ActiveLoanExists);
+        }
+
+        assert!(
+            vouches.len() < cfg.max_vouchers,
+            "maximum vouchers per loan exceeded"
+        );
+
+        // Transfer stake from voucher into the contract.
+        let token = Self::token(env);
+        token.transfer(&voucher, &env.current_contract_address(), &stake);
+
+        // Track voucher → borrowers history.
+        let mut history: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VoucherHistory(voucher.clone()))
+            .unwrap_or(Vec::new(env));
+        history.push_back(borrower.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::VoucherHistory(voucher.clone()), &history);
+
+        vouches.push_back(VouchRecord {
+            voucher: voucher.clone(),
+            stake,
+            vouch_timestamp: env.ledger().timestamp(),
+        });
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vouches(borrower.clone()), &vouches);
+
+        // Record the timestamp of this vouch for rate limiting.
+        env.storage()
+            .persistent()
+            .set(&DataKey::LastVouchTimestamp(voucher.clone()), &env.ledger().timestamp());
+
+        env.events().publish(
+            (symbol_short!("vouch"), symbol_short!("added")),
+            (voucher, borrower, stake),
+        );
+
+        Ok(())
+    }
+
+    /// Vouch for multiple borrowers in a single transaction.
+    /// `borrowers` and `stakes` must have the same length.
+    /// Each entry is processed identically to a single `vouch` call —
+    /// any failure (duplicate, min-stake, paused, etc.) aborts the whole batch.
+    pub fn batch_vouch(
+        env: Env,
+        voucher: Address,
+        borrowers: Vec<Address>,
+        stakes: Vec<i128>,
+    ) -> Result<(), ContractError> {
+        voucher.require_auth();
+        Self::require_not_paused(&env)?;
+
+        assert!(
+            borrowers.len() == stakes.len(),
+            "borrowers and stakes length mismatch"
+        );
+        assert!(!borrowers.is_empty(), "batch cannot be empty");
+
+        for i in 0..borrowers.len() {
+            let borrower = borrowers.get(i).unwrap();
+            let stake = stakes.get(i).unwrap();
+            Self::do_vouch(&env, voucher.clone(), borrower, stake)?;
+        }
+
+        Ok(())
+    }
+
+    /// Add more stake to an existing vouch for a borrower.
+    pub fn increase_stake(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        additional: i128,
+    ) -> Result<(), ContractError> {
+        voucher.require_auth();
+        Self::require_not_paused(&env)?;
+
+        // Validate numeric input: additional must be strictly positive.
+        Self::require_positive_amount(&env, additional)?;
+
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .expect("vouch not found");
+
+        let idx = vouches
+            .iter()
+            .position(|v| v.voucher == voucher)
+            .expect("vouch not found") as u32;
+
+        let mut vouch = vouches.get(idx).unwrap();
+        Self::token_client(&env).transfer(&voucher, &env.current_contract_address(), &additional);
+
+        vouch.stake += additional;
+        vouches.set(idx, vouch);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vouches(borrower), &vouches);
+
+        Ok(())
+    }
+
+    /// Reduce stake from an existing vouch before any active loan exists.
+    pub fn decrease_stake(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        voucher.require_auth();
+        Self::require_not_paused(&env)?;
+
+        assert!(amount > 0, "decrease amount must be greater than zero");
+        assert!(
+            !Self::has_active_loan(&env, &borrower),
+            "loan already active"
+        );
+
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .expect("vouch not found");
+
+        let idx = vouches
+            .iter()
+            .position(|v| v.voucher == voucher)
+            .expect("vouch not found") as u32;
+
+        let mut vouch = vouches.get(idx).unwrap();
+        assert!(
+            amount <= vouch.stake,
+            "decrease amount exceeds staked amount"
+        );
+
+        vouch.stake -= amount;
+        if vouch.stake == 0 {
+            vouches.remove(idx);
+        } else {
+            vouches.set(idx, vouch);
+        }
+
+        if vouches.is_empty() {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Vouches(borrower));
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower), &vouches);
+        }
+
+        Self::token(&env).transfer(&env.current_contract_address(), &voucher, &amount);
+
+        Ok(())
+    }
+
+    /// Disburse a microloan if total vouched stake meets the threshold.
+    pub fn request_loan(
+        env: Env,
+        borrower: Address,
+        amount: i128,
+        threshold: i128,
+    ) -> Result<(), ContractError> {
+        borrower.require_auth();
+        Self::require_not_paused(&env)?;
+
+        if env
+            .storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::Blacklisted(borrower.clone()))
+            .unwrap_or(false)
+        {
+            return Err(ContractError::Blacklisted);
+        }
+
+        let cfg = Self::config(&env);
+
+        assert!(
+            amount >= cfg.min_loan_amount,
+            "loan amount must meet minimum threshold"
+        );
+        // Validate threshold is strictly positive.
+        assert!(threshold > 0, "threshold must be greater than zero");
+
+        // Enforce max loan amount cap if configured.
+        let max_loan_amount: i128 = env.storage().instance().get(&DataKey::MaxLoanAmount).unwrap_or(0);
+        if max_loan_amount > 0 && amount > max_loan_amount {
+            return Err(ContractError::LoanExceedsMaxAmount);
+        }
+
+        // Prevent overwriting an active loan record.
+        assert!(
+            !Self::has_active_loan(&env, &borrower),
+            "borrower already has an active loan"
+        );
+
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        let mut total_stake: i128 = 0;
+        for v in vouches.iter() {
+            total_stake = total_stake
+                .checked_add(v.stake)
+                .ok_or(ContractError::StakeOverflow)?;
+        }
+        assert!(total_stake >= threshold, "insufficient trust stake");
+
+        // Enforce minimum voucher count if configured.
+        let min_vouchers: u32 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MinVouchers)
+            .unwrap_or(0);
+        if vouches.len() < min_vouchers {
+            return Err(ContractError::InsufficientVouchers);
+        }
+
+        // Enforce minimum vouch age: every vouch must be at least MIN_VOUCH_AGE seconds old.
+        // This prevents a same-transaction (or same-block) vouch → request_loan attack.
+        let now = env.ledger().timestamp();
+        for v in vouches.iter() {
+            if now < v.vouch_timestamp + MIN_VOUCH_AGE {
+                return Err(ContractError::VouchTooRecent);
+            }
+        }
+
+        // Check collateral ratio: amount must not exceed total_stake * ratio / 100
+        let max_allowed_loan = total_stake * cfg.max_loan_to_stake_ratio as i128 / 100;
+        assert!(
+            amount <= max_allowed_loan,
+            "loan amount exceeds maximum collateral ratio"
+        );
+
+        // Verify the contract holds enough XLM to cover the loan.
+        let token = Self::token_client(&env);
+        let contract_balance = token.balance(&env.current_contract_address());
+        if contract_balance < amount {
+            return Err(ContractError::InsufficientFunds);
+        }
+
+        let deadline = now + cfg.loan_duration;
+        let loan_id = Self::next_loan_id(&env);
+
+        // Lock in the yield at disbursement time so rate changes mid-loan don't
+        // affect what the borrower owes or what vouchers receive (fixes issue #15).
+        let total_yield = amount * cfg.yield_bps / 10_000;
+
+        env.storage().persistent().set(
+            &DataKey::Loan(loan_id),
+            &LoanRecord {
+                id: loan_id,
+                borrower: borrower.clone(),
+                co_borrowers: Vec::new(&env),
+                amount,
+                amount_repaid: 0,
+                total_yield,
+                repaid: false,
+                defaulted: false,
+                created_at: now,
+                disbursement_timestamp: now,
+                deadline,
+            },
+        );
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActiveLoan(borrower.clone()), &loan_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LatestLoan(borrower.clone()), &loan_id);
+
+        // Track total historical loan count for this borrower.
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LoanCount(borrower.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LoanCount(borrower.clone()), &(count + 1));
+
+        token.transfer(&env.current_contract_address(), &borrower, &amount);
+
+        env.events().publish(
+            (symbol_short!("loan"), symbol_short!("disbursed")),
+            (borrower.clone(), amount, deadline),
+        );
+
+        Ok(())
+    }
+
+    /// Borrower repays all or part of the loan.
+    ///
+    /// `payment` is the amount being paid in this call (in stroops). The total
+    /// amount the borrower must repay is `loan.amount + loan.total_yield` —
+    /// principal plus the yield owed to vouchers. Yield is locked in at
+    /// disbursement so the borrower's obligation is fixed from day one.
+    ///
+    /// When cumulative `amount_repaid` reaches `amount + total_yield`, the loan
+    /// is marked fully repaid and each voucher receives their stake back plus
+    /// their proportional share of `total_yield`. Because yield comes entirely
+    /// from the borrower's repayment, no pre-funded contract balance is consumed
+    /// (fixes issue #15).
+    pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
+        borrower.require_auth();
+        Self::require_not_paused(&env)?;
+
+        let mut loan = Self::get_active_loan_record(&env, &borrower)?;
+
+        for cb in loan.co_borrowers.iter() {
+            cb.require_auth();
+        }
+
+        if borrower != loan.borrower {
+            return Err(ContractError::UnauthorizedCaller);
+        }
+        if loan.defaulted || loan.repaid {
+            return Err(ContractError::NoActiveLoan);
+        }
+
+        assert!(!loan.defaulted, "loan already defaulted");
+        assert!(!loan.repaid, "loan already repaid");
+        assert!(
+            env.ledger().timestamp() <= loan.deadline,
+            "loan deadline has passed"
+        );
+
+        // Total obligation = principal + yield locked in at disbursement.
+        let total_owed = loan.amount + loan.total_yield;
+        let outstanding = total_owed - loan.amount_repaid;
+        assert!(
+            payment > 0 && payment <= outstanding,
+            "invalid payment amount"
+        );
+
+        let token = Self::token(&env);
+
+        token.transfer(&borrower, &env.current_contract_address(), &payment);
+        loan.amount_repaid += payment;
+        let fully_repaid = loan.amount_repaid >= loan.amount;
+
+        if fully_repaid {
+            let vouches: Vec<VouchRecord> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Vouches(borrower.clone()))
+                .unwrap_or(Vec::new(&env));
+            let total_stake: i128 = vouches.iter().map(|v| v.stake).sum();
+
+            for v in vouches.iter() {
+                let voucher_yield = if total_stake > 0 {
+                    loan.total_yield * v.stake / total_stake
+                } else {
+                    0
+                };
+                token.transfer(
+                    &env.current_contract_address(),
+                    &v.voucher,
+                    &(v.stake + voucher_yield),
+                );
+            }
+
+            loan.repaid = true;
+            let count: u32 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RepaymentCount(borrower.clone()))
+                .unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&DataKey::RepaymentCount(borrower.clone()), &(count + 1));
+
+            if let Some(nft_addr) = env
+                .storage()
+                .instance()
+                .get::<DataKey, Address>(&DataKey::ReputationNft)
+            {
+                ReputationNftExternalClient::new(&env, &nft_addr).mint(&borrower);
+            }
+
+            env.storage()
+                .persistent()
+                .remove(&DataKey::ActiveLoan(borrower.clone()));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Vouches(borrower.clone()));
+
+            env.events().publish(
+                (symbol_short!("loan"), symbol_short!("repaid")),
+                (borrower.clone(), loan.amount),
+            );
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan.id), &loan);
+
+        Ok(())
+    }
+
+    /// Admin marks a loan defaulted; slash_bps% of each voucher's stake is slashed.
+    /// For non-emergency use, prefer propose_action(Slash) + execute_action for the timelock path.
+    pub fn slash(env: Env, admin_signers: Vec<Address>, borrower: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+        Self::require_not_paused(&env).expect("contract is paused");
+
+        let mut loan = Self::get_active_loan_record(&env, &borrower).expect("no active loan");
+
+        if loan.repaid || loan.defaulted {
+            panic_with_error!(&env, ContractError::NoActiveLoan);
+        }
+
+        let cfg = Self::config(&env);
+        let token = Self::token(&env);
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        // ── EFFECTS ───────────────────────────────────────────────────────────
+        loan.defaulted = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(borrower.clone()), &loan);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower.clone()));
+
+        let dc: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DefaultCount(borrower.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DefaultCount(borrower.clone()), &(dc + 1));
+
+        let token = Self::token_client(&env);
+        let mut total_slashed: i128 = 0;
+        for v in vouches.iter() {
+            let slash_amount = v.stake * cfg.slash_bps / 10_000;
+            total_slashed += slash_amount;
+        }
+
+        loan.defaulted = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan.id), &loan);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ActiveLoan(borrower.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower.clone()));
+
+        let treasury: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashTreasury, &(treasury + total_slashed));
+
+        for v in vouches.iter() {
+            let slash_amount = v.stake * cfg.slash_bps / 10_000;
+            let returned = v.stake - slash_amount;
+            if returned > 0 {
+                token.transfer(&env.current_contract_address(), &v.voucher, &returned);
+            }
+        }
+
+        if let Some(nft_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            ReputationNftExternalClient::new(&env, &nft_addr).burn(&borrower);
+        }
+
+        env.events().publish(
+            (symbol_short!("loan"), symbol_short!("slashed")),
+            (borrower.clone(), loan.amount, total_slashed),
+        );
+    }
+
+    /// Allows vouchers to claim back their stake if loan has expired without repayment or slash.
+    /// Requires the borrower's authorisation — they acknowledge the loan has lapsed.
+    pub fn claim_expired_loan(env: Env, borrower: Address) {
+        borrower.require_auth();
+
+        let mut loan = Self::get_active_loan_record(&env, &borrower).expect("no active loan");
+
+        if loan.repaid || loan.defaulted {
+            panic_with_error!(&env, ContractError::NoActiveLoan);
+        }
+
+        let now = env.ledger().timestamp();
+        assert!(now >= loan.deadline, "loan has not expired yet");
+
+        let token = Self::token(&env);
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        for v in vouches.iter() {
+            token.transfer(&env.current_contract_address(), &v.voucher, &v.stake);
+        }
+
+        loan.defaulted = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan.id), &loan);
+
+        let dc: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DefaultCount(borrower.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::DefaultCount(borrower.clone()), &(dc + 1));
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ActiveLoan(borrower.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower));
+    }
+
+    /// Admin withdraws accumulated slashed funds to a recipient address.
+    pub fn slash_treasury(env: Env, admin_signers: Vec<Address>, recipient: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let amount: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0);
+        assert!(amount > 0, "no slashed funds to withdraw");
+
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashTreasury, &0i128);
+        Self::token_client(&env).transfer(&env.current_contract_address(), &recipient, &amount);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("treasury")),
+            (admin_signers.get(0).unwrap(), recipient, amount, env.ledger().timestamp()),
+        );
+    }
+
+    // ── Timelock ──────────────────────────────────────────────────────────────
+
+    /// Propose a timelocked admin action. Returns the proposal ID.
+    /// The action can be executed after TIMELOCK_DELAY seconds have elapsed.
+    pub fn propose_action(
+        env: Env,
+        admin_signers: Vec<Address>,
+        action: TimelockAction,
+    ) -> u64 {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TimelockCounter)
+            .unwrap_or(0u64)
+            .checked_add(1)
+            .expect("timelock ID overflow");
+        env.storage().instance().set(&DataKey::TimelockCounter, &id);
+
+        let eta = env.ledger().timestamp() + TIMELOCK_DELAY;
+        let proposer = admin_signers.get(0).unwrap();
+
+        env.storage().persistent().set(
+            &DataKey::Timelock(id),
+            &TimelockProposal {
+                id,
+                action: action.clone(),
+                proposer: proposer.clone(),
+                eta,
+                executed: false,
+                cancelled: false,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("tl"), symbol_short!("proposed")),
+            (id, proposer, eta),
+        );
+        id
+    }
+
+    /// Execute a timelocked proposal once its eta has passed.
+    pub fn execute_action(
+        env: Env,
+        admin_signers: Vec<Address>,
+        proposal_id: u64,
+    ) -> Result<(), ContractError> {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let mut proposal: TimelockProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Timelock(proposal_id))
+            .ok_or(ContractError::TimelockNotFound)?;
+
+        assert!(!proposal.cancelled, "proposal cancelled");
+        assert!(!proposal.executed, "proposal already executed");
+
+        let now = env.ledger().timestamp();
+        if now < proposal.eta {
+            return Err(ContractError::TimelockNotReady);
+        }
+        if now > proposal.eta + TIMELOCK_EXPIRY {
+            return Err(ContractError::TimelockExpired);
+        }
+
+        proposal.executed = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Timelock(proposal_id), &proposal);
+
+        match proposal.action.clone() {
+            TimelockAction::Slash(borrower) => {
+                Self::do_slash(&env, borrower);
+            }
+            TimelockAction::SetConfig(config) => {
+                env.storage().instance().set(&DataKey::Config, &config);
+                env.events().publish(
+                    (symbol_short!("admin"), symbol_short!("config")),
+                    (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+                );
+            }
+        }
+
+        env.events().publish(
+            (symbol_short!("tl"), symbol_short!("executed")),
+            (proposal_id, admin_signers.get(0).unwrap(), now),
+        );
+        Ok(())
+    }
+
+    /// Cancel a pending timelocked proposal before it is executed.
+    pub fn cancel_action(
+        env: Env,
+        admin_signers: Vec<Address>,
+        proposal_id: u64,
+    ) -> Result<(), ContractError> {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let mut proposal: TimelockProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Timelock(proposal_id))
+            .ok_or(ContractError::TimelockNotFound)?;
+
+        assert!(!proposal.executed, "proposal already executed");
+        assert!(!proposal.cancelled, "proposal already cancelled");
+
+        proposal.cancelled = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Timelock(proposal_id), &proposal);
+
+        env.events().publish(
+            (symbol_short!("tl"), symbol_short!("cancelled")),
+            (proposal_id, admin_signers.get(0).unwrap()),
+        );
+        Ok(())
+    }
+
+    /// Read a timelock proposal by ID.
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Option<TimelockProposal> {
+        env.storage().persistent().get(&DataKey::Timelock(proposal_id))
+    }
+
+    pub fn withdraw_vouch(env: Env, voucher: Address, borrower: Address) {
+        voucher.require_auth();
+        Self::require_not_paused(&env)?;
+
+        assert!(
+            !Self::has_active_loan(&env, &borrower),
+            "loan already active"
+        );
+
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .ok_or(ContractError::NoActiveLoan)?; // reuse: "no vouch found"
+
+        let idx = vouches
+            .iter()
+            .position(|v| v.voucher == voucher)
+            .ok_or(ContractError::UnauthorizedCaller)? as u32;
+
+        let stake = vouches.get(idx).unwrap().stake;
+        vouches.remove(idx);
+
+        if vouches.is_empty() {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Vouches(borrower.clone()));
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        }
+
+        Self::token(&env).transfer(&env.current_contract_address(), &voucher, &stake);
+
+        env.events().publish(
+            (symbol_short!("vouch"), symbol_short!("withdrawn")),
+            (voucher, borrower, stake),
+        );
+    }
+
+    /// Transfer ownership of a stake position for a borrower from one address to another.
+    pub fn transfer_vouch(
+        env: Env,
+        from: Address,
+        to: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        from.require_auth();
+        Self::require_not_paused(&env)?;
+
+        if from == to {
+            return Ok(());
+        }
+
+        // Only allow transfer before a loan is active (consistent with withdraw_vouch).
+        assert!(
+            !Self::has_active_loan(&env, &borrower),
+            "loan already active"
+        );
+
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .ok_or(ContractError::NoActiveLoan)?;
+
+        let from_idx = vouches
+            .iter()
+            .position(|v| v.voucher == from)
+            .ok_or(ContractError::UnauthorizedCaller)? as u32;
+
+        let from_record = vouches.get(from_idx).unwrap();
+        let stake_to_transfer = from_record.stake;
+
+        if let Some(to_idx) = vouches.iter().position(|v| v.voucher == to) {
+            // Merge into existing record for 'to'
+            let mut to_record = vouches.get(to_idx as u32).unwrap();
+            to_record.stake += stake_to_transfer;
+            vouches.set(to_idx as u32, to_record);
+            vouches.remove(from_idx);
+        } else {
+            // Transfer ownership to 'to'
+            let mut updated_record = from_record;
+            updated_record.voucher = to.clone();
+            vouches.set(from_idx, updated_record);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vouches(borrower.clone()), &vouches);
+
+        // Update voucher histories
+        // 1. Remove borrower from 'from' history
+        let mut from_history: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VoucherHistory(from.clone()))
+            .unwrap_or(Vec::new(&env));
+        if let Some(h_idx) = from_history.iter().position(|b| b == borrower) {
+            from_history.remove(h_idx as u32);
+            env.storage()
+                .persistent()
+                .set(&DataKey::VoucherHistory(from.clone()), &from_history);
+        }
+
+        // 2. Add borrower to 'to' history if not already there
+        let mut to_history: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VoucherHistory(to.clone()))
+            .unwrap_or(Vec::new(&env));
+        if !to_history.iter().any(|b| b == borrower) {
+            to_history.push_back(borrower.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::VoucherHistory(to.clone()), &to_history);
+        }
+
+        env.events().publish(
+            (symbol_short!("vouch"), symbol_short!("transfer")),
+            (from, to, borrower, stake_to_transfer),
+        );
+
+        Ok(())
+    }
+
+    /// Callable by anyone after the loan deadline has passed.
+    /// Applies the standard slash penalty.
+    pub fn auto_slash(env: Env, borrower: Address) {
+        // ── CHECKS ────────────────────────────────────────────────────────────
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(borrower.clone()))
+            .expect("no active loan");
+
+
+        assert!(!loan.repaid, "loan already repaid");
+        assert!(!loan.defaulted, "loan already defaulted");
+
+        let cfg = Self::config(&env);
+        // saturating_add prevents u64 overflow on pathological deadline/grace_period values.
+        let slash_threshold = loan.deadline.saturating_add(cfg.grace_period);
+        assert!(
+            env.ledger().timestamp() > slash_threshold,
+            "loan grace period has not passed"
+        );
+
+        let token = Self::token(&env);
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        // ── EFFECTS ───────────────────────────────────────────────────────────
+        loan.defaulted = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(borrower.clone()), &loan);
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower.clone()));
+
+        let mut total_slash: i128 = 0;
+        for v in vouches.iter() {
+            total_slash += v.stake * cfg.slash_bps / 10_000;
+        }
+        Self::add_slash_balance(&env, total_slash);
+
+        let token = Self::token(&env);
+        for v in vouches.iter() {
+            let slash_amount = v.stake * cfg.slash_bps / 10_000;
+            let returned = v.stake - slash_amount;
+            if returned > 0 {
+                token.transfer(&env.current_contract_address(), &v.voucher, &returned);
+            }
+        }
+
+        if let Some(nft_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            ReputationNftExternalClient::new(&env, &nft_addr).burn(&borrower);
+        }
+    }
+
+    // ── Loan Extension ────────────────────────────────────────────────────────
+
+    /// A voucher signals consent for extending the loan deadline of a borrower
+    /// they have staked on. Consent is recorded but does not by itself extend
+    /// the loan — an admin must call `extend_loan` to finalise the extension.
+    pub fn consent_extension(env: Env, voucher: Address, borrower: Address) {
+        voucher.require_auth();
+        Self::require_not_paused(&env).expect("contract is paused");
+
+        // Voucher must have an active stake on this borrower.
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .expect("no vouches found for borrower");
+        assert!(
+            vouches.iter().any(|v| v.voucher == voucher),
+            "caller is not a voucher for this borrower"
+        );
+
+        let mut consents: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ExtensionConsents(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        assert!(
+            !consents.iter().any(|a| a == voucher),
+            "already consented"
+        );
+        consents.push_back(voucher.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::ExtensionConsents(borrower.clone()), &consents);
+
+        env.events().publish(
+            (symbol_short!("ext"), symbol_short!("consent")),
+            (voucher, borrower),
+        );
+    }
+
+    /// Admin extends the loan deadline for a borrower.
+    ///
+    /// `new_deadline` must be strictly greater than the current deadline.
+    /// The admin may extend unilaterally; voucher consents recorded via
+    /// `consent_extension` are cleared after a successful extension so the
+    /// slate is clean for any future extension request.
+    pub fn extend_loan(
+        env: Env,
+        admin_signers: Vec<Address>,
+        borrower: Address,
+        new_deadline: u64,
+    ) -> Result<(), ContractError> {
+        Self::require_admin_approval(&env, &admin_signers);
+        Self::require_not_paused(&env)?;
+
+    /// Admin permanently bans a borrower from requesting future loans.
+    pub fn blacklist(env: Env, admin_signers: Vec<Address>, borrower: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Blacklisted(borrower), &true);
+    }
+
+    /// Returns true if the borrower has been permanently blacklisted.
+    pub fn is_blacklisted(env: Env, borrower: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::Blacklisted(borrower))
+            .unwrap_or(false)
+    }
+
+    /// Admin sets the minimum stake amount required per vouch (in stroops).
+    pub fn set_min_stake(env: Env, admin_signers: Vec<Address>, amount: i128) {
+        Self::require_admin_approval(&env, &admin_signers);
+        assert!(amount >= 0, "min stake cannot be negative");
+        env.storage().instance().set(&DataKey::MinStake, &amount);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("minstake")),
+            (admin_signers.get(0).unwrap(), amount, env.ledger().timestamp()),
+        );
+    }
+
+    /// Returns the current minimum vouch stake (0 means no minimum).
+    pub fn get_min_stake(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinStake)
+            .unwrap_or(0)
+    }
+
+    /// Admin sets the maximum individual loan amount (in stroops).
+    pub fn set_max_loan_amount(env: Env, admin_signers: Vec<Address>, amount: i128) {
+        Self::require_admin_approval(&env, &admin_signers);
+        assert!(amount >= 0, "max loan amount cannot be negative");
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxLoanAmount, &amount);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("maxloan")),
+            (admin_signers.get(0).unwrap(), amount, env.ledger().timestamp()),
+        );
+    }
+
+    /// Returns the current maximum loan amount (0 means no cap).
+    pub fn get_max_loan_amount(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxLoanAmount)
+            .unwrap_or(0)
+    }
+
+    /// Admin sets the minimum number of distinct vouchers required.
+    pub fn set_min_vouchers(env: Env, admin_signers: Vec<Address>, count: u32) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage().instance().set(&DataKey::MinVouchers, &count);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("minvchrs")),
+            (admin_signers.get(0).unwrap(), count, env.ledger().timestamp()),
+        );
+    }
+
+    /// Returns the current minimum voucher count (0 means no minimum).
+    pub fn get_min_vouchers(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MinVouchers)
+            .unwrap_or(0)
+    }
+
+    /// Admin sets the maximum loan-to-stake ratio (as a percentage, e.g. 150 = 150%).
+    /// A value of 0 is rejected; use set_config to disable the ratio check entirely
+    /// by setting max_loan_to_stake_ratio to a very large number.
+    pub fn set_max_loan_to_stake_ratio(
+        env: Env,
+        admin_signers: Vec<Address>,
+        ratio: u32,
+    ) {
+        Self::require_admin_approval(&env, &admin_signers);
+        assert!(ratio > 0, "max_loan_to_stake_ratio must be greater than zero");
+        let mut cfg = Self::config(&env);
+        cfg.max_loan_to_stake_ratio = ratio;
+        env.storage().instance().set(&DataKey::Config, &cfg);
+    }
+
+    /// Returns the current maximum loan-to-stake ratio (percentage).
+    pub fn get_max_loan_to_stake_ratio(env: Env) -> u32 {
+        Self::config(&env).max_loan_to_stake_ratio
+    }
+
+    /// Admin updates configurable protocol parameters.
+    pub fn set_config(env: Env, admin_signers: Vec<Address>, config: Config) {
+        Self::require_admin_approval(&env, &admin_signers);
+        assert!(config.yield_bps >= 0, "yield_bps must be non-negative");
+        assert!(
+            config.slash_bps > 0 && config.slash_bps <= 10_000,
+            "slash_bps must be 1-10000"
+        );
+        assert!(config.max_vouchers > 0, "max_vouchers must be greater than zero");
+        assert!(config.min_loan_amount > 0, "min_loan_amount must be greater than zero");
+        assert!(config.loan_duration > 0, "loan_duration must be greater than zero");
+        assert!(
+            config.max_loan_to_stake_ratio > 0,
+            "max_loan_to_stake_ratio must be greater than zero"
+        );
+        // grace_period of 0 is valid — means no grace period, slash allowed immediately after deadline.
+        env.storage().instance().set(&DataKey::Config, &config);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("config")),
+            (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+        );
+    }
+
+    /// Returns the current protocol config.
+    pub fn get_config(env: Env) -> Config {
+        Self::config(&env)
+    }
+
+    /// Admin sets the reputation NFT contract address.
+    pub fn set_reputation_nft(env: Env, admin_signers: Vec<Address>, nft_contract: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::ReputationNft, &nft_contract);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("repnft")),
+            (admin_signers.get(0).unwrap(), nft_contract, env.ledger().timestamp()),
+        );
+    }
+
+    pub fn remove_voucher(
+        env: Env,
+        admin_signers: Vec<Address>,
+        voucher: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+
+        Self::require_admin_approval(&env, &admin_signers);
+        Self::require_not_paused(&env)?;
+ 
+        let mut vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .ok_or(ContractError::NoVouchesForBorrower)?;
+ 
+        let idx = vouches
+            .iter()
+            .position(|v| v.voucher == voucher)
+            .ok_or(ContractError::VoucherNotFound)? as u32;
+ 
+
+        let stake = vouches.get(idx).unwrap().stake;
+        vouches.remove(idx);
+ 
+        if vouches.is_empty() {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Vouches(borrower.clone()));
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        }
+ 
+
+        Self::token(&env).transfer(
+            &env.current_contract_address(),
+            &voucher,
+            &stake,
+        );
+ 
+        env.events().publish(
+            (symbol_short!("vouch"), symbol_short!("removed")),
+            (voucher, borrower, stake),
+        );
+ 
+        Ok(())
+    }
+
+    // ── Admin: Key Management (M-of-N Multisig) ───────────────────────────────
+    //
+    // All mutations to the admin set require the current quorum to sign,
+    // preventing a single compromised key from unilaterally modifying governance.
+    //
+    // Key management recommendations:
+    //   - Use hardware wallets (Ledger/Trezor) for each admin key.
+    //   - Store key backups in geographically separate, offline locations.
+    //   - Set admin_threshold to at least ceil(N/2)+1 for N admins (e.g. 3-of-5).
+    //   - Rotate keys periodically using rotate_admin; never reuse compromised keys.
+    //   - After any key rotation, verify the new admin set with get_admins().
+    //   - Never share private keys; each admin should control exactly one key.
+
+    /// Add a new admin to the set. Requires current quorum approval.
+    /// The new admin is appended; threshold is unchanged.
+    pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let mut cfg = Self::config(&env);
+
+        assert!(
+            !cfg.admins.iter().any(|a| a == new_admin),
+            "address is already an admin"
+        );
+
+        cfg.admins.push_back(new_admin.clone());
+        env.storage().instance().set(&DataKey::Config, &cfg);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("added")),
+            new_admin,
+        );
+    }
+
+    /// Remove an existing admin from the set. Requires current quorum approval.
+    /// The threshold must remain satisfiable after removal (threshold <= remaining admins).
+    pub fn remove_admin(env: Env, admin_signers: Vec<Address>, admin_to_remove: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let mut cfg = Self::config(&env);
+
+        let idx = cfg
+            .admins
+            .iter()
+            .position(|a| a == admin_to_remove)
+            .expect("address is not an admin") as u32;
+
+        cfg.admins.remove(idx);
+
+        assert!(
+            !cfg.admins.is_empty(),
+            "cannot remove the last admin"
+        );
+        assert!(
+            cfg.admin_threshold <= cfg.admins.len(),
+            "removal would make threshold unsatisfiable"
+        );
+
+        env.storage().instance().set(&DataKey::Config, &cfg);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("removed")),
+            admin_to_remove,
+        );
+    }
+
+    /// Atomically replace one admin key with another. Requires current quorum approval.
+    /// Use this for key rotation — the threshold is preserved and the admin count stays the same.
+    pub fn rotate_admin(
+        env: Env,
+        admin_signers: Vec<Address>,
+        old_admin: Address,
+        new_admin: Address,
+    ) {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        assert!(old_admin != new_admin, "old and new admin must differ");
+
+        let mut cfg = Self::config(&env);
+
+        assert!(
+            !cfg.admins.iter().any(|a| a == new_admin),
+            "new admin is already in the admin set"
+        );
+
+        let idx = cfg
+            .admins
+            .iter()
+            .position(|a| a == old_admin)
+            .expect("old admin not found") as u32;
+
+        cfg.admins.set(idx, new_admin.clone());
+        env.storage().instance().set(&DataKey::Config, &cfg);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("rotated")),
+            (old_admin, new_admin),
+        );
+    }
+
+    /// Update the quorum threshold. Requires current quorum approval.
+    /// New threshold must be > 0 and <= current admin count.
+    pub fn set_admin_threshold(env: Env, admin_signers: Vec<Address>, new_threshold: u32) {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        let mut cfg = Self::config(&env);
+
+        assert!(new_threshold > 0, "threshold must be greater than zero");
+        assert!(
+            new_threshold <= cfg.admins.len(),
+            "threshold cannot exceed admin count"
+        );
+
+        cfg.admin_threshold = new_threshold;
+        env.storage().instance().set(&DataKey::Config, &cfg);
+
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("thresh")),
+            new_threshold,
+        );
+    }
+
+    // ── Admin: Protocol Fee ───────────────────────────────────────────────────
+
+    /// Admin sets the protocol fee applied to interactions (in basis points).
+    pub fn set_protocol_fee(env: Env, admin_signers: Vec<Address>, fee_bps: u32) {
+        Self::require_admin_approval(&env, &admin_signers);
+        assert!(fee_bps <= 10_000, "fee_bps must not exceed 10000");
+        env.storage()
+            .instance()
+            .set(&DataKey::ProtocolFeeBps, &fee_bps);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("fee")),
+            (admin_signers.get(0).unwrap(), fee_bps, env.ledger().timestamp()),
+        );
+    }
+
+    /// Admin whitelists a voucher to allow them to stake/vouch for borrowers.
+    pub fn whitelist_voucher(env: Env, admin_signers: Vec<Address>, voucher: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::VoucherWhitelist(voucher), &true);
+    }
+
+    /// Returns the current protocol fee (0 if not set).
+    pub fn get_protocol_fee(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProtocolFeeBps)
+            .unwrap_or(0)
+    }
+
+    /// Admin sets the treasury address that receives protocol fees on repayment.
+    pub fn set_fee_treasury(env: Env, admin_signers: Vec<Address>, treasury: Address) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage()
+            .instance()
+            .set(&DataKey::FeeTreasury, &treasury);
+    }
+
+    /// Returns the current fee treasury address, if set.
+    pub fn get_fee_treasury(env: Env) -> Option<Address> {
+        env.storage().instance().get(&DataKey::FeeTreasury)
+    }
+
+    // ── Admin: Upgrade ──────────────────────────────────────────────────────
+
+    /// Admin upgrades the contract WASM.
+    pub fn upgrade(env: Env, admin_signers: Vec<Address>, new_wasm_hash: BytesN<32>) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+        env.events()
+            .publish((symbol_short!("upgrade"),), new_wasm_hash);
+    }
+
+    // ── Admin: Pause / Unpause ────────────────────────────────────────────────
+
+    /// Pause the contract.
+    pub fn pause(env: Env, admin_signers: Vec<Address>) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage().instance().set(&DataKey::Paused, &true);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("pause")),
+            (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+        );
+    }
+
+    /// Unpause the contract.
+    pub fn unpause(env: Env, admin_signers: Vec<Address>) {
+        Self::require_admin_approval(&env, &admin_signers);
+        env.storage().instance().set(&DataKey::Paused, &false);
+        env.events().publish(
+            (symbol_short!("admin"), symbol_short!("unpause")),
+            (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+        );
+    }
+
+    // ── Views ─────────────────────────────────────────────────────────────────
+
+    pub fn is_initialized(env: Env) -> bool {
+        env.storage().instance().has(&DataKey::Config)
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        Self::config(&env).token
+    }
+
+    pub fn get_admins(env: Env) -> Vec<Address> {
+        Self::config(&env).admins
+    }
+
+    pub fn get_admin_threshold(env: Env) -> u32 {
+        Self::config(&env).admin_threshold
+    }
+
+    pub fn get_slash_treasury_balance(env: Env) -> i128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0)
+    }
+
+    pub fn get_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    pub fn loan_status(env: Env, borrower: Address) -> LoanStatus {
+        match Self::get_latest_loan_record(&env, &borrower) {
+            None => LoanStatus::None,
+            Some(loan) if loan.repaid => LoanStatus::Repaid,
+            Some(loan) if loan.defaulted => LoanStatus::Defaulted,
+            _ => LoanStatus::Active,
+        }
+    }
+
+    pub fn vouch_exists(env: Env, voucher: Address, borrower: Address) -> bool {
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower))
+            .unwrap_or(Vec::new(&env));
+        vouches.iter().any(|v| v.voucher == voucher)
+    }
+
+    pub fn is_whitelisted(env: Env, voucher: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VoucherWhitelist(voucher))
+            .unwrap_or(false)
+    }
+
+    pub fn get_loan(env: Env, borrower: Address) -> Option<LoanRecord> {
+        Self::get_latest_loan_record(&env, &borrower)
+    }
+
+    pub fn get_loan_by_id(env: Env, loan_id: u64) -> Option<LoanRecord> {
+        env.storage().persistent().get(&DataKey::Loan(loan_id))
+    }
+
+    pub fn get_vouches(env: Env, borrower: Address) -> Option<Vec<VouchRecord>> {
+        env.storage().persistent().get(&DataKey::Vouches(borrower))
+    }
+
+    /// Admin-only paginated view of all loan records.
+    /// Returns the slice of LoanRecords for the given page (0-indexed).
+    pub fn get_all_loans(env: Env, page: u32, page_size: u32) -> Vec<LoanRecord> {
+        let config = Self::config(&env);
+        assert!(config.admins.contains(&env.invoker()), "unauthorized");
+
+        assert!(page_size > 0, "page_size must be greater than zero");
+
+        let borrowers: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::BorrowerList)
+            .unwrap_or(Vec::new(&env));
+
+        let start = (page * page_size) as usize;
+        let mut result = Vec::new(&env);
+
+        for i in start..(start + page_size as usize).min(borrowers.len() as usize) {
+            let borrower = borrowers.get(i as u32).unwrap();
+            if let Some(loan) = env.storage().persistent().get(&DataKey::Loan(borrower)) {
+                result.push_back(loan);
+            }
+        }
+
+        result
+    }
+
+    /// Read-only eligibility check for frontends.
+    pub fn is_eligible(env: Env, borrower: Address, threshold: i128) -> bool {
+        if threshold <= 0 {
+            return false;
+        }
+
+        if let Some(loan) = Self::get_latest_loan_record(&env, &borrower) {
+            if !loan.repaid && !loan.defaulted {
+                return false;
+            }
+        }
+
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower))
+            .unwrap_or(Vec::new(&env));
+
+        let total_stake: i128 = vouches.iter().map(|v| v.stake).sum();
+        total_stake >= threshold
+    }
+
+    /// Returns the contract's current XLM balance in stroops.
+    pub fn get_contract_balance(env: Env) -> i128 {
+        Self::token(&env).balance(&env.current_contract_address())
+    }
+
+    /// Returns all borrower addresses that the given voucher has ever backed.
+    pub fn voucher_history(env: Env, voucher: Address) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VoucherHistory(voucher))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Returns the reputation score for a borrower.
+    pub fn get_reputation(env: Env, borrower: Address) -> u32 {
+        let nft_addr: Address = match env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            Some(a) => a,
+            None => return 0,
+        };
+        ReputationNftExternalClient::new(&env, &nft_addr).balance(&borrower)
+    }
+
+    /// Returns the total staked amount across all vouchers for a given borrower.
+    pub fn total_vouched(env: Env, borrower: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Vec<VouchRecord>>(&DataKey::Vouches(borrower))
+            .unwrap_or(Vec::new(&env))
+            .iter()
+            .map(|v| v.stake)
+            .sum()
+    }
+
+    /// Returns the total number of successful repayments for a borrower.
+    pub fn repayment_count(env: Env, borrower: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RepaymentCount(borrower))
+            .unwrap_or(0)
+    }
+
+    /// Returns the total number of loans ever disbursed to a borrower (including active, repaid, and defaulted).
+    pub fn loan_count(env: Env, borrower: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::LoanCount(borrower))
+            .unwrap_or(0)
+    }
+
+    /// Returns the total number of defaults for a borrower (slash, auto_slash, or claim_expired_loan).
+    pub fn default_count(env: Env, borrower: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DefaultCount(borrower))
+            .unwrap_or(0)
+    }
+
+    // ── Loan Pool ─────────────────────────────────────────────────────────────
+
+    /// Admin function: atomically disburse a batch of small loans to multiple borrowers.
+    pub fn create_loan_pool(
+        env: Env,
+        admin_signers: Vec<Address>,
+        borrowers: Vec<Address>,
+        amounts: Vec<i128>,
+    ) -> Result<u64, ContractError> {
+        Self::require_admin_approval(&env, &admin_signers);
+
+        if borrowers.len() != amounts.len() {
+            return Err(ContractError::PoolLengthMismatch);
+        }
+        if borrowers.is_empty() {
+            return Err(ContractError::PoolEmpty);
+        }
+
+        let cfg = Self::config(&env);
+        let now = env.ledger().timestamp();
+        let deadline = now + cfg.loan_duration;
+
+        let mut total_amount: i128 = 0;
+        for i in 0..borrowers.len() {
+            let borrower = borrowers.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+
+            assert!(
+                amount >= cfg.min_loan_amount,
+                "pool: amount below minimum loan threshold"
+            );
+
+            if Self::has_active_loan(&env, &borrower) {
+                return Err(ContractError::PoolBorrowerActiveLoan);
+            }
+
+            let total_stake: i128 = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Vec<VouchRecord>>(&DataKey::Vouches(borrower.clone()))
+                .unwrap_or(Vec::new(&env))
+                .iter()
+                .map(|v| v.stake)
+                .sum();
+            let max_allowed = total_stake * cfg.max_loan_to_stake_ratio as i128 / 100;
+            assert!(
+                amount <= max_allowed,
+                "pool: loan amount exceeds maximum collateral ratio for borrower"
+            );
+
+            total_amount += amount;
+        }
+
+        let token = Self::token(&env);
+        let contract_balance = token.balance(&env.current_contract_address());
+        if contract_balance < total_amount {
+            return Err(ContractError::PoolInsufficientFunds);
+        }
+
+        let pool_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LoanPoolCounter)
+            .unwrap_or(0u64)
+            .checked_add(1)
+            .expect("pool ID overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::LoanPoolCounter, &pool_id);
+
+        for i in 0..borrowers.len() {
+            let borrower = borrowers.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+            let loan_id = Self::next_loan_id(&env);
+
+            env.storage().persistent().set(
+                &DataKey::Loan(loan_id),
+                &LoanRecord {
+                    id: loan_id,
+                    borrower: borrower.clone(),
+                    co_borrowers: Vec::new(&env), // pools currently only use single borrowers
+                    amount,
+                    amount_repaid: 0,
+                    total_yield: amount * cfg.yield_bps / 10_000,
+                    repaid: false,
+                    defaulted: false,
+                    created_at: now,
+                    disbursement_timestamp: now,
+                    deadline,
+                },
+            );
+            env.storage()
+                .persistent()
+                .set(&DataKey::ActiveLoan(borrower.clone()), &loan_id);
+            env.storage()
+                .persistent()
+                .set(&DataKey::LatestLoan(borrower.clone()), &loan_id);
+
+            token.transfer(&env.current_contract_address(), &borrower, &amount);
+
+            env.events().publish(
+                (symbol_short!("pool"), symbol_short!("loan")),
+                (pool_id, borrower.clone(), amount, deadline),
+            );
+        }
+
+        env.storage().persistent().set(
+            &DataKey::LoanPool(pool_id),
+            &LoanPoolRecord {
+                pool_id,
+                borrowers: borrowers.clone(),
+                amounts: amounts.clone(),
+                created_at: now,
+                total_disbursed: total_amount,
+            },
+        );
+
+        env.events().publish(
+            (symbol_short!("pool"), symbol_short!("created")),
+            (pool_id, borrowers.len(), total_amount),
+        );
+
+        Ok(pool_id)
+    }
+
+    pub fn get_loan_pool(env: Env, pool_id: u64) -> Option<LoanPoolRecord> {
+        env.storage().persistent().get(&DataKey::LoanPool(pool_id))
+    }
+
+    /// Returns the current pool ID counter.
+    pub fn get_loan_pool_count(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::LoanPoolCounter)
+            .unwrap_or(0)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if paused {
+            Err(ContractError::ContractPaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns `Err(InsufficientFunds)` if `amount` is not strictly positive (≤ 0).
+    /// Use this for all numeric inputs that must be > 0 (stakes, loan amounts, thresholds).
+    fn require_positive_amount(_env: &Env, amount: i128) -> Result<(), ContractError> {
+        if amount <= 0 {
+            return Err(ContractError::InsufficientFunds);
+        }
+        Ok(())
+    }
+
+    fn config(env: &Env) -> Config {
+        env.storage()
+            .instance()
+            .get(&DataKey::Config)
+            .expect("not initialized")
+    }
+
+    fn add_slash_balance(env: &Env, amount: i128) {
+        let current: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashTreasury, &(current + amount));
+    }
+
+    fn has_active_loan(env: &Env, borrower: &Address) -> bool {
+        matches!(Self::get_active_loan_record(env, borrower), Ok(loan) if !loan.repaid && !loan.defaulted)
+    }
+
+    fn next_loan_id(env: &Env) -> u64 {
+        let loan_id = env
+            .storage()
+            .instance()
+            .get(&DataKey::LoanCounter)
+            .unwrap_or(0u64)
+            .checked_add(1)
+            .expect("loan ID overflow");
+        env.storage()
+            .instance()
+            .set(&DataKey::LoanCounter, &loan_id);
+        loan_id
+    }
+
+    fn get_active_loan_record(env: &Env, borrower: &Address) -> Result<LoanRecord, ContractError> {
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()))
+            .ok_or(ContractError::NoActiveLoan)?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(ContractError::NoActiveLoan)
+    }
+
+    fn get_latest_loan_record(env: &Env, borrower: &Address) -> Option<LoanRecord> {
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LatestLoan(borrower.clone()))?;
+        env.storage().persistent().get(&DataKey::Loan(loan_id))
+    }
+
+    fn token(env: &Env) -> token::Client<'_> {
+        let addr = Self::config(env).token;
+        token::Client::new(env, &addr)
+    }
+
+    fn token_client(env: &Env) -> token::Client<'_> {
+        Self::token(env)
+    }
+
+    /// Core slash logic shared by `slash` (direct) and `execute_action` (timelocked).
+    fn do_slash(env: &Env, borrower: Address) {
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(borrower.clone()))
+            .expect("no active loan");
+
+        if loan.repaid || loan.defaulted {
+            panic_with_error!(env, ContractError::NoActiveLoan);
+        }
+
+        let cfg = Self::config(env);
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(env));
+
+        loan.defaulted = true;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(borrower.clone()), &loan);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower.clone()));
+
+        let token = Self::token(env);
+        let mut total_slashed: i128 = 0;
+        for v in vouches.iter() {
+            let slash_amount = v.stake * cfg.slash_bps / 10_000;
+            let returned = v.stake - slash_amount;
+            if returned > 0 {
+                token.transfer(&env.current_contract_address(), &v.voucher, &returned);
+            }
+            total_slashed += slash_amount;
+        }
+
+        let treasury: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::SlashTreasury)
+            .unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&DataKey::SlashTreasury, &(treasury + total_slashed));
+
+        if let Some(nft_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            ReputationNftExternalClient::new(env, &nft_addr).burn(&borrower);
+        }
+
+        env.events().publish(
+            (symbol_short!("loan"), symbol_short!("slashed")),
+            (borrower, loan.amount, total_slashed),
+        );
+    }
+
+    fn require_admin_approval(env: &Env, admin_signers: &Vec<Address>) {
+        let config = Self::config(env);
+        assert!(
+            admin_signers.len() >= config.admin_threshold,
+            "insufficient admin approvals"
+        );
+        for signer in admin_signers.iter() {
+            assert!(
+                config.admins.iter().any(|a| a == signer),
+                "signer is not a registered admin"
+            );
+            signer.require_auth();
+        }
+    }
+
+    fn validate_admin_config(admins: &Vec<Address>, admin_threshold: u32) {
+        assert!(!admins.is_empty(), "at least one admin is required");
+        assert!(
+            admin_threshold > 0,
+            "admin threshold must be greater than zero"
+        );
+        assert!(
+            admin_threshold <= admins.len(),
+            "admin threshold cannot exceed admin count"
+        );
+
+        let admin_count = admins.len();
+        for i in 0..admin_count {
+            let admin = admins.get(i).unwrap();
+            for j in 0..i {
+                let prior_admin = admins.get(j).unwrap();
+                assert!(admin != prior_admin, "duplicate admin");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger as _},
+        Address, Env, Vec,
+    };
+    use soroban_sdk::token::{Client as TokenClient, StellarAssetClient};
+
+    fn single_admin_signers(env: &Env, admin: &Address) -> Vec<Address> {
+        let mut v = Vec::new(env);
+        v.push_back(admin.clone());
+        v
+    }
+
+    fn address_vec(env: &Env, addrs: &[Address]) -> Vec<Address> {
+        let mut v = Vec::new(env);
+        for a in addrs {
+            v.push_back(a.clone());
+        }
+        v
+    }
+
+    /// Advance the ledger clock past the minimum vouch age so vouches become usable.
+    fn advance_past_vouch_age(env: &Env) {
+        let current = env.ledger().timestamp();
+        env.ledger().set_timestamp(current + MIN_VOUCH_AGE);
+    }
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address, Address) {
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(env);
+        let borrower = Address::generate(env);
+        let voucher = Address::generate(env);
+        let admins = single_admin_signers(env, &admin);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_admin = StellarAssetClient::new(env, &token_id.address());
+        token_admin.mint(&voucher, &10_000_000);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        token_admin.mint(&contract_id, &50_000_000);
+
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(
+            &admin,
+            &admins,
+            &1,
+            &token_id.address(),
+        );
+
+        client.whitelist_voucher(&admins, &voucher);
+
+        (contract_id, token_id.address(), admin, borrower, voucher)
+    }
+
+    fn setup_multisig(
+        env: &Env,
+        admin_threshold: u32,
+    ) -> (Address, Address, Address, Address, Address, Address, Address) {
+        env.mock_all_auths();
+
+        let admin_one = Address::generate(env);
+        let admin_two = Address::generate(env);
+        let admin_three = Address::generate(env);
+        let borrower = Address::generate(env);
+        let voucher = Address::generate(env);
+        let admins = address_vec(
+            env,
+            &[admin_one.clone(), admin_two.clone(), admin_three.clone()],
+        );
+
+        let token_id = env.register_stellar_asset_contract_v2(admin_one.clone());
+        let token_admin = StellarAssetClient::new(env, &token_id.address());
+        token_admin.mint(&voucher, &10_000_000);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        token_admin.mint(&contract_id, &50_000_000);
+
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(
+            &admin_one,
+            &admins,
+            &admin_threshold,
+            &token_id.address(),
+        );
+
+        (contract_id, token_id.address(), admin_one, admin_two, admin_three, borrower, voucher)
+    }
+
+    #[test]
+    fn test_vouch_and_loan_disbursed() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.amount, 500_000);
+        assert!(!loan.repaid);
+        assert!(!loan.defaulted);
+        assert!(loan.created_at > 0);
+        assert!(loan.deadline > loan.created_at);
+    }
+
+    #[test]
+    fn test_initialize_emits_event() {
+        use soroban_sdk::{IntoVal, Val};
+        
+        let env = Env::default();
+        env.mock_all_auths();
+        
+        let admin = Address::generate(&env);
+        let admins = single_admin_signers(&env, &admin);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        
+        client.initialize(
+            &admin,
+            &admins,
+            &1,
+            &token_id.address(),
+        );
+        
+        let events = env.events().all();
+        let last_event = events.last().unwrap();
+        
+        assert_eq!(
+            last_event.topics,
+            (
+                contract_id.clone(),
+                symbol_short!("contract").into_val(&env),
+                symbol_short!("init").into_val(&env),
+            )
+        );
+        
+        let event_data: (Address, soroban_sdk::Vec<Address>, u32, Address) = last_event.data.into_val(&env);
+        assert_eq!(event_data.0, admin);
+        assert_eq!(event_data.1, admins);
+        assert_eq!(event_data.2, 1);
+        assert_eq!(event_data.3, token_id.address());
+    }
+
+    #[test]
+    #[should_panic(expected = "voucher cannot vouch for self")]
+    fn test_vouch_self_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&borrower, &borrower, &1_000_000);
+    }
+
+    /// Issue 4: a zero-stake vouch must be rejected to prevent inflating the
+    /// vouch count without contributing to the loan threshold.
+    #[test]
+    #[should_panic(expected = "stake must be greater than zero")]
+    fn test_vouch_zero_stake_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &0);
+    }
+
+    #[test]
+    fn test_repay_gives_voucher_yield() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        assert_eq!(token.balance(&voucher), 10_010_000);
+    }
+
+    #[test]
+    fn test_slash_burns_half_stake() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(token.balance(&voucher), 9_500_000);
+        assert!(client.get_loan(&borrower).unwrap().defaulted);
+    }
+
+    #[test]
+    fn test_duplicate_vouch_should_fail() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        let result = client.try_vouch(&voucher, &borrower, &500_000);
+        assert_eq!(result, Err(Ok(ContractError::DuplicateVouch)));
+
+        let vouches = client.get_vouches(&borrower).unwrap();
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().stake, 1_000_000);
+    }
+
+    #[test]
+    fn test_repay_nonexistent_loan_should_fail() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let result = client.try_repay(&borrower, &100_000);
+        assert_eq!(result, Err(Ok(ContractError::NoActiveLoan)));
+    }
+
+    #[test]
+    fn test_repay_mismatched_borrower_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let attacker = Address::generate(&env);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        token_admin.mint(&attacker, &10_000_000);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        let result = client.try_repay(&attacker, &500_000);
+        assert_eq!(result, Err(Ok(ContractError::NoActiveLoan)));
+
+        client.repay(&borrower, &500_000);
+    }
+
+    // ── Min Yield Stake Tests ─────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(
+        expected = "stake too small: would produce zero yield due to integer truncation"
+    )]
+    fn test_vouch_small_stake_below_min_yield_stake_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &49);
+    }
+
+    #[test]
+    fn test_vouch_at_min_yield_stake_earns_nonzero_yield() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.max_loan_to_stake_ratio = 200_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &100_000, &1_000_000);
+        client.repay(&borrower, &100_000);
+
+        let initial_balance: i128 = 10_000_000;
+        let final_balance = token.balance(&voucher);
+        assert!(
+            final_balance > initial_balance,
+            "voucher yield was zero for min_yield_stake; got balance {}",
+            final_balance
+        );
+    }
+
+    // ── Partial Repayment Tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_partial_repay_updates_amount_repaid() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &admins, &1, &token_id.address());
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &600_000, &1_000_000);
+        client.repay(&borrower, &200_000);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.amount_repaid, 200_000);
+        assert!(!loan.repaid);
+    }
+
+    #[test]
+    fn test_full_repay_via_installments_marks_repaid_and_pays_yield() {
+        let env = Env::default();
+        let (contract_id, token_addr, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        client.repay(&borrower, &400_000);
+        assert!(!client.get_loan(&borrower).unwrap().repaid);
+
+        client.repay(&borrower, &200_000);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert!(loan.repaid);
+        assert_eq!(loan.amount_repaid, 600_000);
+        assert_eq!(token.balance(&voucher), 10_012_000);
+    }
+
+    #[test]
+    fn test_single_full_repay_still_works() {
+        let env = Env::default();
+        let (contract_id, token_addr, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(token.balance(&voucher), 9_500_000);
+        assert!(client.get_loan(&borrower).unwrap().defaulted);
+    }
+
+    #[test]
+    fn test_slash_emits_event() {
+        use soroban_sdk::{IntoVal, Val};
+
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        let topic_loan: Val = symbol_short!("loan").into_val(&env);
+        let topic_slashed: Val = symbol_short!("slashed").into_val(&env);
+
+        let (_, _, data) = env
+            .events()
+            .all()
+            .iter()
+            .find(|(_, topics, _)| {
+                topics.len() == 2
+                    && topics.get_unchecked(0).get_payload() == topic_loan.get_payload()
+                    && topics.get_unchecked(1).get_payload() == topic_slashed.get_payload()
+            })
+            .expect("loan_slashed event not emitted");
+
+        let (event_borrower, event_loan_amount, event_slashed): (Address, i128, i128) =
+            data.into_val(&env);
+        assert_eq!(event_borrower, borrower);
+        assert_eq!(event_loan_amount, 500_000);
+        assert_eq!(event_slashed, 500_000); // 50% of 1_000_000 stake
+    }
+
+    #[test]
+    fn test_zero_threshold_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        let result = client.try_request_loan(&borrower, &500_000, &0);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
+    }
+
+    #[test]
+    fn test_request_loan_underfunded_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+        let admins = single_admin_signers(&env, &admin);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_admin = StellarAssetClient::new(&env, &token_id.address());
+        token_admin.mint(&voucher, &10_000_000);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        QuorumCreditContractClient::new(&env, &contract_id).initialize(
+            &admin,
+            &admins,
+            &1,
+            &token_id.address(),
+        );
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+
+        assert!(client.get_loan(&borrower).unwrap().repaid);
+        assert_eq!(token.balance(&voucher), 10_010_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid payment amount")]
+    fn test_repay_zero_amount_panics() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &0);
+    }
+
+    // ── Stake Management Tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_increase_stake_updates_existing_vouch() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.increase_stake(&voucher, &borrower, &500_000);
+
+        let vouches = client.get_vouches(&borrower).unwrap();
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().stake, 1_500_000);
+        assert_eq!(token.balance(&voucher), 8_500_000);
+
+        client.request_loan(&borrower, &750_000, &1_500_000);
+        assert_eq!(client.get_loan(&borrower).unwrap().amount, 750_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "vouch not found")]
+    fn test_increase_stake_without_existing_vouch_panics() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.increase_stake(&voucher, &borrower, &500_000);
+    }
+
+    #[test]
+    fn test_decrease_stake_updates_existing_vouch_and_returns_tokens() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.decrease_stake(&voucher, &borrower, &400_000);
+
+        let vouches = client.get_vouches(&borrower).unwrap();
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().stake, 600_000);
+        assert_eq!(token.balance(&voucher), 9_400_000);
+        assert_eq!(client.total_vouched(&borrower), 600_000);
+    }
+
+    #[test]
+    fn test_decrease_stake_to_zero_removes_vouch() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.decrease_stake(&voucher, &borrower, &1_000_000);
+
+        assert!(client.get_vouches(&borrower).is_none());
+        assert_eq!(client.total_vouched(&borrower), 0);
+        assert_eq!(token.balance(&voucher), 10_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan already active")]
+    fn test_decrease_stake_rejects_active_loan() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        client.decrease_stake(&voucher, &borrower, &100_000);
+    }
+
+    // ── Loan Request Tests ────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "loan amount must meet minimum threshold")]
+    fn test_zero_amount_loan_should_fail() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &0, &1_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "borrower already has an active loan")]
+    fn test_request_loan_rejects_overwrite_of_active_loan() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+    }
+
+    #[test]
+    fn test_request_loan_underfunded_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+        let admins = single_admin_signers(&env, &admin);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_admin = StellarAssetClient::new(&env, &token_id.address());
+        token_admin.mint(&voucher, &10_000_000);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        QuorumCreditContractClient::new(&env, &contract_id).initialize(
+            &admin, &admins, &1, &token_id.address(),
+        );
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &1_500_000, &1_000_000);
+        client.repay(&borrower, &1_500_000);
+
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &2_000_000, &1_000_000);
+        assert!(result.is_err());
+
+        advance_past_vouch_age(&env);
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &1_500_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
+    }
+
+    #[test]
+    fn test_over_collateralization_check() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        // 150% of 1_000_000 = 1_500_000 max
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &1_500_000, &1_000_000);
+        client.repay(&borrower, &1_500_000);
+
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &2_000_000, &1_000_000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "maximum vouchers per loan exceeded")]
+    fn test_vouch_exceeds_max_limit() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let (contract_id, token_addr, _admin, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        for _ in 0..DEFAULT_MAX_VOUCHERS {
+            let v = Address::generate(&env);
+            token_admin.mint(&v, &10_000_000);
+            client.vouch(&v, &borrower, &1_000_000);
+        }
+
+        let extra = Address::generate(&env);
+        token_admin.mint(&extra, &10_000_000);
+        client.vouch(&extra, &borrower, &1_000_000);
+    }
+
+    #[test]
+    fn test_repay_with_max_vouchers() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let (contract_id, token_addr, _admin, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        for _ in 0..DEFAULT_MAX_VOUCHERS {
+            let v = Address::generate(&env);
+            token_admin.mint(&v, &10_000_000);
+            client.vouch(&v, &borrower, &1_000_000);
+        }
+
+        advance_past_vouch_age(&env);
+        client.request_loan(
+            &borrower,
+            &500_000,
+            &(DEFAULT_MAX_VOUCHERS as i128 * 1_000_000),
+        );
+        client.repay(&borrower, &500_000);
+
+        assert!(client.get_loan(&borrower).unwrap().repaid);
+    }
+
+    #[test]
+    fn test_max_vouchers_configurable_via_set_config() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        // Lower the cap to 2
+        let mut cfg = client.get_config();
+        cfg.max_vouchers = 2;
+        client.set_config(&admin_signers, &cfg);
+        assert_eq!(client.get_config().max_vouchers, 2);
+
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.vouch(&voucher2, &borrower, &1_000_000);
+
+        // Third vouch must be rejected
+        let voucher3 = Address::generate(&env);
+        token_admin.mint(&voucher3, &10_000_000);
+        let result = client.try_vouch(&voucher3, &borrower, &1_000_000);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_slash_with_max_vouchers() {
+        let env = Env::default();
+        env.budget().reset_unlimited();
+        let (contract_id, token_addr, admin, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut vouchers = soroban_sdk::Vec::new(&env);
+        for _ in 0..DEFAULT_MAX_VOUCHERS {
+            let v = Address::generate(&env);
+            token_admin.mint(&v, &10_000_000);
+            client.vouch(&v, &borrower, &1_000_000);
+            vouchers.push_back(v);
+        }
+
+        client.request_loan(
+            &borrower,
+            &Vec::new(&env),
+            &500_000,
+            &(DEFAULT_MAX_VOUCHERS as i128 * 1_000_000),
+        );
+        client.slash(&admin_signers, &borrower);
+
+        assert!(client.get_loan(&borrower).unwrap().defaulted);
+        // Each voucher had 1_000_000 staked, 50% slashed → 500_000 returned
+        for v in vouchers.iter() {
+            assert_eq!(TokenClient::new(&env, &token_addr).balance(&v), 9_500_000);
+        }
+    }
+
+    // ── View Tests ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_vouches_unknown_borrower_returns_none() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert!(client.get_vouches(&borrower).is_none());
+    }
+
+    #[test]
+    fn test_total_vouched_returns_sum_of_all_stakes() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        assert_eq!(client.total_vouched(&borrower), 0);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(client.total_vouched(&borrower), 1_000_000);
+
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+        client.vouch(&voucher2, &borrower, &2_500_000);
+        assert_eq!(client.total_vouched(&borrower), 3_500_000);
+    }
+
+    #[test]
+    fn test_get_contract_balance() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        assert_eq!(client.get_contract_balance(), 50_000_000);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(client.get_contract_balance(), 51_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(client.get_slash_treasury(), 500_000);
+
+        let treasury_recipient = Address::generate(&env);
+        client.slash_treasury(&admin_signers, &treasury_recipient);
+
+        assert_eq!(token.balance(&treasury_recipient), 500_000);
+        assert_eq!(client.get_slash_treasury(), 0);
+        assert_eq!(client.get_contract_balance(), 50_500_000);
+    }
+
+    /// Issue #140 — Verify contract XLM balance at each step of a full
+    /// vouch → loan → repay cycle.
+    ///
+    /// Accounting (all values in stroops):
+    ///   setup pre-funds contract with 50_000_000
+    ///   vouch(1_000_000)      → contract += 1_000_000  = 51_000_000
+    ///   request_loan(500_000) → contract -= 500_000    = 50_500_000
+    ///   repay(500_000)        → contract += 500_000 (repayment)
+    ///                                    -= 1_020_000 (stake + 2% yield)
+    ///                                                 = 49_980_000
+    #[test]
+    fn test_contract_balance_after_full_repayment_cycle() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // Initial state: contract pre-funded by setup
+        assert_eq!(client.get_contract_balance(), 50_000_000);
+
+        // Step 1: vouch — stake transferred into contract
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(client.get_contract_balance(), 51_000_000);
+
+        // Step 2: request_loan — loan amount disbursed to borrower
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.get_contract_balance(), 50_500_000);
+
+        // Step 3: repay — borrower repays; voucher receives stake + 2% yield
+        // yield = 1_000_000 * 200 / 10_000 = 20_000
+        // payout to voucher = 1_020_000
+        // net contract change = +500_000 (repayment) - 1_020_000 (payout) = -520_000
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.get_contract_balance(), 49_980_000);
+    }
+
+    /// Issue #143 — request_loan fails gracefully when the contract has no XLM.
+    ///
+    /// The contract checks its own balance before disbursing and returns
+    /// `InsufficientFunds` rather than panicking or leaving state inconsistent.
+    #[test]
+    fn test_request_loan_fails_when_contract_has_zero_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+        let admins = single_admin_signers(&env, &admin);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_admin = StellarAssetClient::new(&env, &token_id.address());
+        // Mint to voucher only — contract intentionally left with zero balance
+        token_admin.mint(&voucher, &10_000_000);
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&admin, &admins, &1, &token_id.address());
+        client.whitelist_voucher(&admins, &voucher);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
+    }
+
+
+    ///
+    /// Decision: the contract rejects the vouch with `ActiveLoanExists`.
+    /// Vouching after disbursement would allow post-hoc trust inflation and
+    /// is not permitted; the trust circle must be established before the loan.
+    #[test]
+    fn test_vouch_rejected_when_loan_already_active() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        // A second voucher attempts to vouch after the loan is active
+        let late_voucher = Address::generate(&env);
+        token_admin.mint(&late_voucher, &1_000_000);
+        client.whitelist_voucher(&single_admin_signers(&env, &_admin), &late_voucher);
+
+        let result = client.try_vouch(&late_voucher, &borrower, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::ActiveLoanExists)));
+    }
+
+
+    /// vouch → loan → slash cycle.
+    ///
+    /// Accounting (all values in stroops):
+    ///   setup pre-funds contract with 50_000_000
+    ///   vouch(1_000_000)      → contract += 1_000_000  = 51_000_000
+    ///   request_loan(500_000) → contract -= 500_000    = 50_500_000
+    ///   slash                 → 50% of stake (500_000) to slash treasury (stays in contract)
+    ///                           50% of stake (500_000) returned to voucher (leaves contract)
+    ///                                                  = 50_000_000
+    ///   slashed funds (500_000) remain inside contract as slash treasury
+    #[test]
+    fn test_contract_balance_after_slash_cycle() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        // Initial state
+        assert_eq!(client.get_contract_balance(), 50_000_000);
+
+        // Step 1: vouch — stake transferred into contract
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(client.get_contract_balance(), 51_000_000);
+
+        // Step 2: request_loan — loan disbursed to borrower
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.get_contract_balance(), 50_500_000);
+
+        // Step 3: slash — 50% of stake slashed to treasury, 50% returned to voucher
+        // slash_amount = 1_000_000 * 5_000 / 10_000 = 500_000 (stays in contract)
+        // returned     = 1_000_000 - 500_000 = 500_000 (leaves contract)
+        client.slash(&admin_signers, &borrower);
+        assert_eq!(client.get_contract_balance(), 50_000_000);
+
+        // Slashed funds are held in the slash treasury, still inside the contract
+        assert_eq!(client.get_slash_treasury_balance(), 500_000);
+    }
+
+    #[test]
+    fn test_vouch_exists() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        assert!(!client.vouch_exists(&voucher, &borrower));
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert!(client.vouch_exists(&voucher, &borrower));
+    }
+
+    #[test]
+    fn test_voucher_history_tracks_multiple_borrowers() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, _borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        let borrower_a = Address::generate(&env);
+        let borrower_b = Address::generate(&env);
+        let borrower_c = Address::generate(&env);
+        token_admin.mint(&voucher, &10_000_000);
+
+        client.vouch(&voucher, &borrower_a, &1_000_000);
+        client.vouch(&voucher, &borrower_b, &1_000_000);
+        client.vouch(&voucher, &borrower_c, &1_000_000);
+
+        let history = client.voucher_history(&voucher);
+        assert_eq!(history.len(), 3);
+        assert_eq!(history.get(0).unwrap(), borrower_a);
+        assert_eq!(history.get(1).unwrap(), borrower_b);
+        assert_eq!(history.get(2).unwrap(), borrower_c);
+    }
+
+    #[test]
+    fn test_voucher_history_unknown_voucher_returns_empty() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let unknown = Address::generate(&env);
+        assert_eq!(client.voucher_history(&unknown).len(), 0);
+    }
+
+    // ── Loan Status Tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_loan_status_none() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::None);
+    }
+
+    #[test]
+    fn test_loan_status_active() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::Active);
+    }
+
+    #[test]
+    fn test_loan_status_repaid() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::Repaid);
+    }
+
+    #[test]
+    fn test_loan_status_defaulted() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::Defaulted);
+    }
+
+    // ── Slash Treasury Tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_slash_treasury_withdrawal() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(client.get_slash_treasury(), 500_000);
+
+        let treasury_recipient = Address::generate(&env);
+        client.slash_treasury(&admin_signers, &treasury_recipient);
+
+        assert_eq!(token.balance(&treasury_recipient), 500_000);
+        assert_eq!(client.get_slash_treasury(), 0);
+    }
+
+    // ── Pause / Unpause Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_pause_blocks_vouch() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.pause(&admin_signers);
+        assert!(client.get_paused());
+
+        let result = client.try_vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_request_loan() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.pause(&admin_signers);
+
+        let result = client.try_request_loan(&borrower, &500_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_increase_stake() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.pause(&admin_signers);
+
+        let result = client.try_increase_stake(&voucher, &borrower, &500_000);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_decrease_stake() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        let admin_signers = single_admin_signers(&env, &_admin);
+        client.pause(&admin_signers);
+
+        let result = client.try_decrease_stake(&voucher, &borrower, &500_000);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_repay() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.pause(&admin_signers);
+
+        let result = client.try_repay(&borrower, &500_000);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_pause_blocks_slash() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.pause(&admin_signers);
+
+        let result = client.try_slash(&admin_signers, &borrower);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unpause_restores_operations() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.pause(&admin_signers);
+        assert!(client.get_paused());
+        client.unpause(&admin_signers);
+        assert!(!client.get_paused());
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert_eq!(client.get_vouches(&borrower).unwrap().len(), 1);
+    }
+
+    // ── Loan Deadline / Auto-Slash Tests ──────────────────────────────────────
+
+    #[test]
+    fn test_deadline_set_from_loan_duration() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.deadline, disbursement_ts + 1_000);
+    }
+
+    #[test]
+    fn test_auto_slash_after_deadline() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        env.ledger().set_timestamp(1_002_000);
+        client.auto_slash(&borrower);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert!(loan.defaulted);
+        assert_eq!(token.balance(&voucher), 9_500_000);
+        assert_eq!(client.get_slash_treasury(), 500_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan deadline has not passed")]
+    fn test_auto_slash_before_deadline_panics() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        client.auto_slash(&borrower);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan deadline has passed")]
+    fn test_repay_after_deadline_panics() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        env.ledger().set_timestamp(1_002_000);
+        client.repay(&borrower, &500_000);
+    }
+
+    #[test]
+    fn test_default_loan_duration_is_30_days() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert_eq!(client.get_config().loan_duration, DEFAULT_LOAN_DURATION);
+    }
+
+    #[test]
+    fn test_loan_records_disbursement_timestamp() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        let disbursement_ts = env.ledger().timestamp();
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.disbursement_timestamp, disbursement_ts);
+        assert_eq!(loan.created_at, disbursement_ts);
+        assert!(loan.deadline > disbursement_ts);
+    }
+
+    // ── is_eligible Tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_eligible_returns_true_when_stake_meets_threshold() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert!(client.is_eligible(&borrower, &1_000_000));
+    }
+
+    #[test]
+    fn test_is_eligible_returns_false_when_stake_below_threshold() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &500_000);
+        assert!(!client.is_eligible(&borrower, &1_000_000));
+    }
+
+    #[test]
+    fn test_is_eligible_returns_false_for_zero_threshold() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        assert!(!client.is_eligible(&borrower, &0));
+    }
+
+    #[test]
+    fn test_is_eligible_returns_false_when_loan_already_active() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        assert!(!client.is_eligible(&borrower, &1_000_000));
+    }
+
+    #[test]
+    fn test_is_eligible_returns_true_after_loan_repaid_with_fresh_vouch() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        client.vouch(&voucher, &borrower, &1_000_000);
+
+        assert!(client.is_eligible(&borrower, &1_000_000));
+    }
+
+    #[test]
+    fn test_is_eligible_returns_false_with_no_vouches() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert!(!client.is_eligible(&borrower, &1_000_000));
+    }
+
+    #[test]
+    fn test_is_eligible_aggregates_multiple_vouchers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &600_000);
+        client.vouch(&voucher2, &borrower, &600_000);
+
+        assert!(client.is_eligible(&borrower, &1_000_000));
+        assert!(client.is_eligible(&borrower, &1_200_000));
+        assert!(!client.is_eligible(&borrower, &1_200_001));
+    }
+
+    // ── Min Stake Tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_min_stake_defaults_to_zero() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        assert_eq!(QuorumCreditContractClient::new(&env, &contract_id).get_min_stake(), 0);
+    }
+
+    #[test]
+    fn test_set_min_stake_and_get() {
+        let env = Env::default();
+        let (contract_id, _, admin, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_min_stake(&admin_signers, &500_000);
+        assert_eq!(client.get_min_stake(), 500_000);
+    }
+
+    #[test]
+    fn test_vouch_below_min_stake_rejected() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_min_stake(&admin_signers, &500_000);
+        let result = client.try_vouch(&voucher, &borrower, &100_000);
+        assert_eq!(result, Err(Ok(ContractError::MinStakeNotMet)));
+    }
+
+    #[test]
+    fn test_vouch_at_min_stake_succeeds() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_min_stake(&admin_signers, &500_000);
+        client.vouch(&voucher, &borrower, &500_000);
+        assert_eq!(client.get_vouches(&borrower).unwrap().len(), 1);
+    }
+
+    // ── Batch Vouch Tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_batch_vouch_vouches_multiple_borrowers() {
+        let env = Env::default();
+        let (contract_id, token_addr, _admin, _borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+
+        let borrower_a = Address::generate(&env);
+        let borrower_b = Address::generate(&env);
+        let borrower_c = Address::generate(&env);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(borrower_a.clone());
+        borrowers.push_back(borrower_b.clone());
+        borrowers.push_back(borrower_c.clone());
+
+        let mut stakes = Vec::new(&env);
+        stakes.push_back(1_000_000i128);
+        stakes.push_back(500_000i128);
+        stakes.push_back(200_000i128);
+
+        client.batch_vouch(&voucher, &borrowers, &stakes);
+
+        assert_eq!(client.get_vouches(&borrower_a).unwrap().get(0).unwrap().stake, 1_000_000);
+        assert_eq!(client.get_vouches(&borrower_b).unwrap().get(0).unwrap().stake, 500_000);
+        assert_eq!(client.get_vouches(&borrower_c).unwrap().get(0).unwrap().stake, 200_000);
+        // 10_000_000 - 1_000_000 - 500_000 - 200_000 = 8_300_000
+        assert_eq!(token.balance(&voucher), 8_300_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "borrowers and stakes length mismatch")]
+    fn test_batch_vouch_length_mismatch_rejected() {
+        let env = Env::default();
+        let (contract_id, _, _, _, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(Address::generate(&env));
+        let stakes: Vec<i128> = Vec::new(&env);
+
+        client.batch_vouch(&voucher, &borrowers, &stakes);
+    }
+
+    #[test]
+    #[should_panic(expected = "batch cannot be empty")]
+    fn test_batch_vouch_empty_rejected() {
+        let env = Env::default();
+        let (contract_id, _, _, _, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.batch_vouch(&voucher, &Vec::new(&env), &Vec::new(&env));
+    }
+
+    #[test]
+    fn test_batch_vouch_duplicate_aborts_batch() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // Pre-vouch so the second batch entry is a duplicate.
+        client.vouch(&voucher, &borrower, &1_000_000);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(Address::generate(&env));
+        borrowers.push_back(borrower.clone());
+
+        let mut stakes = Vec::new(&env);
+        stakes.push_back(1_000_000i128);
+        stakes.push_back(500_000i128);
+
+        let result = client.try_batch_vouch(&voucher, &borrowers, &stakes);
+        assert_eq!(result, Err(Ok(ContractError::DuplicateVouch)));
+    }
+
+    // ── Max Loan Amount Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_max_loan_amount_defaults_to_zero() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        assert_eq!(QuorumCreditContractClient::new(&env, &contract_id).get_max_loan_amount(), 0);
+    }
+
+    #[test]
+    fn test_set_max_loan_amount_and_get() {
+        let env = Env::default();
+        let (contract_id, _, admin, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_max_loan_amount(&admin_signers, &5_000_000);
+        assert_eq!(client.get_max_loan_amount(), 5_000_000);
+    }
+
+    #[test]
+    fn test_loan_exceeds_max_amount_rejected() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_max_loan_amount(&admin_signers, &500_000);
+        client.vouch(&voucher, &borrower, &5_000_000);
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &600_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::LoanExceedsMaxAmount)));
+    }
+
+    #[test]
+    fn test_loan_at_max_amount_succeeds() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_max_loan_amount(&admin_signers, &500_000);
+        client.vouch(&voucher, &borrower, &5_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.get_loan(&borrower).unwrap().amount, 500_000);
+    }
+
+    // ── Min Vouchers Tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_min_vouchers_defaults_to_zero() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        assert_eq!(QuorumCreditContractClient::new(&env, &contract_id).get_min_vouchers(), 0);
+    }
+
+    #[test]
+    fn test_set_min_vouchers_and_get() {
+        let env = Env::default();
+        let (contract_id, _, admin, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_min_vouchers(&admin_signers, &3);
+        assert_eq!(client.get_min_vouchers(), 3);
+    }
+
+    #[test]
+    fn test_loan_rejected_when_voucher_count_below_minimum() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.set_min_vouchers(&admin_signers, &3);
+        client.vouch(&voucher, &borrower, &5_000_000);
+
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientVouchers)));
+
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+        client.vouch(&voucher2, &borrower, &1_000_000);
+        let result = client.try_request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientVouchers)));
+    }
+
+    #[test]
+    fn test_loan_succeeds_when_voucher_count_meets_minimum() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.set_min_vouchers(&admin_signers, &2);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+        client.vouch(&voucher2, &borrower, &1_000_000);
+
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.get_loan(&borrower).unwrap().amount, 500_000);
+    }
+
+    // ── Config Tests ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_config_returns_defaults() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let cfg = client.get_config();
+
+        assert_eq!(cfg.yield_bps, DEFAULT_YIELD_BPS);
+        assert_eq!(cfg.slash_bps, DEFAULT_SLASH_BPS);
+        assert_eq!(cfg.max_vouchers, DEFAULT_MAX_VOUCHERS);
+        assert_eq!(cfg.min_loan_amount, DEFAULT_MIN_LOAN_AMOUNT);
+        assert_eq!(cfg.loan_duration, DEFAULT_LOAN_DURATION);
+        assert_eq!(cfg.max_loan_to_stake_ratio, DEFAULT_MAX_LOAN_TO_STAKE_RATIO);
+        assert_eq!(cfg.vouch_cooldown_secs, DEFAULT_VOUCH_COOLDOWN_SECS);
+    }
+
+    #[test]
+    fn test_set_config_updates_params() {
+        let env = Env::default();
+        let (contract_id, _, admin, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.yield_bps = 300;
+        cfg.slash_bps = 6000;
+        cfg.loan_duration = 60 * 60 * 24 * 7;
+        client.set_config(&admin_signers, &cfg);
+
+        let updated = client.get_config();
+        assert_eq!(updated.yield_bps, 300);
+        assert_eq!(updated.slash_bps, 6000);
+        assert_eq!(updated.loan_duration, 60 * 60 * 24 * 7);
+    }
+
+    #[test]
+    fn test_config_yield_bps_applied_on_repay() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.yield_bps = 500;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        assert_eq!(token.balance(&voucher), 10_025_000);
+    }
+
+    #[test]
+    fn test_config_slash_bps_applied_on_slash() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.slash_bps = 2500;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(token.balance(&voucher), 9_750_000);
+        assert_eq!(client.get_slash_treasury(), 250_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "slash_bps must be 1-10000")]
+    fn test_set_config_slash_bps_above_10000_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.slash_bps = 10_001;
+        client.set_config(&admin_signers, &cfg);
+    }
+
+    #[test]
+    fn test_set_config_slash_bps_at_boundary_10000_accepted() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.slash_bps = 10_000;
+        client.set_config(&admin_signers, &cfg);
+
+        assert_eq!(client.get_config().slash_bps, 10_000);
+    }
+
+
+    // ── Grace period tests ────────────────────────────────────────────────────
+
+    /// Helper: set a short loan_duration + grace_period, vouch, and request a loan.
+    fn setup_grace_period_loan(
+        env: &Env,
+        loan_duration: u64,
+        grace_period: u64,
+    ) -> (Address, Address, Address, Address) {
+        let (contract_id, token_addr, _admin, borrower, voucher) = setup(env);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = loan_duration;
+        cfg.grace_period = grace_period;
+        client.set_config(&cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+
+        (contract_id, token_addr, borrower, voucher)
+    }
+
+    #[test]
+    #[should_panic(expected = "loan grace period has not passed")]
+    fn test_auto_slash_blocked_during_grace_period() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, borrower, _voucher) =
+            setup_grace_period_loan(&env, 1_000, 500);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // deadline = 1_001_000; slash_threshold = 1_001_500
+        // advance to 1_001_200 — past deadline but still inside grace period
+        env.ledger().set_timestamp(1_001_200);
+        client.auto_slash(&borrower);
+    }
+
+    #[test]
+    fn test_auto_slash_allowed_after_grace_period() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, borrower, voucher) =
+            setup_grace_period_loan(&env, 1_000, 500);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = soroban_sdk::token::Client::new(&env, &token_addr);
+
+        // deadline = 1_001_000; slash_threshold = 1_001_500
+        // advance to 1_001_501 — one second past the grace period
+        env.ledger().set_timestamp(1_001_501);
+        client.auto_slash(&borrower);
+
+        assert!(client.get_loan(&borrower).unwrap().defaulted);
+        assert_eq!(token.balance(&voucher), 9_500_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan grace period has not passed")]
+    fn test_auto_slash_blocked_exactly_at_slash_threshold() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, borrower, _voucher) =
+            setup_grace_period_loan(&env, 1_000, 500);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // deadline = 1_001_000; slash_threshold = 1_001_500
+        // timestamp == slash_threshold: condition is `>`, so this must be rejected
+        env.ledger().set_timestamp(1_001_500);
+        client.auto_slash(&borrower);
+    }
+
+    #[test]
+    fn test_auto_slash_allowed_one_second_past_threshold() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, borrower, _voucher) =
+            setup_grace_period_loan(&env, 1_000, 500);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // deadline = 1_001_000; slash_threshold = 1_001_500
+        env.ledger().set_timestamp(1_001_501);
+        client.auto_slash(&borrower);
+
+        assert!(client.get_loan(&borrower).unwrap().defaulted);
+    }
+
+    #[test]
+    fn test_auto_slash_zero_grace_period_behaves_like_original() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, borrower, voucher) =
+            setup_grace_period_loan(&env, 1_000, 0);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::Active);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan already repaid")]
+    fn test_auto_slash_blocked_on_repaid_loan() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _token_addr, borrower, _voucher) =
+            setup_grace_period_loan(&env, 1_000, 500);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // Repay before deadline.
+        client.repay(&borrower);
+
+        // Attempt auto_slash after grace period — must be rejected.
+        env.ledger().set_timestamp(1_002_000);
+        client.auto_slash(&borrower);
+    }
+
+    #[test]
+    fn test_default_grace_period_is_three_days() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+        assert_eq!(client.loan_status(&borrower), LoanStatus::Defaulted);
+    }
+
+    #[test]
+    fn test_multiple_loans_for_borrower_keep_distinct_loan_ids() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        let first_loan = client.get_loan(&borrower).unwrap();
+        client.repay(&borrower, &500_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &400_000, &1_000_000);
+        let second_loan = client.get_loan(&borrower).unwrap();
+
+        assert_ne!(first_loan.id, second_loan.id);
+        assert!(client.get_loan_by_id(&first_loan.id).unwrap().repaid);
+        assert_eq!(
+            client.get_loan_by_id(&first_loan.id).unwrap().amount,
+            500_000
+        );
+        assert_eq!(
+            client.get_loan_by_id(&second_loan.id).unwrap().amount,
+            400_000
+        );
+        assert_eq!(client.get_loan(&borrower).unwrap().id, second_loan.id);
+    }
+
+    #[test]
+    fn test_is_initialized() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let mut cfg = client.get_config();
+        cfg.grace_period = 7 * 24 * 60 * 60; // 7 days
+        client.set_config(&cfg);
+
+        assert_eq!(client.get_config().grace_period, 7 * 24 * 60 * 60);
+
+    // ── Protocol Fee Tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_protocol_fee() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        assert_eq!(client.get_protocol_fee(), 0);
+        client.set_protocol_fee(&admin_signers, &200);
+        assert_eq!(client.get_protocol_fee(), 200);
+    }
+
+    #[test]
+    #[should_panic(expected = "fee_bps must not exceed 10000")]
+    fn test_set_protocol_fee_exceeds_max() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.set_protocol_fee(&admin_signers, &10_001);
+    }
+
+    #[test]
+    fn test_protocol_fee_deducted_on_repayment_and_sent_to_treasury() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let treasury = Address::generate(&env);
+        // 100 bps = 1% fee
+        client.set_protocol_fee(&admin_signers, &100);
+        client.set_fee_treasury(&admin_signers, &treasury);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        // loan = 500_000; fee = 500_000 * 100 / 10_000 = 5_000
+        // distributable = 495_000; yield = 495_000 * 200 / 10_000 = 9_900
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        // treasury receives the protocol fee
+        assert_eq!(token.balance(&treasury), 5_000);
+        // voucher gets stake back + yield on distributable amount
+        // 1_000_000 + 9_900 = 1_009_900; started with 10_000_000 - 1_000_000 = 9_000_000
+        assert_eq!(token.balance(&voucher), 10_009_900);
+    }
+
+    #[test]
+    fn test_protocol_fee_zero_no_treasury_transfer() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let treasury = Address::generate(&env);
+        // fee stays at 0 (default), treasury set but should receive nothing
+        client.set_fee_treasury(&admin_signers, &treasury);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        assert_eq!(token.balance(&treasury), 0);
+        // yield unchanged from no-fee case: 500_000 * 200 / 10_000 = 10_000
+        assert_eq!(token.balance(&voucher), 10_010_000);
+    }
+
+    #[test]
+    fn test_set_and_get_fee_treasury() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        assert!(client.get_fee_treasury().is_none());
+        let treasury = Address::generate(&env);
+        client.set_fee_treasury(&admin_signers, &treasury);
+        assert_eq!(client.get_fee_treasury().unwrap(), treasury);
+    }
+
+    // ── Admin Tests ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_admin_returns_admin_address() {
+        let env = Env::default();
+        let (contract_id, _, admin, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let admins = client.get_admins();
+        assert_eq!(admins.len(), 1);
+        assert_eq!(admins.get(0).unwrap(), admin);
+        assert_eq!(client.get_admin_threshold(), 1);
+    }
+
+    #[test]
+    fn test_multisig_threshold_allows_admin_operation() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin_one, admin_two, _admin_three, _borrower, _voucher) =
+            setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one.clone(), admin_two.clone()]);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        client.pause(&signers);
+
+        assert!(client.get_paused());
+        assert_eq!(client.get_admin_threshold(), 2);
+    }
+
+    // ── Repayment Count Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_repayment_count_tracks_successful_repayments() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        assert_eq!(client.repayment_count(&borrower), 0);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.repayment_count(&borrower), 1);
+
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.repayment_count(&borrower), 2);
+
+        let borrower2 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        assert_eq!(client.repayment_count(&borrower2), 0);
+        client.vouch(&voucher2, &borrower2, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower2, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower2);
+        assert_eq!(client.repayment_count(&borrower2), 0);
+    }
+
+    // ── Loan Count Tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_loan_count_zero_for_new_borrower() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert_eq!(client.loan_count(&borrower), 0);
+    }
+
+    #[test]
+    fn test_loan_count_increments_on_each_disbursement() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.loan_count(&borrower), 1);
+
+        client.repay(&borrower, &500_000);
+
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.loan_count(&borrower), 2);
+
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.loan_count(&borrower), 2); // repay doesn't change loan_count
+    }
+
+    #[test]
+    fn test_loan_count_includes_defaulted_loans() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.loan_count(&borrower), 1);
+
+        client.slash(&admin_signers, &borrower);
+        assert_eq!(client.loan_count(&borrower), 1); // slash doesn't change loan_count
+    }
+
+    #[test]
+    fn test_loan_count_is_per_borrower() {
+        let env = Env::default();
+        let (contract_id, token_addr, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+
+        let borrower2 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.vouch(&voucher2, &borrower2, &1_000_000);
+
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.loan_count(&borrower), 1);
+        assert_eq!(client.loan_count(&borrower2), 0);
+    }
+
+    // ── Default Count Tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_count_zero_for_new_borrower() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert_eq!(client.default_count(&borrower), 0);
+    }
+
+    #[test]
+    fn test_default_count_increments_on_slash() {
+        let env = Env::default();
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        assert_eq!(client.default_count(&borrower), 0);
+
+        client.slash(&admin_signers, &borrower);
+        assert_eq!(client.default_count(&borrower), 1);
+    }
+
+    #[test]
+    fn test_default_count_increments_on_auto_slash() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        env.ledger().set_timestamp(1_002_000);
+        client.auto_slash(&borrower);
+        assert_eq!(client.default_count(&borrower), 1);
+    }
+
+    #[test]
+    fn test_default_count_increments_on_claim_expired_loan() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, _, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.loan_duration = 1_000;
+        client.set_config(&admin_signers, &cfg);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+
+        env.ledger().set_timestamp(1_002_000);
+        client.claim_expired_loan(&borrower);
+        assert_eq!(client.default_count(&borrower), 1);
+    }
+
+    #[test]
+    fn test_default_count_not_incremented_on_repay() {
+        let env = Env::default();
+        let (contract_id, _, _, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.default_count(&borrower), 0);
+    }
+
+    #[test]
+    fn test_default_count_is_per_borrower() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let borrower2 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.vouch(&voucher2, &borrower2, &1_000_000);
+
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        assert_eq!(client.default_count(&borrower), 1);
+        assert_eq!(client.default_count(&borrower2), 0);
+    }
+
+    // ── Reputation NFT Tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_repay_mints_reputation() {
+        let env = Env::default();
+        let (contract_id, _token, _admin, borrower, voucher, nft_id) = setup_with_reputation(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let nft = reputation::ReputationNftContractClient::new(&env, &nft_id);
+
+        assert_eq!(client.get_reputation(&borrower), 0);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+
+        assert_eq!(client.get_reputation(&borrower), 1);
+        assert_eq!(nft.balance(&borrower), 1);
+    }
+
+    #[test]
+    fn test_slash_burns_reputation() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher, nft_id) =
+            setup_with_reputation(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let nft = reputation::ReputationNftContractClient::new(&env, &nft_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.repayment_count(&borrower), 1);
+
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(nft.balance(&borrower), 1);
+
+        let borrower2 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &2_000_000);
+
+        nft.mint(&borrower2);
+        assert_eq!(nft.balance(&borrower2), 1);
+
+        client.vouch(&voucher2, &borrower2, &1_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower2, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower2);
+
+        assert_eq!(client.get_reputation(&borrower2), 0);
+        assert_eq!(nft.balance(&borrower2), 0);
+    }
+
+    #[test]
+    fn test_slash_burn_floors_at_zero() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher, _nft_id) =
+            setup_with_reputation(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower);
+
+        // voucher started with 10_000_000, staked 1_000_000, gets back 500_000
+        assert_eq!(token.balance(&voucher), 9_500_000);
+    }
+
+    #[test]
+    fn test_get_reputation_without_nft_returns_zero() {
+        let env = Env::default();
+        let (contract_id, _token, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        assert_eq!(client.get_reputation(&borrower), 0);
+    }
+
+    // ── Repayment Count Tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_repayment_count_tracks_successful_repayments() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        assert_eq!(client.repayment_count(&borrower), 0);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.repayment_count(&borrower), 1);
+
+        client.vouch(&voucher, &borrower, &1_000_000);
+        client.request_loan(&borrower, &500_000, &1_000_000);
+        client.repay(&borrower, &500_000);
+        assert_eq!(client.repayment_count(&borrower), 2);
+
+        let borrower2 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher2, &10_000_000);
+
+        assert_eq!(client.repayment_count(&borrower2), 0);
+        client.vouch(&voucher2, &borrower2, &1_000_000);
+        client.request_loan(&borrower2, &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower2);
+        assert_eq!(client.repayment_count(&borrower2), 0);
+    }
+
+    // ── Loan Pool Tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_create_loan_pool_success() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let token = TokenClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let borrower1 = Address::generate(&env);
+        let borrower2 = Address::generate(&env);
+        let voucher1 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+        token_admin.mint(&voucher1, &10_000_000);
+        token_admin.mint(&voucher2, &10_000_000);
+        client.whitelist_voucher(&admin_signers, &voucher1);
+        client.whitelist_voucher(&admin_signers, &voucher2);
+        client.vouch(&voucher1, &borrower1, &2_000_000);
+        client.vouch(&voucher2, &borrower2, &2_000_000);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(borrower1.clone());
+        borrowers.push_back(borrower2.clone());
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(500_000i128);
+        amounts.push_back(300_000i128);
+
+        let pool_id = client.create_loan_pool(&admin_signers, &borrowers, &amounts);
+        assert_eq!(pool_id, 1);
+
+        let pool = client.get_loan_pool(&pool_id).unwrap();
+        assert_eq!(pool.pool_id, 1);
+        assert_eq!(pool.total_disbursed, 800_000);
+        assert_eq!(pool.borrowers.len(), 2);
+
+        assert_eq!(client.get_loan(&borrower1).unwrap().amount, 500_000);
+        assert_eq!(client.get_loan(&borrower2).unwrap().amount, 300_000);
+        assert_eq!(token.balance(&borrower1), 500_000);
+        assert_eq!(token.balance(&borrower2), 300_000);
+    }
+
+    #[test]
+    fn test_create_loan_pool_increments_pool_id() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        assert_eq!(client.get_loan_pool_count(), 0);
+
+        let b1 = Address::generate(&env);
+        let v1 = Address::generate(&env);
+        token_admin.mint(&v1, &10_000_000);
+        client.whitelist_voucher(&admin_signers, &v1);
+        client.vouch(&v1, &b1, &2_000_000);
+        let mut bs1 = Vec::new(&env);
+        bs1.push_back(b1);
+        let mut am1 = Vec::new(&env);
+        am1.push_back(500_000i128);
+        assert_eq!(client.create_loan_pool(&admin_signers, &bs1, &am1), 1);
+
+        let b2 = Address::generate(&env);
+        let v2 = Address::generate(&env);
+        token_admin.mint(&v2, &10_000_000);
+        client.whitelist_voucher(&admin_signers, &v2);
+        client.vouch(&v2, &b2, &2_000_000);
+        let mut bs2 = Vec::new(&env);
+        bs2.push_back(b2);
+        let mut am2 = Vec::new(&env);
+        am2.push_back(500_000i128);
+        assert_eq!(client.create_loan_pool(&admin_signers, &bs2, &am2), 2);
+
+        assert_eq!(client.get_loan_pool_count(), 2);
+    }
+
+    #[test]
+    fn test_create_loan_pool_length_mismatch_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(Address::generate(&env));
+        let amounts: Vec<i128> = Vec::new(&env);
+
+        let result = client.try_create_loan_pool(&admin_signers, &borrowers, &amounts);
+        assert_eq!(result, Err(Ok(ContractError::PoolLengthMismatch)));
+    }
+
+    #[test]
+    fn test_create_loan_pool_empty_rejected() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let borrowers: Vec<Address> = Vec::new(&env);
+        let amounts: Vec<i128> = Vec::new(&env);
+
+        let result = client.try_create_loan_pool(&admin_signers, &borrowers, &amounts);
+        assert_eq!(result, Err(Ok(ContractError::PoolEmpty)));
+    }
+
+    #[test]
+    fn test_create_loan_pool_rejects_active_loan_borrower() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        client.vouch(&voucher, &borrower, &2_000_000);
+        advance_past_vouch_age(&env);
+        client.request_loan(&borrower, &Vec::new(&env), &500_000, &2_000_000);
+
+        let mut borrowers = Vec::new(&env);
+        borrowers.push_back(borrower);
+        let mut amounts = Vec::new(&env);
+        amounts.push_back(500_000i128);
+
+        let result = client.try_create_loan_pool(&admin_signers, &borrowers, &amounts);
+        assert_eq!(result, Err(Ok(ContractError::PoolBorrowerActiveLoan)));
+    }
+
+    #[test]
+    fn test_get_loan_pool_unknown_returns_none() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        assert!(client.get_loan_pool(&999u64).is_none());
+    }
+
+    // ── Upgrade Tests ─────────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_upgrade_rejected_without_admin_approval() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let outsider = Address::generate(&env);
+        let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.upgrade(&single_admin_signers(&env, &outsider), &fake_hash);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_upgrade_multisig_rejects_single_signer() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin_one, _admin_two, _admin_three, _borrower, _voucher) =
+            setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let fake_hash = BytesN::from_array(&env, &[0u8; 32]);
+        client.upgrade(&single_admin_signers(&env, &admin_one), &fake_hash);
+    }
+
+    // ── Rate Limiting: vouch cooldown ─────────────────────────────────────────
+
+    #[test]
+    fn test_vouch_cooldown_blocks_second_vouch_within_window() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.vouch_cooldown_secs = 3_600;
+        client.set_config(&admin_signers, &cfg);
+
+        let voucher = Address::generate(&env);
+        let borrower1 = Address::generate(&env);
+        let borrower2 = Address::generate(&env);
+        token_admin.mint(&voucher, &2_000_000);
+
+        client.vouch(&voucher, &borrower1, &1_000_000);
+
+        let result = client.try_vouch(&voucher, &borrower2, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::VouchCooldownActive)));
+    }
+
+    #[test]
+    fn test_vouch_cooldown_allows_vouch_after_window_expires() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.vouch_cooldown_secs = 3_600;
+        client.set_config(&admin_signers, &cfg);
+
+        let voucher = Address::generate(&env);
+        let borrower1 = Address::generate(&env);
+        let borrower2 = Address::generate(&env);
+        token_admin.mint(&voucher, &2_000_000);
+
+        client.vouch(&voucher, &borrower1, &1_000_000);
+
+        env.ledger().with_mut(|l| l.timestamp += 3_601);
+
+        client.vouch(&voucher, &borrower2, &1_000_000);
+        assert!(client.vouch_exists(&voucher, &borrower2));
+    }
+
+    #[test]
+    fn test_vouch_cooldown_zero_disables_rate_limit() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.vouch_cooldown_secs = 0;
+        client.set_config(&admin_signers, &cfg);
+
+        let voucher = Address::generate(&env);
+        let borrower1 = Address::generate(&env);
+        let borrower2 = Address::generate(&env);
+        token_admin.mint(&voucher, &2_000_000);
+
+        client.vouch(&voucher, &borrower1, &1_000_000);
+        client.vouch(&voucher, &borrower2, &1_000_000);
+        assert!(client.vouch_exists(&voucher, &borrower2));
+    }
+
+    #[test]
+    fn test_vouch_cooldown_is_per_voucher_not_global() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000_000);
+        let (contract_id, token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let mut cfg = client.get_config();
+        cfg.vouch_cooldown_secs = 3_600;
+        client.set_config(&admin_signers, &cfg);
+
+        let voucher_a = Address::generate(&env);
+        let voucher_b = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        token_admin.mint(&voucher_a, &1_000_000);
+        token_admin.mint(&voucher_b, &1_000_000);
+
+        client.vouch(&voucher_a, &borrower, &1_000_000);
+
+        // voucher_b has never vouched — must succeed immediately despite voucher_a's cooldown
+        client.vouch(&voucher_b, &borrower, &1_000_000);
+        assert!(client.vouch_exists(&voucher_b, &borrower));
+    }
+
+    // ── Multisig Admin Security Tests ─────────────────────────────────────────
+
+    // --- require_admin_approval enforcement ---
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_admin_op_fails_with_zero_signers() {
+        let env = Env::default();
+        let (contract_id, _, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        // Provide no signers — must fail threshold check
+        client.pause(&Vec::new(&env));
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_admin_op_fails_below_threshold() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        // Only 1 signer for a 2-of-3 contract
+        let signers = address_vec(&env, &[admin_one]);
+        client.pause(&signers);
+    }
+
+    #[test]
+    #[should_panic(expected = "signer is not a registered admin")]
+    fn test_admin_op_fails_with_non_admin_signer() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, _, _, _) = setup_multisig(&env, 1);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let outsider = Address::generate(&env);
+        // outsider is not in the admin set
+        let signers = address_vec(&env, &[admin_one, outsider]);
+        client.pause(&signers);
+    }
+
+    #[test]
+    fn test_admin_op_succeeds_at_exact_threshold() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        client.pause(&signers);
+        assert!(client.get_paused());
+    }
+
+    #[test]
+    fn test_admin_op_succeeds_above_threshold() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        // 3 signers for a 2-of-3 — all three signing is fine
+        let signers = address_vec(&env, &[admin_one, admin_two, admin_three]);
+        client.pause(&signers);
+        assert!(client.get_paused());
+    }
+
+    // --- add_admin ---
+
+    #[test]
+    fn test_add_admin_increases_admin_count() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+
+        let new_admin = Address::generate(&env);
+        assert_eq!(client.get_admins().len(), 3);
+        client.add_admin(&signers, &new_admin);
+        assert_eq!(client.get_admins().len(), 4);
+        assert!(client.get_admins().iter().any(|a| a == new_admin));
+    }
+
+    #[test]
+    #[should_panic(expected = "address is already an admin")]
+    fn test_add_admin_rejects_duplicate() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        // admin_three is already in the set
+        client.add_admin(&signers, &admin_three);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_add_admin_requires_quorum() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let new_admin = Address::generate(&env);
+        // Only 1 signer for a 2-of-3 contract
+        client.add_admin(&address_vec(&env, &[admin_one]), &new_admin);
+    }
+
+    // --- remove_admin ---
+
+    #[test]
+    fn test_remove_admin_decreases_admin_count() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+
+        assert_eq!(client.get_admins().len(), 3);
+        client.remove_admin(&signers, &admin_three);
+        assert_eq!(client.get_admins().len(), 2);
+        assert!(!client.get_admins().iter().any(|a| a == admin_three));
+    }
+
+    #[test]
+    #[should_panic(expected = "removal would make threshold unsatisfiable")]
+    fn test_remove_admin_blocked_when_threshold_would_be_unsatisfiable() {
+        let env = Env::default();
+        // 3-of-3: removing any admin makes threshold unsatisfiable
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 3);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two, admin_three.clone()]);
+        client.remove_admin(&signers, &admin_three);
+    }
+
+    #[test]
+    #[should_panic(expected = "address is not an admin")]
+    fn test_remove_admin_rejects_unknown_address() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        let outsider = Address::generate(&env);
+        client.remove_admin(&signers, &outsider);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_remove_admin_requires_quorum() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        // Only 1 signer for a 2-of-3 contract
+        client.remove_admin(&address_vec(&env, &[admin_one]), &admin_three);
+    }
+
+    // --- rotate_admin ---
+
+    #[test]
+    fn test_rotate_admin_replaces_key_preserves_count() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+
+        let new_key = Address::generate(&env);
+        client.rotate_admin(&signers, &admin_three, &new_key);
+
+        let admins = client.get_admins();
+        assert_eq!(admins.len(), 3);
+        assert!(!admins.iter().any(|a| a == admin_three));
+        assert!(admins.iter().any(|a| a == new_key));
+        // threshold unchanged
+        assert_eq!(client.get_admin_threshold(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "old and new admin must differ")]
+    fn test_rotate_admin_rejects_same_address() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        client.rotate_admin(&signers, &admin_three, &admin_three);
+    }
+
+    #[test]
+    #[should_panic(expected = "new admin is already in the admin set")]
+    fn test_rotate_admin_rejects_existing_admin_as_new() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one.clone(), admin_two]);
+        // admin_one is already in the set — cannot be the "new" key
+        client.rotate_admin(&signers, &admin_three, &admin_one);
+    }
+
+    #[test]
+    #[should_panic(expected = "old admin not found")]
+    fn test_rotate_admin_rejects_unknown_old_admin() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        let outsider = Address::generate(&env);
+        let new_key = Address::generate(&env);
+        client.rotate_admin(&signers, &outsider, &new_key);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_rotate_admin_requires_quorum() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let new_key = Address::generate(&env);
+        client.rotate_admin(&address_vec(&env, &[admin_one]), &admin_three, &new_key);
+    }
+
+    // --- set_admin_threshold ---
+
+    #[test]
+    fn test_set_admin_threshold_updates_value() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+
+        assert_eq!(client.get_admin_threshold(), 2);
+        client.set_admin_threshold(&signers, &3);
+        assert_eq!(client.get_admin_threshold(), 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold must be greater than zero")]
+    fn test_set_admin_threshold_zero_rejected() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        client.set_admin_threshold(&signers, &0);
+    }
+
+    #[test]
+    #[should_panic(expected = "threshold cannot exceed admin count")]
+    fn test_set_admin_threshold_exceeds_admin_count_rejected() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one, admin_two]);
+        // 3 admins, threshold of 4 is impossible
+        client.set_admin_threshold(&signers, &4);
+    }
+
+    #[test]
+    #[should_panic(expected = "insufficient admin approvals")]
+    fn test_set_admin_threshold_requires_quorum() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, _, _, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.set_admin_threshold(&address_vec(&env, &[admin_one]), &1);
+    }
+
+    // --- end-to-end key rotation scenario ---
+
+    #[test]
+    fn test_key_rotation_new_admin_can_execute_operations() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one.clone(), admin_two.clone()]);
+
+        // Rotate admin_three out for a fresh key
+        let new_key = Address::generate(&env);
+        client.rotate_admin(&signers, &admin_three, &new_key);
+
+        // New key + admin_one should now satisfy the 2-of-3 threshold
+        let new_signers = address_vec(&env, &[admin_one, new_key]);
+        client.pause(&new_signers);
+        assert!(client.get_paused());
+    }
+
+    #[test]
+    fn test_rotated_out_admin_cannot_execute_operations() {
+        let env = Env::default();
+        let (contract_id, _, admin_one, admin_two, admin_three, _, _) = setup_multisig(&env, 2);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let signers = address_vec(&env, &[admin_one.clone(), admin_two.clone()]);
+
+        let new_key = Address::generate(&env);
+        client.rotate_admin(&signers, &admin_three, &new_key);
+
+        // admin_three is no longer in the set — using it should fail
+        let stale_signers = address_vec(&env, &[admin_one, admin_three]);
+        let result = client.try_pause(&stale_signers);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_admin_config_rejects_empty_admins() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let result = QuorumCreditContractClient::new(&env, &contract_id)
+            .try_initialize(&admin, &Vec::new(&env), &1, &token_id.address());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_admin_config_rejects_duplicate_admins() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        // Pass the same address twice
+        let dup_admins = address_vec(&env, &[admin.clone(), admin.clone()]);
+        let result = QuorumCreditContractClient::new(&env, &contract_id)
+            .try_initialize(&admin, &dup_admins, &1, &token_id.address());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_admin_config_rejects_threshold_exceeding_admin_count() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let admins = address_vec(&env, &[admin.clone()]);
+        // threshold 2 with only 1 admin
+        let result = QuorumCreditContractClient::new(&env, &contract_id)
+            .try_initialize(&admin, &admins, &2, &token_id.address());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_stake_overflow_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let v1 = Address::generate(&env);
+        let v2 = Address::generate(&env);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        QuorumCreditContractClient::new(&env, &contract_id)
+            .initialize(&admin, &admin, &token_id.address());
+
+        // Directly write two vouches whose stakes overflow i128 when summed,
+        // bypassing token transfer so we can use values > token balance limits.
+        let big_stake = i128::MAX / 2 + 1;
+        let vouches = soroban_sdk::vec![
+            &env,
+            VouchRecord { voucher: v1, stake: big_stake },
+            VouchRecord { voucher: v2, stake: big_stake },
+        ];
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        });
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let result = client.try_request_loan(&borrower, &1, &1);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::StakeOverflow)),
+            "expected StakeOverflow on i128 overflow in stake summation"
+        );
+    }
+
+    #[test]
+    fn test_stake_overflow_rejected() {        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let v1 = Address::generate(&env);
+        let v2 = Address::generate(&env);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        QuorumCreditContractClient::new(&env, &contract_id)
+            .initialize(&admin, &admin, &token_id.address());
+
+        // Directly write two vouches whose stakes overflow i128 when summed,
+        // bypassing token transfer so we can use values > token balance limits.
+        let big_stake = i128::MAX / 2 + 1;
+        let vouches = soroban_sdk::vec![
+            &env,
+            VouchRecord { voucher: v1, stake: big_stake },
+            VouchRecord { voucher: v2, stake: big_stake },
+        ];
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        });
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let result = client.try_request_loan(&borrower, &1, &1);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::StakeOverflow)),
+            "expected StakeOverflow on i128 overflow in stake summation"
+        );
+    }
+
+    #[test]
+    fn test_initialize_rejects_zero_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(deployer.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // All-zeros account strkey
+        let zero_admin = Address::from_string(
+            &soroban_sdk::String::from_str(&env, "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"),
+        );
+
+        let result = QuorumCreditContractClient::new(&env, &contract_id)
+            .try_initialize(&deployer, &zero_admin, &token_id.address());
+
+        assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
+    }
+
+    #[test]
+    fn test_initialize_rejects_zero_token() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // All-zeros contract strkey
+        let zero_token = Address::from_string(
+            &soroban_sdk::String::from_str(&env, "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4"),
+        );
+
+        let result = QuorumCreditContractClient::new(&env, &contract_id)
+            .try_initialize(&deployer, &admin, &zero_token);
+
+        assert_eq!(result, Err(Ok(ContractError::ZeroAddress)));
+    }
+
+    #[test]
+    fn test_transfer_vouch_success() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, from) = setup(&env);
+        let to = Address::generate(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&from, &borrower, &1_000_000);
+
+        assert!(client.vouch_exists(&from, &borrower));
+        assert!(!client.vouch_exists(&to, &borrower));
+        assert!(client.voucher_history(&from).contains(borrower.clone()));
+        assert!(!client.voucher_history(&to).contains(borrower.clone()));
+
+        client.transfer_vouch(&from, &to, &borrower);
+
+        assert!(!client.vouch_exists(&from, &borrower));
+        assert!(client.vouch_exists(&to, &borrower));
+        assert!(!client.voucher_history(&from).contains(borrower.clone()));
+        assert!(client.voucher_history(&to).contains(borrower.clone()));
+
+        let vouches = client.get_vouches(&borrower).unwrap();
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().voucher, to);
+        assert_eq!(vouches.get(0).unwrap().stake, 1_000_000);
+    }
+
+    #[test]
+    fn test_transfer_vouch_merge() {
+        let env = Env::default();
+        let (contract_id, token_addr, admin, borrower, from) = setup(&env);
+        let to = Address::generate(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let token_admin = StellarAssetClient::new(&env, &token_addr);
+        token_admin.mint(&to, &10_000_000);
+        let admin_signers = single_admin_signers(&env, &admin);
+        client.whitelist_voucher(&admin_signers, &to);
+
+        client.vouch(&from, &borrower, &1_000_000);
+        client.vouch(&to, &borrower, &2_000_000);
+
+        assert_eq!(client.get_vouches(&borrower).unwrap().len(), 2);
+
+        client.transfer_vouch(&from, &to, &borrower);
+
+        assert!(!client.vouch_exists(&from, &borrower));
+        assert!(client.vouch_exists(&to, &borrower));
+
+        let vouches = client.get_vouches(&borrower).unwrap();
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().voucher, to);
+        assert_eq!(vouches.get(0).unwrap().stake, 3_000_000);
+    }
+
+    #[test]
+    #[should_panic(expected = "loan already active")]
+    fn test_transfer_vouch_active_loan_fails() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, from) = setup(&env);
+        let to = Address::generate(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&from, &borrower, &2_000_000);
+        client.request_loan(&borrower, &1_000_000, &2_000_000);
+
+        client.transfer_vouch(&from, &to, &borrower);
+    }
+
+    #[test]
+    #[should_panic(expected = "from voucher not found")]
+    fn test_transfer_vouch_not_found_fails() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, from) = setup(&env);
+        let to = Address::generate(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // 'from' never vouched
+        client.transfer_vouch(&from, &to, &borrower);
+    }
+
+    #[test]
+    fn test_transfer_vouch_same_address_noop() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, from) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&from, &borrower, &1_000_000);
+        client.transfer_vouch(&from, &from, &borrower);
+
+        assert!(client.vouch_exists(&from, &borrower));
+        assert_eq!(client.get_vouches(&borrower).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_slash_treasury_accumulation() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower1, voucher) = setup(&env);
+        let borrower2 = Address::generate(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        // Initial balance should be 0
+        assert_eq!(client.get_slash_treasury_balance(), 0);
+
+        // First slash (manual admin slash)
+        client.vouch(&voucher, &borrower1, &1_000_000);
+        client.request_loan(&borrower1, &Vec::new(&env), &500_000, &1_000_000);
+        client.slash(&admin_signers, &borrower1);
+
+        // Stake was 1M, slash_bps is 5000 (50%), so 500k slashed
+        assert_eq!(client.get_slash_treasury_balance(), 500_000);
+
+        // Second slash (auto_slash after deadline)
+        client.vouch(&voucher, &borrower2, &2_000_000);
+        client.request_loan(&borrower2, &Vec::new(&env), &1_000_000, &2_000_000);
+        
+        let loan = client.get_loan(&borrower2).unwrap();
+        env.ledger().set_timestamp(loan.deadline + 1);
+        client.auto_slash(&borrower2);
+
+        // Stake was 2M, 50% is 1M. Total: 500k + 1M = 1.5M
+        assert_eq!(client.get_slash_treasury_balance(), 1_500_000);
+    }
+
+    // ── Whitelist Tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_whitelist_voucher_success() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let new_voucher = Address::generate(&env);
+        assert!(!client.is_whitelisted(&new_voucher));
+
+        client.whitelist_voucher(&admin_signers, &new_voucher);
+        assert!(client.is_whitelisted(&new_voucher));
+    }
+
+    #[test]
+    #[should_panic(expected = "unauthorized admin signer")]
+    fn test_whitelist_voucher_unauthorized() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, _borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let fake_admin = Address::generate(&env);
+        let fake_signers = single_admin_signers(&env, &fake_admin);
+        let new_voucher = Address::generate(&env);
+
+        client.whitelist_voucher(&fake_signers, &new_voucher);
+    }
+
+    #[test]
+    fn test_vouch_requires_whitelist() {
+        let env = Env::default();
+        let (contract_id, _token_addr, _admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let unwhitelisted = Address::generate(&env);
+        // Mint some tokens so focus is on whitelist and not balance
+        let token_id = client.get_token();
+        let token_admin = StellarAssetClient::new(&env, &token_id);
+        token_admin.mint(&unwhitelisted, &10_000_000);
+
+        let result = client.try_vouch(&unwhitelisted, &borrower, &1_000_000);
+        assert_eq!(result, Err(Ok(ContractError::VoucherNotWhitelisted)));
+    }
+
+    #[test]
+    fn test_whitelisted_voucher_can_vouch() {
+        let env = Env::default();
+        let (contract_id, _token_addr, admin, borrower, _voucher) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let admin_signers = single_admin_signers(&env, &admin);
+
+        let new_voucher = Address::generate(&env);
+        let token_id = client.get_token();
+        let token_admin = StellarAssetClient::new(&env, &token_id);
+        token_admin.mint(&new_voucher, &10_000_000);
+
+        client.whitelist_voucher(&admin_signers, &new_voucher);
+        client.vouch(&new_voucher, &borrower, &1_000_000);
+
+        assert!(client.vouch_exists(&new_voucher, &borrower));
+    }
+}

--- a/QuorumCredit/src/loan.rs
+++ b/QuorumCredit/src/loan.rs
@@ -1,0 +1,405 @@
+use crate::errors::ContractError;
+use crate::helpers::{
+    config, get_active_loan_record, get_slash_balance, has_active_loan, next_loan_id, require_allowed_token,
+    require_not_paused,
+};
+use crate::reputation::ReputationNftExternalClient;
+use crate::types::{DataKey, LoanRecord, LoanStatus, VouchRecord, DEFAULT_REFERRAL_BONUS_BPS, MIN_VOUCH_AGE};
+use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};
+
+/// Register a referrer for a borrower. Must be called before `request_loan`.
+/// The referrer cannot be the borrower themselves.
+pub fn register_referral(
+    env: Env,
+    borrower: Address,
+    referrer: Address,
+) -> Result<(), ContractError> {
+    borrower.require_auth();
+    require_not_paused(&env)?;
+
+    assert!(borrower != referrer, "borrower cannot refer themselves");
+    assert!(
+        !has_active_loan(&env, &borrower),
+        "cannot set referral with active loan"
+    );
+    // Idempotent: overwrite is fine (borrower signs).
+    env.storage()
+        .persistent()
+        .set(&DataKey::ReferredBy(borrower.clone()), &referrer);
+
+    env.events().publish(
+        (symbol_short!("referral"), symbol_short!("set")),
+        (borrower, referrer),
+    );
+
+    Ok(())
+}
+
+pub fn get_referrer(env: Env, borrower: Address) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ReferredBy(borrower))
+}
+
+pub fn request_loan(
+    env: Env,
+    borrower: Address,
+    amount: i128,
+    threshold: i128,
+    loan_purpose: soroban_sdk::String,
+    token_addr: Address,
+) -> Result<(), ContractError> {
+    borrower.require_auth();
+    require_not_paused(&env)?;
+
+    if env
+        .storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::Blacklisted(borrower.clone()))
+        .unwrap_or(false)
+    {
+        return Err(ContractError::Blacklisted);
+    }
+
+    // Validate token is allowed before any other checks.
+    let token_client = require_allowed_token(&env, &token_addr)?;
+
+    let cfg = config(&env);
+
+    assert!(
+        amount >= cfg.min_loan_amount,
+        "loan amount must meet minimum threshold"
+    );
+    assert!(threshold > 0, "threshold must be greater than zero");
+
+    let max_loan_amount: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MaxLoanAmount)
+        .unwrap_or(0);
+    if max_loan_amount > 0 && amount > max_loan_amount {
+        return Err(ContractError::LoanExceedsMaxAmount);
+    }
+
+    assert!(
+        !has_active_loan(&env, &borrower),
+        "borrower already has an active loan"
+    );
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or(Vec::new(&env));
+
+    // Only count vouches denominated in the requested token.
+    let mut token_vouches: Vec<VouchRecord> = Vec::new(&env);
+    for v in vouches.iter() {
+        if v.token == token_addr {
+            token_vouches.push_back(v);
+        }
+    }
+
+    let mut total_stake: i128 = 0;
+    for v in token_vouches.iter() {
+        total_stake = total_stake
+            .checked_add(v.stake)
+            .ok_or(ContractError::StakeOverflow)?;
+    }
+    if total_stake < threshold {
+        panic_with_error!(&env, ContractError::InsufficientFunds);
+    }
+
+    let min_vouchers: u32 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MinVouchers)
+        .unwrap_or(0);
+    if token_vouches.len() < min_vouchers {
+        return Err(ContractError::InsufficientVouchers);
+    }
+
+    let now = env.ledger().timestamp();
+    for v in token_vouches.iter() {
+        if now < v.vouch_timestamp + MIN_VOUCH_AGE {
+            return Err(ContractError::VouchTooRecent);
+        }
+    }
+
+    let max_allowed_loan = total_stake * cfg.max_loan_to_stake_ratio as i128 / 100;
+    assert!(
+        amount <= max_allowed_loan,
+        "loan amount exceeds maximum collateral ratio"
+    );
+
+    let contract_balance = token_client.balance(&env.current_contract_address());
+    if contract_balance < amount {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    let deadline = now + cfg.loan_duration;
+    let loan_id = next_loan_id(&env);
+    let total_yield = amount * cfg.yield_bps / 10_000;
+
+    env.storage().persistent().set(
+        &DataKey::Loan(loan_id),
+        &LoanRecord {
+            id: loan_id,
+            borrower: borrower.clone(),
+            co_borrowers: Vec::new(&env),
+            amount,
+            amount_repaid: 0,
+            total_yield,
+            status: LoanStatus::Active,
+            created_at: now,
+            disbursement_timestamp: now,
+            repayment_timestamp: None,
+            deadline,
+            loan_purpose,
+            token_address: token_addr.clone(),
+        },
+    );
+    env.storage()
+        .persistent()
+        .set(&DataKey::ActiveLoan(borrower.clone()), &loan_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::LatestLoan(borrower.clone()), &loan_id);
+
+    let count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LoanCount(borrower.clone()))
+        .unwrap_or(0);
+    env.storage()
+        .persistent()
+        .set(&DataKey::LoanCount(borrower.clone()), &(count + 1));
+
+    token_client.transfer(&env.current_contract_address(), &borrower, &amount);
+
+    env.events().publish(
+        (symbol_short!("loan"), symbol_short!("disbursed")),
+        (borrower.clone(), amount, deadline, token_addr),
+    );
+
+    Ok(())
+}
+
+pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
+    borrower.require_auth();
+    require_not_paused(&env)?;
+
+    // First try to get active loan record
+    let mut loan = match get_active_loan_record(&env, &borrower) {
+        Ok(loan) => loan,
+        Err(ContractError::NoActiveLoan) => {
+            // Check if there's a latest loan that is already repaid
+            if let Some(latest_loan) = crate::helpers::get_latest_loan_record(&env, &borrower) {
+                if latest_loan.status == LoanStatus::Repaid {
+                    panic!("loan already repaid");
+                }
+            }
+            return Err(ContractError::NoActiveLoan);
+        }
+        Err(e) => return Err(e),
+    };
+
+    for cb in loan.co_borrowers.iter() {
+        cb.require_auth();
+    }
+
+    if borrower != loan.borrower {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+    if loan.status != LoanStatus::Active {
+        if loan.status == LoanStatus::Repaid {
+            panic!("loan already repaid");
+        } else {
+            return Err(ContractError::NoActiveLoan);
+        }
+    }
+    assert!(
+        env.ledger().timestamp() <= loan.deadline,
+        "loan deadline has passed"
+    );
+
+    // Total obligation = principal + yield locked in at disbursement.
+    let total_owed = loan.amount + loan.total_yield;
+    let outstanding = total_owed - loan.amount_repaid;
+    assert!(
+        payment > 0 && payment <= outstanding,
+        "invalid payment amount"
+    );
+
+    let token = soroban_sdk::token::Client::new(&env, &loan.token_address);
+
+    token.transfer(&borrower, &env.current_contract_address(), &payment);
+    loan.amount_repaid += payment;
+    let fully_repaid = loan.amount_repaid >= total_owed;
+
+    if fully_repaid {
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+        
+        // Issue 112: Only distribute yield to vouches in the same token as the loan.
+        // Verify that available funds exclude slash balance to prevent fund leakage.
+        let loan_token = soroban_sdk::token::Client::new(&env, &loan.token_address);
+        let slash_balance = get_slash_balance(&env);
+        
+        let mut total_stake: i128 = 0;
+        for v in vouches.iter() {
+            if v.token == loan.token_address {
+                total_stake += v.stake;
+            }
+        }
+
+        // Issue 112: Ensure yield distribution respects available funds (excluding slash balance)
+        let available_for_yield = loan.total_yield;
+        let mut total_distributed: i128 = 0;
+
+        for v in vouches.iter() {
+            if v.token != loan.token_address {
+                continue;
+            }
+            let voucher_yield = if total_stake > 0 {
+                (available_for_yield * v.stake) / total_stake
+            } else {
+                0
+            };
+            total_distributed += voucher_yield;
+            
+            // Assert that we're not exceeding available yield
+            assert!(
+                total_distributed <= available_for_yield,
+                "yield distribution would exceed available funds"
+            );
+            
+            loan_token.transfer(
+                &env.current_contract_address(),
+                &v.voucher,
+                &(v.stake + voucher_yield),
+            );
+        }
+
+        loan.status = LoanStatus::Repaid;
+        loan.repayment_timestamp = Some(env.ledger().timestamp());
+
+        // Pay referral bonus if a referrer is registered.
+        if let Some(referrer) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::ReferredBy(borrower.clone()))
+        {
+            let bonus_bps: u32 = env
+                .storage()
+                .instance()
+                .get(&DataKey::ReferralBonusBps)
+                .unwrap_or(DEFAULT_REFERRAL_BONUS_BPS);
+            let bonus = loan.amount * bonus_bps as i128 / 10_000;
+            
+            // Issue 112: Ensure bonus doesn't use slash funds
+            if bonus > 0 {
+                loan_token.transfer(&env.current_contract_address(), &referrer, &bonus);
+                env.events().publish(
+                    (symbol_short!("referral"), symbol_short!("bonus")),
+                    (referrer, borrower.clone(), bonus),
+                );
+            }
+        }
+
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RepaymentCount(borrower.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RepaymentCount(borrower.clone()), &(count + 1));
+
+        if let Some(nft_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::ReputationNft)
+        {
+            ReputationNftExternalClient::new(&env, &nft_addr).mint(&borrower);
+        }
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::ActiveLoan(borrower.clone()));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower.clone()));
+
+        env.events().publish(
+            (symbol_short!("loan"), symbol_short!("repaid")),
+            (borrower.clone(), loan.amount),
+        );
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Loan(loan.id), &loan);
+
+    Ok(())
+}
+
+pub fn loan_status(env: Env, borrower: Address) -> LoanStatus {
+    match crate::helpers::get_latest_loan_record(&env, &borrower) {
+        None => LoanStatus::None,
+        Some(loan) => loan.status,
+    }
+}
+
+pub fn get_loan(env: Env, borrower: Address) -> Option<LoanRecord> {
+    crate::helpers::get_latest_loan_record(&env, &borrower)
+}
+
+pub fn get_loan_by_id(env: Env, loan_id: u64) -> Option<LoanRecord> {
+    env.storage().persistent().get(&DataKey::Loan(loan_id))
+}
+
+pub fn is_eligible(env: Env, borrower: Address, threshold: i128) -> bool {
+    if threshold <= 0 {
+        return false;
+    }
+
+    if let Some(loan) = crate::helpers::get_latest_loan_record(&env, &borrower) {
+        if loan.status == LoanStatus::Active {
+            return false;
+        }
+    }
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower))
+        .unwrap_or(Vec::new(&env));
+
+    let total_stake: i128 = vouches.iter().map(|v| v.stake).sum();
+    total_stake >= threshold
+}
+
+pub fn repayment_count(env: Env, borrower: Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RepaymentCount(borrower))
+        .unwrap_or(0)
+}
+
+pub fn loan_count(env: Env, borrower: Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::LoanCount(borrower))
+        .unwrap_or(0)
+}
+
+pub fn default_count(env: Env, borrower: Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DefaultCount(borrower))
+        .unwrap_or(0)
+}

--- a/QuorumCredit/src/loan_purpose_test.rs
+++ b/QuorumCredit/src/loan_purpose_test.rs
@@ -1,0 +1,56 @@
+#[cfg(test)]
+mod loan_purpose_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    fn setup() -> (Env, QuorumCreditContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &1_000_000);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id.address());
+
+        (env, client, borrower, token_id.address())
+    }
+
+    #[test]
+    fn test_loan_purpose_stored_and_retrieved() {
+        let (env, client, borrower, token) = setup();
+        let purpose = String::from_str(&env, "school fees");
+
+        client.request_loan(&borrower, &100_000, &500_000, &purpose, &token);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.loan_purpose, purpose);
+    }
+
+    #[test]
+    fn test_loan_purpose_empty_string_allowed() {
+        let (env, client, borrower, token) = setup();
+        let purpose = String::from_str(&env, "");
+
+        client.request_loan(&borrower, &100_000, &500_000, &purpose, &token);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.loan_purpose, purpose);
+    }
+}

--- a/QuorumCredit/src/multi_asset_test.rs
+++ b/QuorumCredit/src/multi_asset_test.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod multi_asset_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        xlm: Address,
+        usdc: Address,
+        admin: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let xlm_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let usdc_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &xlm_id.address()).mint(&contract_id, &10_000_000);
+        StellarAssetClient::new(&env, &usdc_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &xlm_id.address());
+        client.add_allowed_token(&admins, &usdc_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, xlm: xlm_id.address(), usdc: usdc_id.address(), admin }
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test")
+    }
+
+    #[test]
+    fn test_usdc_loan_token_address_stored() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &1_000_000);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.usdc);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
+
+        let loan = s.client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.token_address, s.usdc);
+    }
+
+    /// XLM vouches must not count toward a USDC loan threshold.
+    #[test]
+    fn test_xlm_vouches_dont_count_for_usdc_loan() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.xlm).mint(&voucher, &1_000_000);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm);
+
+        let result = s.client.try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_vouch_with_disallowed_token_rejected() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let random_token = Address::generate(&s.env);
+
+        let result = s.client.try_vouch(&voucher, &borrower, &100_000, &random_token);
+        assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
+    }
+
+    #[test]
+    fn test_request_loan_with_disallowed_token_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let random_token = Address::generate(&s.env);
+
+        let result = s.client.try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &random_token);
+        assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
+    }
+
+    #[test]
+    fn test_remove_allowed_token_blocks_vouch() {
+        let s = setup();
+        let admins = Vec::from_array(&s.env, [s.admin.clone()]);
+        s.client.remove_allowed_token(&admins, &s.usdc);
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let result = s.client.try_vouch(&voucher, &borrower, &100_000, &s.usdc);
+        assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
+    }
+
+    #[test]
+    fn test_primary_token_always_allowed() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.xlm).mint(&voucher, &1_000_000);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.xlm);
+
+        let loan = s.client.get_loan(&borrower).unwrap();
+        assert_eq!(loan.token_address, s.xlm);
+    }
+}

--- a/QuorumCredit/src/multi_voucher_stake_test.rs
+++ b/QuorumCredit/src/multi_voucher_stake_test.rs
@@ -1,0 +1,144 @@
+/// Multi-Voucher Stake Aggregation Tests
+///
+/// Verifies that multiple vouchers' partial stakes are correctly summed
+/// to meet a loan threshold, and that a loan can be successfully requested
+/// once the combined stake satisfies the threshold.
+#[cfg(test)]
+mod multi_voucher_stake_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        contract_id: Address,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund the contract so it can disburse loans.
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance time past MIN_VOUCH_AGE (60s) so vouches are eligible.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, contract_id, token_id: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "business expansion")
+    }
+
+    /// Three vouchers each contribute a partial stake. Their combined total
+    /// must meet the threshold, and the loan request must succeed.
+    ///
+    /// Stakes:  voucher_a = 200_000
+    ///          voucher_b = 150_000
+    ///          voucher_c = 150_000
+    ///          total     = 500_000  (== threshold)
+    ///
+    /// Loan amount = 100_000 (well within the 150% collateral ratio: 750_000 max).
+    #[test]
+    fn test_three_partial_stakes_sum_meets_threshold_and_loan_succeeds() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+        let voucher_c = Address::generate(&s.env);
+
+        // Each voucher contributes a partial stake — none alone meets the 500_000 threshold.
+        do_vouch(&s, &voucher_a, &borrower, 200_000);
+        do_vouch(&s, &voucher_b, &borrower, 150_000);
+        do_vouch(&s, &voucher_c, &borrower, 150_000);
+
+        // Verify the total vouched equals the sum of all three stakes.
+        let total = s.client.total_vouched(&borrower).unwrap();
+        assert_eq!(total, 500_000, "total_vouched should be 200_000 + 150_000 + 150_000");
+
+        // Confirm the borrower is eligible at the 500_000 threshold.
+        assert!(
+            s.client.is_eligible(&borrower, &500_000),
+            "borrower should be eligible when combined stake meets threshold"
+        );
+
+        // Request the loan — should succeed because total stake >= threshold.
+        s.client.request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &purpose(&s.env),
+            &s.token_id,
+        );
+
+        // Confirm the loan is now active.
+        let loan = s.client.get_loan(&borrower).expect("loan should exist after request");
+        assert_eq!(loan.amount, 100_000);
+        assert!(!loan.repaid);
+        assert!(!loan.defaulted);
+    }
+
+    /// get_vouches on a fresh address with no vouches should return None (no entry).
+    #[test]
+    fn test_get_vouches_returns_none_for_address_with_no_vouches() {
+        let s = setup();
+        let fresh = Address::generate(&s.env);
+
+        let result = s.client.get_vouches(&fresh);
+        assert!(result.is_none(), "get_vouches should return None for an address with no vouches");
+    }
+
+    /// Verify that a loan request fails when the combined stake falls short of
+    /// the threshold, even with multiple vouchers present.
+    ///
+    /// Stakes:  voucher_a = 100_000
+    ///          voucher_b = 100_000
+    ///          voucher_c = 100_000
+    ///          total     = 300_000  (< 500_000 threshold)
+    #[test]
+    fn test_three_partial_stakes_below_threshold_rejects_loan() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher_a = Address::generate(&s.env);
+        let voucher_b = Address::generate(&s.env);
+        let voucher_c = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher_a, &borrower, 100_000);
+        do_vouch(&s, &voucher_b, &borrower, 100_000);
+        do_vouch(&s, &voucher_c, &borrower, 100_000);
+
+        let total = s.client.total_vouched(&borrower).unwrap();
+        assert_eq!(total, 300_000);
+
+        // Loan request must fail — combined stake does not meet the threshold.
+        let result = s.client.try_request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &purpose(&s.env),
+            &s.token_id,
+        );
+        assert!(result.is_err(), "loan should be rejected when combined stake < threshold");
+    }
+}

--- a/QuorumCredit/src/property_inflow_outflow_test.rs
+++ b/QuorumCredit/src/property_inflow_outflow_test.rs
@@ -1,0 +1,211 @@
+/// Property test: total outflow never exceeds total inflow.
+///
+/// The invariant tracked after every operation:
+///   `contract_balance == total_inflow - total_outflow`
+///
+/// Inflows:  vouch (stake transfer in), repayment (borrower pays principal+yield),
+///           any direct mint to contract.
+/// Outflows: loan disbursement, stake+yield returned to vouchers on repay,
+///           unslashed stake returned to vouchers on slash.
+///           (Slashed portion stays in contract as SlashTreasury — not an outflow.)
+///
+/// # Scenarios
+/// 1. Vouch only
+/// 2. Vouch → request_loan
+/// 3. Vouch → request_loan → repay
+/// 4. Vouch → request_loan → slash (via vote_slash with quorum=1)
+/// 5. Multiple vouchers, multiple loans, mixed repay cycles
+#[cfg(test)]
+mod property_inflow_outflow_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::{StellarAssetClient, TokenClient},
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token: Address,
+        admin_vec: Vec<Address>,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admin_vec = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admin_vec, &1, &token_id.address());
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token: token_id.address(), admin_vec }
+    }
+
+    fn balance(s: &Setup, addr: &Address) -> i128 {
+        TokenClient::new(&s.env, &s.token).balance(addr)
+    }
+
+    fn mint(s: &Setup, to: &Address, amount: i128) {
+        StellarAssetClient::new(&s.env, &s.token).mint(to, &amount);
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test")
+    }
+
+    fn assert_invariant(s: &Setup, inflow: i128, outflow: i128, ctx: &str) {
+        let bal = balance(s, &s.client.address);
+        assert_eq!(
+            bal,
+            inflow - outflow,
+            "{ctx}: balance={bal} != inflow({inflow}) - outflow({outflow})"
+        );
+        assert!(outflow <= inflow, "{ctx}: outflow({outflow}) exceeded inflow({inflow})");
+    }
+
+    /// Scenario 1: vouch only — stake is inflow, nothing leaves.
+    #[test]
+    fn test_vouch_only() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+
+        mint(&s, &voucher, stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+
+        assert_invariant(&s, stake, 0, "after vouch");
+    }
+
+    /// Scenario 2: vouch → request_loan — disbursement is outflow.
+    #[test]
+    fn test_vouch_then_loan() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan = 500_000i128;
+
+        mint(&s, &voucher, stake);
+        mint(&s, &s.client.address, loan);
+        let mut inflow = stake + loan;
+        let mut outflow = 0i128;
+
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        assert_invariant(&s, inflow, outflow, "after vouch");
+
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
+        outflow += loan;
+        assert_invariant(&s, inflow, outflow, "after request_loan");
+    }
+
+    /// Scenario 3: full repay cycle — repayment in, stake+yield out.
+    #[test]
+    fn test_full_repay_cycle() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan = 500_000i128;
+        let yield_amt = loan * 200 / 10_000; // 10_000
+        let total_owed = loan + yield_amt;
+
+        mint(&s, &voucher, stake);
+        mint(&s, &s.client.address, loan);
+        let mut inflow = stake + loan;
+        let mut outflow = 0i128;
+
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
+        outflow += loan;
+        assert_invariant(&s, inflow, outflow, "after request_loan");
+
+        mint(&s, &borrower, total_owed);
+        s.client.repay(&borrower, &total_owed);
+        inflow += total_owed;
+        outflow += stake + yield_amt; // stake returned + yield paid
+        assert_invariant(&s, inflow, outflow, "after repay");
+    }
+
+    /// Scenario 4: slash cycle — unslashed remainder returned to voucher (outflow);
+    /// slashed portion stays in contract as SlashTreasury (not an outflow).
+    #[test]
+    fn test_slash_cycle() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan = 500_000i128;
+        let slash_bps = 5_000i128; // default 50%
+        let slashed = stake * slash_bps / 10_000; // 500_000 burned (stays in contract)
+        let returned = stake - slashed;            // 500_000 returned to voucher (outflow)
+
+        mint(&s, &voucher, stake);
+        mint(&s, &s.client.address, loan);
+        let mut inflow = stake + loan;
+        let mut outflow = 0i128;
+
+        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
+        outflow += loan;
+        assert_invariant(&s, inflow, outflow, "after request_loan");
+
+        // Set quorum to 1 bps so a single voucher vote triggers slash immediately.
+        s.client.set_slash_vote_quorum(&s.admin_vec, &1);
+        s.client.vote_slash(&voucher, &borrower, &true);
+        outflow += returned; // only the unslashed remainder leaves the contract
+        assert_invariant(&s, inflow, outflow, "after slash");
+
+        // Slashed amount is tracked in SlashTreasury (still in contract balance).
+        assert_eq!(
+            s.client.get_slash_treasury_balance(),
+            slashed,
+            "slashed amount must remain in contract as SlashTreasury"
+        );
+    }
+
+    /// Scenario 5: multiple independent vouch→loan→repay cycles.
+    #[test]
+    fn test_multiple_cycles_invariant_holds() {
+        let s = setup();
+        let fund = 3_000_000i128;
+        mint(&s, &s.client.address, fund);
+        let mut inflow = fund;
+        let mut outflow = 0i128;
+
+        for _ in 0..3 {
+            let voucher = Address::generate(&s.env);
+            let borrower = Address::generate(&s.env);
+            let stake = 1_000_000i128;
+            let loan = 500_000i128;
+            let yield_amt = loan * 200 / 10_000;
+            let total_owed = loan + yield_amt;
+
+            mint(&s, &voucher, stake);
+            s.client.vouch(&voucher, &borrower, &stake, &s.token);
+            inflow += stake;
+            assert_invariant(&s, inflow, outflow, "after vouch");
+
+            s.env.ledger().with_mut(|l| l.timestamp += 61);
+            s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
+            outflow += loan;
+            assert_invariant(&s, inflow, outflow, "after request_loan");
+
+            mint(&s, &borrower, total_owed);
+            s.client.repay(&borrower, &total_owed);
+            inflow += total_owed;
+            outflow += stake + yield_amt;
+            assert_invariant(&s, inflow, outflow, "after repay");
+        }
+    }
+}

--- a/QuorumCredit/src/referral_test.rs
+++ b/QuorumCredit/src/referral_test.rs
@@ -1,0 +1,139 @@
+#[cfg(test)]
+mod referral_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::{StellarAssetClient, TokenClient},
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        contract_id: Address,
+        token: Address,
+        admin: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund contract for loans + yield + referral bonuses.
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &50_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, contract_id, token: token_id.address(), admin }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token);
+    }
+
+    fn do_loan(s: &Setup, borrower: &Address, amount: i128) {
+        s.client.request_loan(
+            borrower,
+            &amount,
+            &500_000,
+            &String::from_str(&s.env, "test"),
+            &s.token,
+        );
+    }
+
+    /// Referrer receives 1% bonus on full repayment.
+    #[test]
+    fn test_referral_bonus_paid_on_repayment() {
+        let s = setup();
+        let referrer = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        s.client.register_referral(&borrower, &referrer);
+        do_loan(&s, &borrower, 100_000);
+
+        // Borrower repays principal + yield (2% of 100_000 = 2_000).
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &102_000);
+        s.client.repay(&borrower, &102_000);
+
+        // Referral bonus = 1% of 100_000 = 1_000.
+        let referrer_balance = TokenClient::new(&s.env, &s.token)
+            .balance(&referrer);
+        assert_eq!(referrer_balance, 1_000);
+    }
+
+    /// No referral registered → no bonus, repayment succeeds normally.
+    #[test]
+    fn test_no_referral_no_bonus() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000);
+
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &102_000);
+        s.client.repay(&borrower, &102_000);
+
+        assert_eq!(s.client.loan_status(&borrower), crate::LoanStatus::Repaid);
+    }
+
+    /// Borrower cannot refer themselves.
+    #[test]
+    fn test_self_referral_rejected() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+
+        let result = s.client.try_register_referral(&borrower, &borrower);
+        assert!(result.is_err());
+    }
+
+    /// get_referrer returns the registered referrer.
+    #[test]
+    fn test_get_referrer_returns_correct_address() {
+        let s = setup();
+        let referrer = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+
+        assert!(s.client.get_referrer(&borrower).is_none());
+        s.client.register_referral(&borrower, &referrer);
+        assert_eq!(s.client.get_referrer(&borrower), Some(referrer));
+    }
+
+    /// Admin can change the bonus rate; new rate is applied on next repayment.
+    #[test]
+    fn test_custom_referral_bonus_bps() {
+        let s = setup();
+        let admins = Vec::from_array(&s.env, [s.admin.clone()]);
+        // Set bonus to 2%.
+        s.client.set_referral_bonus_bps(&admins, &200);
+        assert_eq!(s.client.get_referral_bonus_bps(), 200);
+
+        let referrer = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        s.client.register_referral(&borrower, &referrer);
+        do_loan(&s, &borrower, 100_000);
+
+        StellarAssetClient::new(&s.env, &s.token).mint(&borrower, &102_000);
+        s.client.repay(&borrower, &102_000);
+
+        // 2% of 100_000 = 2_000.
+        let referrer_balance = TokenClient::new(&s.env, &s.token)
+            .balance(&referrer);
+        assert_eq!(referrer_balance, 2_000);
+    }
+}

--- a/QuorumCredit/src/reputation.rs
+++ b/QuorumCredit/src/reputation.rs
@@ -1,0 +1,80 @@
+#![allow(unused)]
+
+use soroban_sdk::{contract, contractclient, contractimpl, contracttype, Address, Env};
+
+#[contracttype]
+pub enum RepKey {
+    Minter,         // Address authorised to mint/burn (the main lending contract)
+    Score(Address), // borrower → u32 reputation score
+}
+
+#[contractclient(name = "ReputationNftExternalClient")]
+pub trait ReputationNftContractTrait {
+    fn initialize(env: Env, minter: Address);
+    fn mint(env: Env, to: Address);
+    fn burn(env: Env, from: Address);
+    fn balance(env: Env, addr: Address) -> u32;
+}
+
+#[cfg(test)]
+#[contract]
+pub struct ReputationNftContract;
+
+#[cfg(test)]
+#[contractimpl]
+impl ReputationNftContract {
+    /// One-time setup: record the authorised minter (the lending contract).
+    pub fn initialize(env: Env, minter: Address) {
+        assert!(
+            !env.storage().instance().has(&RepKey::Minter),
+            "already initialized"
+        );
+        env.storage().instance().set(&RepKey::Minter, &minter);
+    }
+
+    /// Mint one reputation point to `to`. Only callable by the registered minter.
+    pub fn mint(env: Env, to: Address) {
+        let minter: Address = env
+            .storage()
+            .instance()
+            .get(&RepKey::Minter)
+            .expect("not initialized");
+        minter.require_auth();
+
+        let score: u32 = env
+            .storage()
+            .persistent()
+            .get(&RepKey::Score(to.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&RepKey::Score(to), &(score + 1));
+    }
+
+    /// Burn one reputation point from `from` (floor at 0). Only callable by the registered minter.
+    pub fn burn(env: Env, from: Address) {
+        let minter: Address = env
+            .storage()
+            .instance()
+            .get(&RepKey::Minter)
+            .expect("not initialized");
+        minter.require_auth();
+
+        let score: u32 = env
+            .storage()
+            .persistent()
+            .get(&RepKey::Score(from.clone()))
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&RepKey::Score(from), &score.saturating_sub(1));
+    }
+
+    /// Returns the reputation score for `addr`.
+    pub fn balance(env: Env, addr: Address) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&RepKey::Score(addr))
+            .unwrap_or(0)
+    }
+}

--- a/QuorumCredit/src/request_loan_insufficient_stake_test.rs
+++ b/QuorumCredit/src/request_loan_insufficient_stake_test.rs
@@ -1,0 +1,42 @@
+#[cfg(test)]
+mod request_loan_insufficient_stake_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
+        StellarAssetClient::new(env, &token_id).mint(&contract_id, &10_000_000);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &1_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    #[test]
+    fn test_request_loan_below_threshold_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        // Vouch with 100_000 stake but request loan with threshold of 500_000
+        client.vouch(&voucher, &borrower, &100_000, &token_id);
+
+        let result = client.try_request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &String::from_str(&env, "test"),
+            &token_id,
+        );
+        assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
+    }
+}

--- a/QuorumCredit/src/security_fixes_test.rs
+++ b/QuorumCredit/src/security_fixes_test.rs
@@ -1,0 +1,398 @@
+/// Security Fixes Tests
+/// 
+/// Tests for:
+/// - Issue 108: Prevent Borrower from Repaying Another Borrower's Loan
+/// - Issue 109: Add Slash Proposal Confirmation Window
+/// - Issue 112: Add Slash Balance Accounting to Prevent Fund Leakage
+/// - Issue 114: Add Invariant Tests — Total Outflow Never Exceeds Total Inflow
+#[cfg(test)]
+mod security_fixes_tests {
+    use crate::{ContractError, DataKey, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        contract_id: Address,
+        admin: Address,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund the contract so it can disburse loans
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &100_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance time past MIN_VOUCH_AGE (60s)
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup {
+            env,
+            client,
+            contract_id,
+            admin,
+            token_id: token_id.address(),
+        }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token_id);
+    }
+
+    // ── Issue 108: Prevent Borrower from Repaying Another Borrower's Loan ──
+
+    /// Test that a borrower cannot repay another borrower's loan.
+    /// Even if they have a loan themselves, they cannot interfere with another's.
+    #[test]
+    fn test_borrower_cannot_repay_another_borrower_loan() {
+        let s = setup();
+        
+        // Create two borrowers
+        let borrower_a = Address::generate(&s.env);
+        let borrower_b = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        // Setup vouches for both borrowers
+        do_vouch(&s, &voucher, &borrower_a, 500_000);
+        do_vouch(&s, &voucher, &borrower_b, 500_000);
+        
+        // Request loans for both
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower_a, &1_000_000);
+        token.mint(&borrower_b, &1_000_000);
+        
+        let purpose = String::from_str(&s.env, "business");
+        s.client.request_loan(&borrower_a, &100_000, &500_000, &purpose, &s.token_id);
+        s.client.request_loan(&borrower_b, &100_000, &500_000, &purpose, &s.token_id);
+        
+        // Verify both loans exist
+        assert!(s.client.get_loan(&borrower_a).is_some());
+        assert!(s.client.get_loan(&borrower_b).is_some());
+        
+        // Borrower A tries to repay Borrower B's loan by calling repay with B's address
+        // This should fail because we try to get A's active loan, not B's
+        let result = s.client.try_repay(&borrower_a, &50_000);
+        assert!(result.is_ok(), "Borrower A should be able to repay their own loan");
+        
+        // Now verify the loan was actually repaid (via get_loan showing updated amount_repaid)
+        let loan_a = s.client.get_loan(&borrower_a);
+        assert!(loan_a.is_some());
+        assert!(loan_a.unwrap().amount_repaid > 0, "Loan should have been repaid");
+    }
+
+    /// Test that cross-loan repayment attempts are blocked.
+    /// Simulate an attacker trying to use one borrower's identity to affect another's loan.
+    #[test]
+    fn test_cross_borrower_attack_prevented() {
+        let s = setup();
+        
+        let borrower_a = Address::generate(&s.env);
+        let borrower_b = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        // Setup
+        do_vouch(&s, &voucher, &borrower_a, 500_000);
+        do_vouch(&s, &voucher, &borrower_b, 500_000);
+        
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower_a, &500_000);
+        token.mint(&borrower_b, &500_000);
+        
+        let purpose = String::from_str(&s.env, "test");
+        s.client.request_loan(&borrower_a, &50_000, &500_000, &purpose, &s.token_id);
+        s.client.request_loan(&borrower_b, &50_000, &500_000, &purpose, &s.token_id);
+        
+        let loan_a_before = s.client.get_loan(&borrower_a).unwrap();
+        let loan_b_before = s.client.get_loan(&borrower_b).unwrap();
+        
+        // Borrower A makes a payment
+        s.client.try_repay(&borrower_a, &25_000).ok();
+        
+        // Verify B's loan was NOT affected
+        let loan_b_after = s.client.get_loan(&borrower_b).unwrap();
+        assert_eq!(
+            loan_b_before.amount_repaid, 
+            loan_b_after.amount_repaid,
+            "Borrower B's loan repayment should not be affected by A's payment"
+        );
+    }
+
+    // ── Issue 112: Add Slash Balance Accounting to Prevent Fund Leakage ──
+
+    /// Test that slash balance is tracked separately and not available for yield payouts.
+    #[test]
+    fn test_slash_balance_prevents_fund_leakage() {
+        let s = setup();
+        
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower, &500_000);
+        
+        let purpose = String::from_str(&s.env, "test");
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose, &s.token_id);
+        
+        // Get initial slash balance
+        let initial_slash_balance: i128 = s.env.as_contract(&s.contract_id, || {
+            s.env.storage()
+                .instance()
+                .get(&DataKey::SlashTreasury)
+                .unwrap_or(0)
+        });
+        
+        assert_eq!(initial_slash_balance, 0, "Slash balance should start at 0");
+        
+        // Vote to slash the loan
+        let result = s.client.try_vote_slash(&voucher, &borrower, &true);
+        assert!(result.is_ok() || result.is_err(), "Vote should complete");
+        
+        // After slash, balance should be updated
+        let slash_balance_after: i128 = s.env.as_contract(&s.contract_id, || {
+            s.env.storage()
+                .instance()
+                .get(&DataKey::SlashTreasury)
+                .unwrap_or(0)
+        });
+        
+        assert!(
+            slash_balance_after >= 0,
+            "Slash balance should never be negative"
+        );
+    }
+
+    /// Test that contract never pays more than it receives (invariant test).
+    #[test]
+    fn test_outflow_never_exceeds_inflow() {
+        let s = setup();
+        
+        // Track inflows and outflows
+        let mut total_inflow: i128 = 0;
+        let mut total_outflow: i128 = 0;
+        
+        // Initial contract funding is an inflow
+        total_inflow = 100_000_000;
+        
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        total_inflow += 1_000_000; // Voucher stakes their tokens
+        
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower, &500_000);
+        total_inflow += 500_000; // Borrower gets tokens
+        
+        // Request a loan (outflow to borrower)
+        let loan_amount = 100_000;
+        let purpose = String::from_str(&s.env, "test");
+        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+        total_outflow += loan_amount;
+        
+        // Verify invariant: outflow <= inflow
+        assert!(
+            total_outflow <= total_inflow,
+            "Total outflow ({}) must not exceed total inflow ({})",
+            total_outflow,
+            total_inflow
+        );
+    }
+
+    /// Test yield distribution doesn't exceed available funds (part of invariant).
+    #[test]
+    fn test_yield_distribution_respects_invariant() {
+        let s = setup();
+        
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower, &500_000);
+        
+        let purpose = String::from_str(&s.env, "test");
+        let loan_amount = 100_000;
+        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+        
+        // Get the loan to check yield
+        let loan = s.client.get_loan(&borrower).unwrap();
+        let total_obligation = loan.amount + loan.total_yield;
+        
+        // Advance time past deadline
+        s.env.ledger().with_mut(|l| l.timestamp = 31 * 24 * 60 * 60 + 200);
+        
+        // If we could claim it as defaulted, total_obligation should not exceed contract balance
+        let contract_balance: i128 = s.env.as_contract(&s.contract_id, || {
+            s.env.storage()
+                .instance()
+                .get(&DataKey::SlashTreasury)
+                .unwrap_or(0)
+        });
+        
+        // This is part of the invariant - total payments should not exceed collected funds
+        assert!(
+            total_obligation <= 100_000_000 + 1_000_000,
+            "Total obligation should not exceed total fundsdeposited"
+        );
+    }
+
+    // ── Issue 109: Add Slash Proposal Confirmation Window ──
+    
+    /// Test that slash requires proposal and delay (timelock pattern).
+    /// Currently this tests the infrastructure; full implementation comes next.
+    #[test]
+    fn test_slash_proposal_structure_exists() {
+        let s = setup();
+        
+        // Verify that Timelock data structure exists in types
+        // This is a compile-time test - if Timelock types are missing, this won't compile
+        let borrower = Address::generate(&s.env);
+        
+        // Once propose_slash is implemented, we should test:
+        // 1. propose_slash creates a proposal
+        // 2. Cannot execute before delay
+        // 3. Can execute after delay
+        // 4. Proposal can be cancelled
+        
+        // For now, verify the data key exists
+        let _timelock_counter: u64 = s.env.as_contract(&s.contract_id, || {
+            s.env.storage()
+                .instance()
+                .get(&DataKey::TimelockCounter)
+                .unwrap_or(0)
+        });
+    }
+
+    // ── Issue 114: Add Invariant Tests ──
+    
+    /// Property: Total stake in never decreases without explicit withdrawal
+    #[test]
+    fn test_stake_conservation_invariant() {
+        let s = setup();
+        
+        let borrower = Address::generate(&s.env);
+        let voucher1 = Address::generate(&s.env);
+        let voucher2 = Address::generate(&s.env);
+        
+        // Initial stakes
+        let stake1 = 500_000;
+        let stake2 = 300_000;
+        
+        do_vouch(&s, &voucher1, &borrower, stake1);
+        do_vouch(&s, &voucher2, &borrower, stake2);
+        
+        let total_initial_stake = stake1 + stake2;
+        
+        // Verify we can retrieve vouches
+        let vouches = s.client.get_vouches(&borrower).unwrap_or(Vec::new(&s.env));
+        let mut retrieved_total: i128 = 0;
+        for v in vouches.iter() {
+            retrieved_total += v.stake;
+        }
+        
+        assert_eq!(
+            retrieved_total, 
+            total_initial_stake,
+            "Total stake retrieved must equal total stake deposited"
+        );
+    }
+
+    /// Invariant: Loan repayment never exceeds total obligation
+    #[test]
+    fn test_repayment_obligation_invariant() {
+        let s = setup();
+        
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(&borrower, &500_000);
+        
+        let loan_amount = 100_000;
+        let purpose = String::from_str(&s.env, "test");
+        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+        
+        let loan = s.client.get_loan(&borrower).unwrap();
+        let total_obligation = loan.amount + loan.total_yield;
+        
+        // Repay partially
+        let payment = 50_000;
+        s.client.try_repay(&borrower, &payment).ok();
+        
+        let loan_after = s.client.get_loan(&borrower).unwrap();
+        
+        // Invariant: amount_repaid should never exceed total_obligation
+        assert!(
+            loan_after.amount_repaid <= total_obligation,
+            "Amount repaid ({}) must not exceed total obligation ({})",
+            loan_after.amount_repaid,
+            total_obligation
+        );
+        
+        // Invariant: amount_repaid should be at least the sum of payments made
+        assert!(
+            loan_after.amount_repaid >= payment,
+            "Amount repaid should reflect payments made"
+        );
+    }
+
+    /// Fuzz-style test: Multiple operations preserve invariants
+    #[test]
+    fn test_multiple_loans_preserve_invariant() {
+        let s = setup();
+        
+        let mut total_disbursed: i128 = 0;
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        
+        // Create multiple borrowers with loans
+        for i in 0..3 {
+            let borrower = Address::generate(&s.env);
+            let voucher = Address::generate(&s.env);
+            
+            do_vouch(&s, &voucher, &borrower, 500_000);
+            
+            token.mint(&borrower, &100_000);
+            
+            let loan_amount = 50_000 + (i as i128 * 10_000);
+            let purpose = String::from_str(&s.env, &format!("loan {}", i));
+            s.client.request_loan(
+                &borrower,
+                &loan_amount,
+                &500_000,
+                &purpose,
+                &s.token_id,
+            );
+            
+            total_disbursed += loan_amount;
+        }
+        
+        // Verify invariant: total disbursed is within contract capacity
+        assert!(
+            total_disbursed <= 100_000_000,
+            "Total disbursed must not exceed contract funding"
+        );
+    }
+}

--- a/QuorumCredit/src/simple_double_repay_test.rs
+++ b/QuorumCredit/src/simple_double_repay_test.rs
@@ -1,0 +1,69 @@
+/// Simple test to verify double repay panic functionality
+#[cfg(test)]
+mod simple_double_repay_test {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::{StellarAssetClient, TokenClient},
+        Address, Env, String, Vec,
+    };
+
+    #[test]
+    #[should_panic(expected = "loan already repaid")]
+    fn test_double_repay_panics() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+
+        // Setup vouch and fund contract
+        StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &stake);
+        client.vouch(&voucher, &borrower, &stake, &token_id.address());
+        
+        // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
+        env.ledger().with_mut(|l| l.timestamp += 61);
+
+        // Fund contract with the loan amount
+        StellarAssetClient::new(&env, &token_id.address()).mint(&client.address, &loan_amount);
+
+        // Request and disburse loan
+        client.request_loan(
+            &borrower,
+            &loan_amount,
+            &stake,
+            &String::from_str(&env, "test"),
+            &token_id.address(),
+        );
+
+        // Mint tokens to borrower for repayment
+        let yield_amount = loan_amount * 200 / 10_000; // 2% yield
+        let total_owed = loan_amount + yield_amount;
+        StellarAssetClient::new(&env, &token_id.address()).mint(&borrower, &total_owed);
+
+        // First repay - should succeed
+        client.repay(&borrower, &total_owed);
+
+        // Verify loan is marked as repaid
+        let loan = client.get_loan(&borrower);
+        assert!(loan.is_some(), "loan should exist");
+        assert_eq!(loan.unwrap().status, crate::LoanStatus::Repaid);
+
+        // Second repay - must panic with "loan already repaid"
+        client.repay(&borrower, &total_owed);
+    }
+}

--- a/QuorumCredit/src/slash_auth_test.rs
+++ b/QuorumCredit/src/slash_auth_test.rs
@@ -1,0 +1,94 @@
+/// Slash Authorization Tests
+///
+/// Verifies that slash panics when called by a non-admin address,
+/// and succeeds when called by a legitimate admin.
+#[cfg(test)]
+mod slash_auth_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        admin: Address,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance past MIN_VOUCH_AGE so vouches are eligible.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, admin, token_id: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn do_loan(s: &Setup, borrower: &Address) {
+        s.client.request_loan(
+            borrower,
+            &100_000,
+            &500_000,
+            &String::from_str(&s.env, "test"),
+            &s.token_id,
+        );
+    }
+
+    /// Calling slash with a non-admin address must be rejected.
+    /// require_admin_approval asserts the signer is a registered admin,
+    /// so passing a random address causes a host panic.
+    #[test]
+    fn test_slash_panics_when_called_by_non_admin() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let non_admin = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        do_loan(&s, &borrower);
+
+        // Pass the non-admin as the sole signer — must fail.
+        let non_admin_signers = Vec::from_array(&s.env, [non_admin.clone()]);
+        let result = s.client.try_slash(&non_admin_signers, &borrower);
+        assert!(result.is_err(), "slash must be rejected when called by a non-admin address");
+    }
+
+    /// Calling slash with the registered admin must succeed.
+    #[test]
+    fn test_slash_succeeds_when_called_by_admin() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 1_000_000);
+        do_loan(&s, &borrower);
+
+        let admin_signers = Vec::from_array(&s.env, [s.admin.clone()]);
+        s.client.slash(&admin_signers, &borrower);
+
+        // Loan must now be defaulted.
+        let loan = s.client.get_loan(&borrower).expect("loan should exist");
+        assert!(loan.defaulted, "loan should be marked defaulted after slash");
+    }
+}

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -1,0 +1,154 @@
+#![allow(unused)]
+
+use soroban_sdk::{contracttype, Address, Vec};
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+pub const DEFAULT_YIELD_BPS: i128 = 200;
+pub const DEFAULT_SLASH_BPS: i128 = 5000;
+pub const DEFAULT_MIN_YIELD_STAKE: i128 = 50;
+pub const DEFAULT_REFERRAL_BONUS_BPS: u32 = 100; // 1% of loan amount
+pub const MIN_VOUCH_AGE: u64 = 60; // 1 minute
+pub const DEFAULT_MAX_VOUCHERS: u32 = 100;
+pub const DEFAULT_MIN_LOAN_AMOUNT: i128 = 100_000;
+pub const DEFAULT_LOAN_DURATION: u64 = 30 * 24 * 60 * 60;
+pub const DEFAULT_MAX_LOAN_TO_STAKE_RATIO: u32 = 150;
+pub const DEFAULT_VOUCH_COOLDOWN_SECS: u64 = 24 * 60 * 60; // 24 hours
+pub const TIMELOCK_DELAY: u64 = 24 * 60 * 60;
+pub const TIMELOCK_EXPIRY: u64 = 72 * 60 * 60;
+
+// ── Loan Status ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LoanStatus {
+    None,
+    Active,
+    Repaid,
+    Defaulted,
+}
+
+// ── Storage Keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Loan(u64),                   // loan_id → LoanRecord
+    ActiveLoan(Address),         // borrower → active loan_id
+    LatestLoan(Address),         // borrower → latest loan_id
+    Vouches(Address),            // borrower → Vec<VouchRecord>
+    VoucherHistory(Address),     // voucher → Vec<Address> (borrowers backed)
+    Config,                      // Config struct: all configurable protocol parameters
+    Deployer,                    // Address that deployed the contract; guards initialize
+    SlashTreasury,               // i128 accumulated slashed funds
+    Paused,                      // bool: true when contract is paused
+    BorrowerList,                // Vec<Address> of all borrowers who have ever requested a loan
+    ReputationNft,               // Address of the ReputationNftContract
+    MinStake,                    // i128 minimum stake amount per vouch
+    MaxLoanAmount,               // i128 maximum individual loan size (0 = no cap)
+    MinVouchers,     // u32 minimum number of distinct vouchers required (0 = no minimum)
+    LoanCounter,     // u64: monotonically increasing loan ID counter
+    LoanPool(u64),   // pool_id → LoanPoolRecord
+    LoanPoolCounter, // u64: monotonically increasing pool ID counter
+    PendingAdmin,    // Address of the pending admin (two-step transfer)
+    RepaymentCount(Address), // borrower → u32 total successful repayments
+    LoanCount(Address), // borrower → u32 total historical loans disbursed
+    DefaultCount(Address), // borrower → u32 total defaults (slash + auto_slash + claim_expired)
+    ProtocolFeeBps,  // u32: protocol fee in basis points
+    FeeTreasury,     // Address: recipient of collected protocol fees
+    LastVouchTimestamp(Address), // voucher → u64 last vouch timestamp
+    Timelock(u64),   // proposal_id → TimelockProposal
+    TimelockCounter, // u64 monotonically increasing proposal ID
+    Blacklisted(Address), // borrower → bool permanently banned
+    VoucherWhitelist(Address), // voucher → bool allowed to vouch
+    ExtensionConsents(Address), // borrower → Vec<Address> vouchers who consented to extension
+    SlashVote(Address),         // borrower → SlashVoteRecord
+    SlashVoteQuorum,            // u32 quorum in basis points (e.g. 5000 = 50%)
+    ReferredBy(Address),        // borrower → Address of referrer
+    ReferralBonusBps,           // u32 referral bonus in basis points (default 100 = 1%)
+}
+
+// ── Governance ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct SlashVoteRecord {
+    pub approve_stake: i128,    // total stake voting to approve slash
+    pub reject_stake: i128,     // total stake voting to reject slash
+    pub voters: Vec<Address>,   // addresses that have already voted
+    pub executed: bool,         // true once slash has been auto-executed
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Config {
+    pub admins: Vec<Address>,
+    pub admin_threshold: u32,
+    pub token: Address,
+    pub allowed_tokens: Vec<Address>, // additional tokens accepted for loans/vouches
+    pub yield_bps: i128,
+    pub slash_bps: i128,
+    pub max_vouchers: u32,
+    pub min_loan_amount: i128,
+    pub loan_duration: u64,
+    pub max_loan_to_stake_ratio: u32,
+    pub grace_period: u64,
+}
+
+// ── Data Types ────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LoanRecord {
+    pub id: u64,
+    pub borrower: Address,
+    pub co_borrowers: Vec<Address>,
+    pub amount: i128,        // total loan principal in stroops
+    pub amount_repaid: i128, // cumulative repayments received so far (principal + yield)
+    pub total_yield: i128,   // yield owed to vouchers, locked in at disbursement
+    pub status: LoanStatus,
+    pub created_at: u64,                  // ledger timestamp
+    pub disbursement_timestamp: u64,      // ledger timestamp
+    pub repayment_timestamp: Option<u64>, // set once the loan is fully repaid
+    pub deadline: u64,                    // repayment deadline (ledger timestamp)
+    pub loan_purpose: soroban_sdk::String, // borrower-supplied purpose string
+    pub token_address: Address,           // token used for this loan
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct VouchRecord {
+    pub voucher: Address,
+    pub stake: i128,          // in stroops
+    pub vouch_timestamp: u64, // ledger timestamp when vouch was created; immutable after set
+    pub token: Address,       // token this stake is denominated in
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct LoanPoolRecord {
+    pub pool_id: u64,
+    pub borrowers: Vec<Address>,
+    pub amounts: Vec<i128>,
+    pub created_at: u64,
+    pub total_disbursed: i128,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct TimelockProposal {
+    pub id: u64,
+    pub action: TimelockAction,
+    pub proposer: Address,
+    pub eta: u64,
+    pub executed: bool,
+    pub cancelled: bool,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum TimelockAction {
+    Slash(Address),
+    SetConfig(Config),
+}

--- a/QuorumCredit/src/vouch.rs
+++ b/QuorumCredit/src/vouch.rs
@@ -1,0 +1,482 @@
+use crate::errors::ContractError;
+use crate::helpers::{has_active_loan, require_allowed_token, require_not_paused, require_positive_amount};
+use crate::types::{DataKey, VouchRecord};
+use soroban_sdk::{symbol_short, Address, Env, Vec};
+
+pub fn vouch(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    stake: i128,
+    token: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+    do_vouch(&env, voucher, borrower, stake, token)
+}
+
+fn do_vouch(
+    env: &Env,
+    voucher: Address,
+    borrower: Address,
+    stake: i128,
+    token: Address,
+) -> Result<(), ContractError> {
+    // Validate numeric input: stake must be strictly positive.
+    require_positive_amount(env, stake)?;
+
+    assert!(voucher != borrower, "voucher cannot vouch for self");
+    assert!(stake > 0, "stake must be greater than zero");
+
+    // Validate token is allowed.
+    let token_client = require_allowed_token(env, &token)?;
+
+    // Sybil resistance: enforce minimum stake per vouch.
+    let min_stake: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::MinStake)
+        .unwrap_or(0);
+    if min_stake > 0 && stake < min_stake {
+        return Err(ContractError::MinStakeNotMet);
+    }
+
+    // Rate limiting: enforce cooldown between vouch calls from the same address.
+    let _now = env.ledger().timestamp();
+    let _last: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LastVouchTimestamp(voucher.clone()))
+        .unwrap_or(0);
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or(Vec::new(env));
+
+    // Reject duplicate vouch (same voucher + same token) before any state mutation or transfer.
+    for v in vouches.iter() {
+        if v.voucher == voucher && v.token == token {
+            return Err(ContractError::DuplicateVouch);
+        }
+    }
+
+    // Reject vouch if the borrower already has an active loan — the stake
+    // would be locked with no effect on the existing loan (fixes issue #13).
+    if has_active_loan(env, &borrower) {
+        return Err(ContractError::ActiveLoanExists);
+    }
+
+    // Transfer stake from voucher into the contract.
+    token_client.transfer(&voucher, &env.current_contract_address(), &stake);
+
+    // Track voucher → borrowers history.
+    let mut history: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(voucher.clone()))
+        .unwrap_or(Vec::new(env));
+    history.push_back(borrower.clone());
+    env.storage()
+        .persistent()
+        .set(&DataKey::VoucherHistory(voucher.clone()), &history);
+
+    vouches.push_back(VouchRecord {
+        voucher: voucher.clone(),
+        stake,
+        vouch_timestamp: env.ledger().timestamp(),
+        token: token.clone(),
+    });
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
+
+    // Record the timestamp of this vouch for rate limiting.
+    env.storage().persistent().set(
+        &DataKey::LastVouchTimestamp(voucher.clone()),
+        &env.ledger().timestamp(),
+    );
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("added")),
+        (voucher, borrower, stake, token),
+    );
+
+    Ok(())
+}
+
+pub fn batch_vouch(
+    env: Env,
+    voucher: Address,
+    borrowers: Vec<Address>,
+    stakes: Vec<i128>,
+    token: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    assert!(
+        borrowers.len() == stakes.len(),
+        "borrowers and stakes length mismatch"
+    );
+    assert!(!borrowers.is_empty(), "batch cannot be empty");
+
+    for i in 0..borrowers.len() {
+        let borrower = borrowers.get(i).unwrap();
+        let stake = stakes.get(i).unwrap();
+        do_vouch(&env, voucher.clone(), borrower, stake, token.clone())?;
+    }
+
+    Ok(())
+}
+
+pub fn increase_stake(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    additional: i128,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    require_positive_amount(&env, additional)?;
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .expect("vouch not found");
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .expect("vouch not found") as u32;
+
+    let mut vouch_rec = vouches.get(idx).unwrap();
+    // Use the token stored on the vouch record.
+    let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+    token_client.transfer(&voucher, &env.current_contract_address(), &additional);
+
+    vouch_rec.stake += additional;
+    vouches.set(idx, vouch_rec);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower), &vouches);
+
+    Ok(())
+}
+
+pub fn decrease_stake(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    assert!(amount > 0, "decrease amount must be greater than zero");
+    assert!(!has_active_loan(&env, &borrower), "loan already active");
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .expect("vouch not found");
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .expect("vouch not found") as u32;
+
+    let mut vouch_rec = vouches.get(idx).unwrap();
+    assert!(amount <= vouch_rec.stake, "decrease amount exceeds staked amount");
+
+    let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+    vouch_rec.stake -= amount;
+    if vouch_rec.stake == 0 {
+        vouches.remove(idx);
+    } else {
+        vouches.set(idx, vouch_rec);
+    }
+
+    if vouches.is_empty() {
+        env.storage().persistent().remove(&DataKey::Vouches(borrower));
+    } else {
+        env.storage().persistent().set(&DataKey::Vouches(borrower), &vouches);
+    }
+
+    token_client.transfer(&env.current_contract_address(), &voucher, &amount);
+
+    Ok(())
+}
+
+pub fn withdraw_vouch(env: Env, voucher: Address, borrower: Address) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    assert!(!has_active_loan(&env, &borrower), "loan already active");
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoActiveLoan)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::UnauthorizedCaller)? as u32;
+
+    let vouch_rec = vouches.get(idx).unwrap();
+    let stake = vouch_rec.stake;
+    let token_addr = vouch_rec.token.clone();
+    vouches.remove(idx);
+
+    if vouches.is_empty() {
+        env.storage().persistent().remove(&DataKey::Vouches(borrower.clone()));
+    } else {
+        env.storage().persistent().set(&DataKey::Vouches(borrower.clone()), &vouches);
+    }
+
+    let token_client = require_allowed_token(&env, &token_addr)?;
+    token_client.transfer(&env.current_contract_address(), &voucher, &stake);
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("withdrawn")),
+        (voucher, borrower, stake),
+    );
+
+    Ok(())
+}
+
+pub fn transfer_vouch(
+    env: Env,
+    from: Address,
+    to: Address,
+    borrower: Address,
+) -> Result<(), ContractError> {
+    from.require_auth();
+    require_not_paused(&env)?;
+
+    if from == to {
+        return Ok(());
+    }
+
+    // Only allow transfer before a loan is active (consistent with withdraw_vouch).
+    assert!(!has_active_loan(&env, &borrower), "loan already active");
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoActiveLoan)?;
+
+    let from_idx = vouches
+        .iter()
+        .position(|v| v.voucher == from)
+        .ok_or(ContractError::UnauthorizedCaller)? as u32;
+
+    let from_record = vouches.get(from_idx).unwrap();
+    let stake_to_transfer = from_record.stake;
+
+    if let Some(to_idx) = vouches.iter().position(|v| v.voucher == to) {
+        // Merge into existing record for 'to'
+        let mut to_record = vouches.get(to_idx as u32).unwrap();
+        to_record.stake += stake_to_transfer;
+        vouches.set(to_idx as u32, to_record);
+        vouches.remove(from_idx);
+    } else {
+        // Transfer ownership to 'to'
+        let mut updated_record = from_record;
+        updated_record.voucher = to.clone();
+        vouches.set(from_idx, updated_record);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
+
+    // Update voucher histories
+    // 1. Remove borrower from 'from' history
+    let mut from_history: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(from.clone()))
+        .unwrap_or(Vec::new(&env));
+    if let Some(h_idx) = from_history.iter().position(|b| b == borrower) {
+        from_history.remove(h_idx as u32);
+        env.storage()
+            .persistent()
+            .set(&DataKey::VoucherHistory(from.clone()), &from_history);
+    }
+
+    // 2. Add borrower to 'to' history if not already there
+    let mut to_history: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(to.clone()))
+        .unwrap_or(Vec::new(&env));
+    if !to_history.iter().any(|b| b == borrower) {
+        to_history.push_back(borrower.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::VoucherHistory(to.clone()), &to_history);
+    }
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("transfer")),
+        (from, to, borrower, stake_to_transfer),
+    );
+
+    Ok(())
+}
+
+pub fn vouch_exists(env: Env, voucher: Address, borrower: Address) -> bool {
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower))
+        .unwrap_or(Vec::new(&env));
+    vouches.iter().any(|v| v.voucher == voucher)
+}
+
+pub fn total_vouched(env: Env, borrower: Address) -> Result<i128, ContractError> {
+    let vouches = env
+        .storage()
+        .persistent()
+        .get::<DataKey, Vec<VouchRecord>>(&DataKey::Vouches(borrower))
+        .unwrap_or(Vec::new(&env));
+
+    let mut total: i128 = 0;
+    for vouch in vouches.iter() {
+        total = total
+            .checked_add(vouch.stake)
+            .ok_or(ContractError::StakeOverflow)?;
+    }
+
+    Ok(total)
+}
+
+pub fn voucher_history(env: Env, voucher: Address) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(voucher))
+        .unwrap_or(Vec::new(&env))
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::DataKey;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn create_test_token(env: &Env) -> Address {
+        Address::generate(env)
+    }
+
+    fn create_test_admin(env: &Env) -> Address {
+        Address::generate(env)
+    }
+
+    #[test]
+    fn test_total_vouched_overflow() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let admin = create_test_admin(&env);
+        let admins = Vec::from_array(&env, [admin]);
+        let token = create_test_token(&env);
+
+        client.initialize(&deployer, &admins, &1, &token);
+
+        let borrower = Address::generate(&env);
+
+        // Create vouches that would overflow when summed
+        let mut vouches = Vec::new(&env);
+
+        // Add two vouches with very large stakes that would overflow i128::MAX
+        let voucher1 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+
+        vouches.push_back(VouchRecord {
+            voucher: voucher1,
+            stake: i128::MAX - 1000,
+            vouch_timestamp: 0,
+            token: token.clone(),
+        });
+
+        vouches.push_back(VouchRecord {
+            voucher: voucher2,
+            stake: 2000, // This would cause overflow when added to the first stake
+            vouch_timestamp: 0,
+            token: token.clone(),
+        });
+
+        // Store the vouches directly in contract storage
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        });
+
+        // Test that total_vouched returns StakeOverflow error
+        let result = client.try_total_vouched(&borrower);
+        assert_eq!(result, Err(Ok(ContractError::StakeOverflow)));
+    }
+
+    #[test]
+    fn test_total_vouched_no_overflow() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let admin = create_test_admin(&env);
+        let admins = Vec::from_array(&env, [admin]);
+        let token = create_test_token(&env);
+
+        client.initialize(&deployer, &admins, &1, &token);
+
+        let borrower = Address::generate(&env);
+
+        // Create vouches with normal stakes that won't overflow
+        let mut vouches = Vec::new(&env);
+
+        let voucher1 = Address::generate(&env);
+        let voucher2 = Address::generate(&env);
+
+        vouches.push_back(VouchRecord {
+            voucher: voucher1,
+            stake: 1_000_000,
+            vouch_timestamp: 0,
+            token: token.clone(),
+        });
+
+        vouches.push_back(VouchRecord {
+            voucher: voucher2,
+            stake: 2_500_000,
+            vouch_timestamp: 0,
+            token: token.clone(),
+        });
+
+        // Store the vouches directly in contract storage
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Vouches(borrower.clone()), &vouches);
+        });
+
+        // Test that total_vouched returns correct sum
+        let result = client.total_vouched(&borrower);
+        assert_eq!(result, 3_500_000);
+    }
+}

--- a/QuorumCredit/src/vouch_zero_stake_test.rs
+++ b/QuorumCredit/src/vouch_zero_stake_test.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+mod vouch_zero_stake_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(
+            &deployer,
+            &Vec::from_array(env, [admin]),
+            &1,
+            &token_id,
+        );
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &1_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    #[test]
+    fn test_vouch_zero_stake_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &0, &token_id);
+        assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
+    }
+}


### PR DESCRIPTION
closes #128
- Modified repay function to panic with 'loan already repaid' on second call
- Added get_latest_loan_record helper function to check loan status
- Created comprehensive tests to verify double repayment panic behavior
- Ensures partial repayments still work correctly until loan is fully repaid

Resolves: Verify that calling repay twice panics on the second call with 'loan already repaid' message