### PR TITLE
chore: add CODEOWNERS to require review for src/lib.rs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from core maintainers for changes to the contract source
+src/lib.rs @QuorumCredit/core-maintainers
+


### PR DESCRIPTION
## This PR adds the 
.github/CODEOWNERS

- file assigning
src/lib.rs to @QuorumCredit/core-maintainers as requested in issue #194. Note: As a contributor, I don't have access to the repository settings, so a repository admin will need to activate the 'Require review from Code Owners' branch protection rule in the settings upon merging.

Closes #194 