### PR TITLE
dx: add Makefile for build, test, and deployment workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: build test deploy-testnet deploy-mainnet
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+CONTRACT_DIR := QuorumCredit
+WASM_TARGET  := wasm32-unknown-unknown
+
+# ── Targets ───────────────────────────────────────────────────────────────────
+
+## Compile the contract (native + WASM release build)
+build:
+	cd $(CONTRACT_DIR) && cargo build --target $(WASM_TARGET) --release
+
+## Run the full test suite
+test:
+	cd $(CONTRACT_DIR) && cargo test
+
+## Deploy to Stellar testnet
+deploy-testnet:
+	stellar contract deploy \
+		--wasm $(CONTRACT_DIR)/target/$(WASM_TARGET)/release/quorum_credit.wasm \
+		--network testnet \
+		--source $(DEPLOYER_SECRET_KEY)
+
+## Deploy to Stellar mainnet — requires interactive confirmation
+deploy-mainnet:
+	@echo "WARNING: You are about to deploy to MAINNET."
+	@read -p "Are you sure you want to deploy to MAINNET? [y/N]: " confirm && \
+		[ "$${confirm:-N}" = "y" ] || [ "$${confirm:-N}" = "Y" ] || \
+		(echo "Deployment aborted."; exit 1)
+	stellar contract deploy \
+		--wasm $(CONTRACT_DIR)/target/$(WASM_TARGET)/release/quorum_credit.wasm \
+		--network mainnet \
+		--source $(DEPLOYER_SECRET_KEY)


### PR DESCRIPTION

## Summary

Adds a `Makefile` to the repository root to automate common developer workflows for the QuorumCredit project.

## Targets

| Command | Description |
|---|---|
| `make build` | Compiles the contract to WASM release (`cargo build --target wasm32-unknown-unknown --release`) |
| `make test` | Runs the full test suite (`cargo test`) |
| `make deploy-testnet` | Deploys to Stellar testnet using `$DEPLOYER_SECRET_KEY` |
| `make deploy-mainnet` | Deploys to Stellar mainnet — **requires interactive `y/Y` confirmation** before proceeding |

## Safety

`deploy-mainnet` prompts:

WARNING: You are about to deploy to MAINNET.
Are you sure you want to deploy to MAINNET? [y/N]:
Any input other than `y` or `Y` aborts with a non-zero exit code, preventing accidental mainnet deploys in scripts.

## Notes
- All targets are `.PHONY`
- Deployment targets read `DEPLOYER_SECRET_KEY` from the environment (set in `.env`, never committed)
- Run `make build` before any deploy target to ensure the WASM artifact is up to date


Closes #187 
