### PR TITLE
feat: add GitHub Actions release workflow for WASM artifact (Issue #191)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release WASM Artifact
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-release:
+    name: Build WASM and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build WASM (release)
+        run: cargo build --release --target wasm32-unknown-unknown
+
+      - name: Rename artifact
+        run: |
+          cp target/wasm32-unknown-unknown/release/quorum_credit.wasm \
+             quorum_credit_${{ github.ref_name }}.wasm
+
+      - name: Generate SHA256 checksum
+        run: |
+          sha256sum quorum_credit_${{ github.ref_name }}.wasm \
+            > quorum_credit_${{ github.ref_name }}.wasm.sha256
+
+      - name: Create GitHub Release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          name: QuorumCredit ${{ github.ref_name }}
+          body: |
+            ## QuorumCredit ${{ github.ref_name }}
+
+            ### Assets
+            - `quorum_credit_${{ github.ref_name }}.wasm` — compiled CosmWasm contract
+            - `quorum_credit_${{ github.ref_name }}.wasm.sha256` — SHA256 checksum
+
+            ### Verify checksum
+            ```bash
+            sha256sum -c quorum_credit_${{ github.ref_name }}.wasm.sha256
+            ```
+          files: |
+            quorum_credit_${{ github.ref_name }}.wasm
+            quorum_credit_${{ github.ref_name }}.wasm.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Trigger on version tags (v*.*.*)
- Build WASM with wasm32-unknown-unknown target
- Upload .wasm and .sha256 checksum as GitHub Release assets

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed

closes #191 
