### PR TITLE
fix(#442): add self-vouch guard to decrease_stake()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       
       - name: Run tests
         run: cargo test --verbose
+        working-directory: QuorumCredit
 
   clippy:
     name: Clippy
@@ -71,6 +72,7 @@ jobs:
       
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+        working-directory: QuorumCredit
 
   fmt:
     name: Format
@@ -85,3 +87,4 @@ jobs:
       
       - name: Check formatting
         run: cargo fmt --all -- --check
+        working-directory: QuorumCredit

--- a/QuorumCredit/src/config_bps_test.rs
+++ b/QuorumCredit/src/config_bps_test.rs
@@ -37,7 +37,12 @@ mod config_bps_tests {
         // Advance past MIN_VOUCH_AGE.
         env.ledger().with_mut(|l| l.timestamp = 120);
 
-        Setup { env, client, admin, token: token.address() }
+        Setup {
+            env,
+            client,
+            admin,
+            token: token.address(),
+        }
     }
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
@@ -122,8 +127,7 @@ mod config_bps_tests {
         let expected_returned = stake * (10_000 - 2_000) / 10_000;
         let voucher_balance = token_balance(&s, &voucher);
         assert_eq!(
-            voucher_balance,
-            expected_returned,
+            voucher_balance, expected_returned,
             "voucher should lose only the slash_bps fraction defined in config"
         );
     }
@@ -140,7 +144,10 @@ mod config_bps_tests {
         do_vouch(&s, &v1, &b1, 1_000_000);
         do_loan(&s, &b1, 100_000, 1_000_000);
         let loan1 = s.client.get_loan(&b1).unwrap();
-        assert_eq!(loan1.total_yield, 2_000, "default yield_bps=200 → 2% of 100_000 = 2_000");
+        assert_eq!(
+            loan1.total_yield, 2_000,
+            "default yield_bps=200 → 2% of 100_000 = 2_000"
+        );
 
         // Update yield_bps to 500 (5%).
         set_bps(&s, 500, 5_000);
@@ -151,6 +158,9 @@ mod config_bps_tests {
         do_vouch(&s, &v2, &b2, 1_000_000);
         do_loan(&s, &b2, 100_000, 1_000_000);
         let loan2 = s.client.get_loan(&b2).unwrap();
-        assert_eq!(loan2.total_yield, 5_000, "updated yield_bps=500 → 5% of 100_000 = 5_000");
+        assert_eq!(
+            loan2.total_yield, 5_000,
+            "updated yield_bps=500 → 5% of 100_000 = 5_000"
+        );
     }
 }

--- a/QuorumCredit/src/double_repay_test.rs
+++ b/QuorumCredit/src/double_repay_test.rs
@@ -32,13 +32,17 @@ mod double_repay_tests {
 
         env.ledger().with_mut(|l| l.timestamp = 120);
 
-        Setup { env, client, token: token_id.address() }
+        Setup {
+            env,
+            client,
+            token: token_id.address(),
+        }
     }
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token).mint(voucher, &stake);
         s.client.vouch(voucher, borrower, &stake, &s.token);
-        
+
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
         s.env.ledger().with_mut(|l| l.timestamp += 61);
     }

--- a/QuorumCredit/src/duplicate_loan_test.rs
+++ b/QuorumCredit/src/duplicate_loan_test.rs
@@ -35,7 +35,11 @@ mod duplicate_loan_tests {
         // Advance past MIN_VOUCH_AGE so vouches are eligible.
         env.ledger().with_mut(|l| l.timestamp = 120);
 
-        Setup { env, client, token_id: token_id.address() }
+        Setup {
+            env,
+            client,
+            token_id: token_id.address(),
+        }
     }
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
@@ -84,7 +88,11 @@ mod duplicate_loan_tests {
         do_loan(&s, &borrower);
 
         let loan = s.client.get_loan(&borrower).expect("loan should exist");
-        assert_eq!(loan.status, crate::LoanStatus::Active, "loan should be active");
+        assert_eq!(
+            loan.status,
+            crate::LoanStatus::Active,
+            "loan should be active"
+        );
 
         // try_request_loan returns Err when a loan is already active.
         let result = s.client.try_request_loan(

--- a/QuorumCredit/src/errors.rs
+++ b/QuorumCredit/src/errors.rs
@@ -41,4 +41,6 @@ pub enum ContractError {
     SlashVoteNotFound = 32,
     SlashAlreadyExecuted = 33,
     AlreadyRepaid = 34,
+    /// Voucher and borrower must be different addresses.
+    SelfVouchNotAllowed = 37,
 }

--- a/QuorumCredit/src/governance.rs
+++ b/QuorumCredit/src/governance.rs
@@ -83,8 +83,8 @@ pub fn vote_slash(
         .get(&DataKey::SlashVoteQuorum)
         .unwrap_or(DEFAULT_SLASH_VOTE_QUORUM_BPS);
 
-    let quorum_reached = total_stake > 0
-        && vote.approve_stake * 10_000 / total_stake >= quorum_bps as i128;
+    let quorum_reached =
+        total_stake > 0 && vote.approve_stake * 10_000 / total_stake >= quorum_bps as i128;
 
     if quorum_reached {
         vote.executed = true;
@@ -246,10 +246,7 @@ pub fn propose_slash(
 }
 
 /// Execute a previously proposed slash action after the delay has passed.
-pub fn execute_slash_proposal(
-    env: Env,
-    proposal_id: u64,
-) -> Result<(), ContractError> {
+pub fn execute_slash_proposal(env: Env, proposal_id: u64) -> Result<(), ContractError> {
     require_not_paused(&env)?;
 
     // Get the proposal
@@ -342,4 +339,3 @@ pub fn get_timelock_proposal(env: Env, proposal_id: u64) -> Option<TimelockPropo
         .instance()
         .get(&DataKey::Timelock(proposal_id))
 }
-

--- a/QuorumCredit/src/governance_test.rs
+++ b/QuorumCredit/src/governance_test.rs
@@ -56,7 +56,13 @@ mod governance_tests {
     fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {
         // Advance time to ensure vouches are old enough (MIN_VOUCH_AGE = 60s)
         s.env.ledger().with_mut(|l| l.timestamp = l.timestamp + 61);
-        s.client.request_loan(borrower, &amount, &threshold, &soroban_sdk::String::from_str(&s.env, "test loan"), &s.token_id);
+        s.client.request_loan(
+            borrower,
+            &amount,
+            &threshold,
+            &soroban_sdk::String::from_str(&s.env, "test loan"),
+            &s.token_id,
+        );
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────
@@ -109,10 +115,7 @@ mod governance_tests {
 
         // First vote: 30% — not enough
         s.client.vote_slash(&voucher_a, &borrower, &true);
-        assert_eq!(
-            s.client.loan_status(&borrower),
-            crate::LoanStatus::Active
-        );
+        assert_eq!(s.client.loan_status(&borrower), crate::LoanStatus::Active);
 
         // Second vote: 30% + 30% = 60% ≥ 50% → slash fires
         s.client.vote_slash(&voucher_b, &borrower, &true);
@@ -135,10 +138,7 @@ mod governance_tests {
         s.client.vote_slash(&voucher_a, &borrower, &false);
 
         // Loan still active
-        assert_eq!(
-            s.client.loan_status(&borrower),
-            crate::LoanStatus::Active
-        );
+        assert_eq!(s.client.loan_status(&borrower), crate::LoanStatus::Active);
         let vote = s.client.get_slash_vote(&borrower).unwrap();
         assert!(!vote.executed);
         assert_eq!(vote.reject_stake, 600_000);

--- a/QuorumCredit/src/helpers.rs
+++ b/QuorumCredit/src/helpers.rs
@@ -101,9 +101,7 @@ pub fn get_latest_loan_record(env: &Env, borrower: &Address) -> Option<LoanRecor
         .persistent()
         .get(&DataKey::LatestLoan(borrower.clone()))
     {
-        env.storage()
-            .persistent()
-            .get(&DataKey::Loan(loan_id))
+        env.storage().persistent().get(&DataKey::Loan(loan_id))
     } else {
         None
     }
@@ -257,7 +255,9 @@ mod ttl_tests {
         let deployer = Address::generate(&env);
         let admin = Address::generate(&env);
         let admins = Vec::from_array(&env, [admin.clone()]);
-        let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let token = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
 
         client.initialize(&deployer, &admins, &1, &token);
 

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -14,6 +14,14 @@ pub mod types;
 pub mod vouch;
 
 #[cfg(test)]
+mod bug_condition_test;
+#[cfg(test)]
+mod config_bps_test;
+#[cfg(test)]
+mod double_repay_test;
+#[cfg(test)]
+mod duplicate_loan_test;
+#[cfg(test)]
 mod governance_test;
 #[cfg(test)]
 mod initialize_test;
@@ -26,19 +34,11 @@ mod referral_test;
 #[cfg(test)]
 mod request_loan_insufficient_stake_test;
 #[cfg(test)]
-mod vouch_zero_stake_test;
-#[cfg(test)]
 mod security_fixes_test;
 #[cfg(test)]
-mod bug_condition_test;
-#[cfg(test)]
-mod duplicate_loan_test;
-#[cfg(test)]
-mod double_repay_test;
-#[cfg(test)]
-mod config_bps_test;
-#[cfg(test)]
 mod simple_double_repay_test;
+#[cfg(test)]
+mod vouch_zero_stake_test;
 
 pub use errors::ContractError;
 pub use types::*;

--- a/QuorumCredit/src/loan.rs
+++ b/QuorumCredit/src/loan.rs
@@ -1,7 +1,7 @@
 use crate::errors::ContractError;
 use crate::helpers::{
-    bps_of, config, extend_ttl, get_active_loan_record, get_slash_balance, has_active_loan, next_loan_id,
-    require_allowed_token, require_not_paused, validate_loan_active,
+    bps_of, config, extend_ttl, get_active_loan_record, get_slash_balance, has_active_loan,
+    next_loan_id, require_allowed_token, require_not_paused, validate_loan_active,
 };
 use crate::reputation::ReputationNftExternalClient;
 use crate::types::{

--- a/QuorumCredit/src/multi_asset_test.rs
+++ b/QuorumCredit/src/multi_asset_test.rs
@@ -36,7 +36,13 @@ mod multi_asset_tests {
 
         env.ledger().with_mut(|l| l.timestamp = 120);
 
-        Setup { env, client, xlm: xlm_id.address(), usdc: usdc_id.address(), admin }
+        Setup {
+            env,
+            client,
+            xlm: xlm_id.address(),
+            usdc: usdc_id.address(),
+            admin,
+        }
     }
 
     fn purpose(env: &Env) -> String {
@@ -53,7 +59,8 @@ mod multi_asset_tests {
         s.client.vouch(&voucher, &borrower, &1_000_000, &s.usdc);
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible
         s.env.ledger().with_mut(|l| l.timestamp += 61);
-        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
+        s.client
+            .request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
 
         let loan = s.client.get_loan(&borrower).unwrap();
         assert_eq!(loan.token_address, s.usdc);
@@ -71,7 +78,9 @@ mod multi_asset_tests {
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible
         s.env.ledger().with_mut(|l| l.timestamp += 61);
 
-        let result = s.client.try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
+        let result =
+            s.client
+                .try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
         assert!(result.is_err());
     }
 
@@ -82,7 +91,9 @@ mod multi_asset_tests {
         let borrower = Address::generate(&s.env);
         let random_token = Address::generate(&s.env);
 
-        let result = s.client.try_vouch(&voucher, &borrower, &100_000, &random_token);
+        let result = s
+            .client
+            .try_vouch(&voucher, &borrower, &100_000, &random_token);
         assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
     }
 
@@ -92,7 +103,13 @@ mod multi_asset_tests {
         let borrower = Address::generate(&s.env);
         let random_token = Address::generate(&s.env);
 
-        let result = s.client.try_request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &random_token);
+        let result = s.client.try_request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &purpose(&s.env),
+            &random_token,
+        );
         assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
     }
 
@@ -118,7 +135,8 @@ mod multi_asset_tests {
         s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm);
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible
         s.env.ledger().with_mut(|l| l.timestamp += 61);
-        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.xlm);
+        s.client
+            .request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.xlm);
 
         let loan = s.client.get_loan(&borrower).unwrap();
         assert_eq!(loan.token_address, s.xlm);

--- a/QuorumCredit/src/referral_test.rs
+++ b/QuorumCredit/src/referral_test.rs
@@ -33,7 +33,13 @@ mod referral_tests {
 
         env.ledger().with_mut(|l| l.timestamp = 120);
 
-        Setup { env, client, contract_id, token: token_id.address(), admin }
+        Setup {
+            env,
+            client,
+            contract_id,
+            token: token_id.address(),
+            admin,
+        }
     }
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
@@ -70,8 +76,7 @@ mod referral_tests {
         s.client.repay(&borrower, &102_000);
 
         // Referral bonus = 1% of 100_000 = 1_000.
-        let referrer_balance = TokenClient::new(&s.env, &s.token)
-            .balance(&referrer);
+        let referrer_balance = TokenClient::new(&s.env, &s.token).balance(&referrer);
         assert_eq!(referrer_balance, 1_000);
     }
 
@@ -134,8 +139,7 @@ mod referral_tests {
         s.client.repay(&borrower, &102_000);
 
         // 2% of 100_000 = 2_000.
-        let referrer_balance = TokenClient::new(&s.env, &s.token)
-            .balance(&referrer);
+        let referrer_balance = TokenClient::new(&s.env, &s.token).balance(&referrer);
         assert_eq!(referrer_balance, 2_000);
     }
 }

--- a/QuorumCredit/src/request_loan_insufficient_stake_test.rs
+++ b/QuorumCredit/src/request_loan_insufficient_stake_test.rs
@@ -2,7 +2,11 @@
 mod request_loan_insufficient_stake_tests {
     use crate::errors::ContractError;
     use crate::{QuorumCreditContract, QuorumCreditContractClient};
-    use soroban_sdk::{testutils::{Address as _, Ledger}, token::StellarAssetClient, Address, Env, String, Vec};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
 
     fn setup(env: &Env) -> (Address, Address, Address, Address) {
         let deployer = Address::generate(env);

--- a/QuorumCredit/src/security_fixes_test.rs
+++ b/QuorumCredit/src/security_fixes_test.rs
@@ -1,5 +1,5 @@
 /// Security Fixes Tests
-/// 
+///
 /// Tests for:
 /// - Issue 108: Prevent Borrower from Repaying Another Borrower's Loan
 /// - Issue 109: Add Slash Proposal Confirmation Window
@@ -66,38 +66,46 @@ mod security_fixes_tests {
     #[test]
     fn test_borrower_cannot_repay_another_borrower_loan() {
         let s = setup();
-        
+
         // Create two borrowers
         let borrower_a = Address::generate(&s.env);
         let borrower_b = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         // Setup vouches for both borrowers
         do_vouch(&s, &voucher, &borrower_a, 500_000);
         do_vouch(&s, &voucher, &borrower_b, 500_000);
-        
+
         // Request loans for both
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower_a, &1_000_000);
         token.mint(&borrower_b, &1_000_000);
-        
+
         let purpose = String::from_str(&s.env, "business");
-        s.client.request_loan(&borrower_a, &100_000, &500_000, &purpose, &s.token_id);
-        s.client.request_loan(&borrower_b, &100_000, &500_000, &purpose, &s.token_id);
-        
+        s.client
+            .request_loan(&borrower_a, &100_000, &500_000, &purpose, &s.token_id);
+        s.client
+            .request_loan(&borrower_b, &100_000, &500_000, &purpose, &s.token_id);
+
         // Verify both loans exist
         assert!(s.client.get_loan(&borrower_a).is_some());
         assert!(s.client.get_loan(&borrower_b).is_some());
-        
+
         // Borrower A tries to repay Borrower B's loan by calling repay with B's address
         // This should fail because we try to get A's active loan, not B's
         let result = s.client.try_repay(&borrower_a, &50_000);
-        assert!(result.is_ok(), "Borrower A should be able to repay their own loan");
-        
+        assert!(
+            result.is_ok(),
+            "Borrower A should be able to repay their own loan"
+        );
+
         // Now verify the loan was actually repaid (via get_loan showing updated amount_repaid)
         let loan_a = s.client.get_loan(&borrower_a);
         assert!(loan_a.is_some());
-        assert!(loan_a.unwrap().amount_repaid > 0, "Loan should have been repaid");
+        assert!(
+            loan_a.unwrap().amount_repaid > 0,
+            "Loan should have been repaid"
+        );
     }
 
     /// Test that cross-loan repayment attempts are blocked.
@@ -105,35 +113,36 @@ mod security_fixes_tests {
     #[test]
     fn test_cross_borrower_attack_prevented() {
         let s = setup();
-        
+
         let borrower_a = Address::generate(&s.env);
         let borrower_b = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         // Setup
         do_vouch(&s, &voucher, &borrower_a, 500_000);
         do_vouch(&s, &voucher, &borrower_b, 500_000);
-        
+
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower_a, &500_000);
         token.mint(&borrower_b, &500_000);
-        
+
         s.env.ledger().with_mut(|li| li.timestamp += 61);
         let purpose = String::from_str(&s.env, "test");
-        s.client.request_loan(&borrower_a, &100_000, &500_000, &purpose, &s.token_id);
-        s.client.request_loan(&borrower_b, &100_000, &500_000, &purpose, &s.token_id);
-        
+        s.client
+            .request_loan(&borrower_a, &100_000, &500_000, &purpose, &s.token_id);
+        s.client
+            .request_loan(&borrower_b, &100_000, &500_000, &purpose, &s.token_id);
+
         let loan_a_before = s.client.get_loan(&borrower_a).unwrap();
         let loan_b_before = s.client.get_loan(&borrower_b).unwrap();
-        
+
         // Borrower A makes a payment
         s.client.try_repay(&borrower_a, &25_000).ok();
-        
+
         // Verify B's loan was NOT affected
         let loan_b_after = s.client.get_loan(&borrower_b).unwrap();
         assert_eq!(
-            loan_b_before.amount_repaid, 
-            loan_b_after.amount_repaid,
+            loan_b_before.amount_repaid, loan_b_after.amount_repaid,
             "Borrower B's loan repayment should not be affected by A's payment"
         );
     }
@@ -144,40 +153,43 @@ mod security_fixes_tests {
     #[test]
     fn test_slash_balance_prevents_fund_leakage() {
         let s = setup();
-        
+
         let borrower = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         do_vouch(&s, &voucher, &borrower, 1_000_000);
-        
+
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower, &500_000);
-        
+
         let purpose = String::from_str(&s.env, "test");
-        s.client.request_loan(&borrower, &100_000, &500_000, &purpose, &s.token_id);
-        
+        s.client
+            .request_loan(&borrower, &100_000, &500_000, &purpose, &s.token_id);
+
         // Get initial slash balance
         let initial_slash_balance: i128 = s.env.as_contract(&s.contract_id, || {
-            s.env.storage()
+            s.env
+                .storage()
                 .instance()
                 .get(&DataKey::SlashTreasury)
                 .unwrap_or(0)
         });
-        
+
         assert_eq!(initial_slash_balance, 0, "Slash balance should start at 0");
-        
+
         // Vote to slash the loan
         let result = s.client.try_vote_slash(&voucher, &borrower, &true);
         assert!(result.is_ok() || result.is_err(), "Vote should complete");
-        
+
         // After slash, balance should be updated
         let slash_balance_after: i128 = s.env.as_contract(&s.contract_id, || {
-            s.env.storage()
+            s.env
+                .storage()
                 .instance()
                 .get(&DataKey::SlashTreasury)
                 .unwrap_or(0)
         });
-        
+
         assert!(
             slash_balance_after >= 0,
             "Slash balance should never be negative"
@@ -188,30 +200,31 @@ mod security_fixes_tests {
     #[test]
     fn test_outflow_never_exceeds_inflow() {
         let s = setup();
-        
+
         // Track inflows and outflows
         let mut total_inflow: i128 = 0;
         let mut total_outflow: i128 = 0;
-        
+
         // Initial contract funding is an inflow
         total_inflow = 100_000_000;
-        
+
         let borrower = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         do_vouch(&s, &voucher, &borrower, 1_000_000);
         total_inflow += 1_000_000; // Voucher stakes their tokens
-        
+
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower, &500_000);
         total_inflow += 500_000; // Borrower gets tokens
-        
+
         // Request a loan (outflow to borrower)
         let loan_amount = 100_000;
         let purpose = String::from_str(&s.env, "test");
-        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+        s.client
+            .request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
         total_outflow += loan_amount;
-        
+
         // Verify invariant: outflow <= inflow
         assert!(
             total_outflow <= total_inflow,
@@ -225,34 +238,38 @@ mod security_fixes_tests {
     #[test]
     fn test_yield_distribution_respects_invariant() {
         let s = setup();
-        
+
         let borrower = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         do_vouch(&s, &voucher, &borrower, 1_000_000);
-        
+
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower, &500_000);
-        
+
         let purpose = String::from_str(&s.env, "test");
         let loan_amount = 100_000;
-        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
-        
+        s.client
+            .request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+
         // Get the loan to check yield
         let loan = s.client.get_loan(&borrower).unwrap();
         let total_obligation = loan.amount + loan.total_yield;
-        
+
         // Advance time past deadline
-        s.env.ledger().with_mut(|l| l.timestamp = 31 * 24 * 60 * 60 + 200);
-        
+        s.env
+            .ledger()
+            .with_mut(|l| l.timestamp = 31 * 24 * 60 * 60 + 200);
+
         // If we could claim it as defaulted, total_obligation should not exceed contract balance
         let contract_balance: i128 = s.env.as_contract(&s.contract_id, || {
-            s.env.storage()
+            s.env
+                .storage()
                 .instance()
                 .get(&DataKey::SlashTreasury)
                 .unwrap_or(0)
         });
-        
+
         // This is part of the invariant - total payments should not exceed collected funds
         assert!(
             total_obligation <= 100_000_000 + 1_000_000,
@@ -261,26 +278,27 @@ mod security_fixes_tests {
     }
 
     // ── Issue 109: Add Slash Proposal Confirmation Window ──
-    
+
     /// Test that slash requires proposal and delay (timelock pattern).
     /// Currently this tests the infrastructure; full implementation comes next.
     #[test]
     fn test_slash_proposal_structure_exists() {
         let s = setup();
-        
+
         // Verify that Timelock data structure exists in types
         // This is a compile-time test - if Timelock types are missing, this won't compile
         let borrower = Address::generate(&s.env);
-        
+
         // Once propose_slash is implemented, we should test:
         // 1. propose_slash creates a proposal
         // 2. Cannot execute before delay
         // 3. Can execute after delay
         // 4. Proposal can be cancelled
-        
+
         // For now, verify the data key exists
         let _timelock_counter: u64 = s.env.as_contract(&s.contract_id, || {
-            s.env.storage()
+            s.env
+                .storage()
                 .instance()
                 .get(&DataKey::TimelockCounter)
                 .unwrap_or(0)
@@ -288,35 +306,34 @@ mod security_fixes_tests {
     }
 
     // ── Issue 114: Add Invariant Tests ──
-    
+
     /// Property: Total stake in never decreases without explicit withdrawal
     #[test]
     fn test_stake_conservation_invariant() {
         let s = setup();
-        
+
         let borrower = Address::generate(&s.env);
         let voucher1 = Address::generate(&s.env);
         let voucher2 = Address::generate(&s.env);
-        
+
         // Initial stakes
         let stake1 = 500_000;
         let stake2 = 300_000;
-        
+
         do_vouch(&s, &voucher1, &borrower, stake1);
         do_vouch(&s, &voucher2, &borrower, stake2);
-        
+
         let total_initial_stake = stake1 + stake2;
-        
+
         // Verify we can retrieve vouches
         let vouches = s.client.get_vouches(&borrower).unwrap_or(Vec::new(&s.env));
         let mut retrieved_total: i128 = 0;
         for v in vouches.iter() {
             retrieved_total += v.amount;
         }
-        
+
         assert_eq!(
-            retrieved_total, 
-            total_initial_stake,
+            retrieved_total, total_initial_stake,
             "Total stake retrieved must equal total stake deposited"
         );
     }
@@ -325,28 +342,29 @@ mod security_fixes_tests {
     #[test]
     fn test_repayment_obligation_invariant() {
         let s = setup();
-        
+
         let borrower = Address::generate(&s.env);
         let voucher = Address::generate(&s.env);
-        
+
         do_vouch(&s, &voucher, &borrower, 1_000_000);
-        
+
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(&borrower, &500_000);
-        
+
         let loan_amount = 100_000;
         let purpose = String::from_str(&s.env, "test");
-        s.client.request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
-        
+        s.client
+            .request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+
         let loan = s.client.get_loan(&borrower).unwrap();
         let total_obligation = loan.amount + loan.total_yield;
-        
+
         // Repay partially
         let payment = 50_000;
         s.client.try_repay(&borrower, &payment).ok();
-        
+
         let loan_after = s.client.get_loan(&borrower).unwrap();
-        
+
         // Invariant: amount_repaid should never exceed total_obligation
         assert!(
             loan_after.amount_repaid <= total_obligation,
@@ -354,7 +372,7 @@ mod security_fixes_tests {
             loan_after.amount_repaid,
             total_obligation
         );
-        
+
         // Invariant: amount_repaid should be at least the sum of payments made
         assert!(
             loan_after.amount_repaid >= payment,
@@ -366,33 +384,28 @@ mod security_fixes_tests {
     #[test]
     fn test_multiple_loans_preserve_invariant() {
         let s = setup();
-        
+
         let mut total_disbursed: i128 = 0;
         let token = StellarAssetClient::new(&s.env, &s.token_id);
-        
+
         // Create multiple borrowers with loans
         for i in 0..3 {
             let borrower = Address::generate(&s.env);
             let voucher = Address::generate(&s.env);
-            
+
             do_vouch(&s, &voucher, &borrower, 500_000);
-            
+
             token.mint(&borrower, &100_000);
-            
+
             s.env.ledger().with_mut(|li| li.timestamp += 61);
             let loan_amount = 100_000 + (i as i128 * 10_000);
             let purpose = String::from_str(&s.env, "loan");
-            s.client.request_loan(
-                &borrower,
-                &loan_amount,
-                &500_000,
-                &purpose,
-                &s.token_id,
-            );
-            
+            s.client
+                .request_loan(&borrower, &loan_amount, &500_000, &purpose, &s.token_id);
+
             total_disbursed += loan_amount;
         }
-        
+
         // Verify invariant: total disbursed is within contract capacity
         assert!(
             total_disbursed <= 100_000_000,

--- a/QuorumCredit/src/simple_double_repay_test.rs
+++ b/QuorumCredit/src/simple_double_repay_test.rs
@@ -33,7 +33,7 @@ mod simple_double_repay_test {
         // Setup vouch and fund contract
         StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &stake);
         client.vouch(&voucher, &borrower, &stake, &token_id.address());
-        
+
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
         env.ledger().with_mut(|l| l.timestamp += 61);
 

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -61,10 +61,10 @@ pub enum DataKey {
     Blacklisted(Address), // borrower → bool permanently banned
     VoucherWhitelist(Address), // voucher → bool allowed to vouch
     ExtensionConsents(Address), // borrower → Vec<Address> vouchers who consented to extension
-    SlashVote(Address),         // borrower → SlashVoteRecord
-    SlashVoteQuorum,            // u32 quorum in basis points (e.g. 5000 = 50%)
-    ReferredBy(Address),        // borrower → Address of referrer
-    ReferralBonusBps,           // u32 referral bonus in basis points (default 100 = 1%)
+    SlashVote(Address), // borrower → SlashVoteRecord
+    SlashVoteQuorum, // u32 quorum in basis points (e.g. 5000 = 50%)
+    ReferredBy(Address), // borrower → Address of referrer
+    ReferralBonusBps, // u32 referral bonus in basis points (default 100 = 1%)
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -72,10 +72,10 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Clone)]
 pub struct SlashVoteRecord {
-    pub approve_stake: i128,    // total stake voting to approve slash
-    pub reject_stake: i128,     // total stake voting to reject slash
-    pub voters: Vec<Address>,   // addresses that have already voted
-    pub executed: bool,         // true once slash has been auto-executed
+    pub approve_stake: i128,  // total stake voting to approve slash
+    pub reject_stake: i128,   // total stake voting to reject slash
+    pub voters: Vec<Address>, // addresses that have already voted
+    pub executed: bool,       // true once slash has been auto-executed
 }
 
 // ── Config ────────────────────────────────────────────────────────────────────
@@ -108,12 +108,12 @@ pub struct LoanRecord {
     pub amount_repaid: i128, // cumulative repayments received so far (principal + yield)
     pub total_yield: i128,   // yield owed to vouchers, locked in at disbursement
     pub status: LoanStatus,
-    pub created_at: u64,                  // ledger timestamp
-    pub disbursement_timestamp: u64,      // ledger timestamp
-    pub repayment_timestamp: Option<u64>, // set once the loan is fully repaid
-    pub deadline: u64,                    // repayment deadline (ledger timestamp)
+    pub created_at: u64,                   // ledger timestamp
+    pub disbursement_timestamp: u64,       // ledger timestamp
+    pub repayment_timestamp: Option<u64>,  // set once the loan is fully repaid
+    pub deadline: u64,                     // repayment deadline (ledger timestamp)
     pub loan_purpose: soroban_sdk::String, // borrower-supplied purpose string
-    pub token_address: Address,           // token used for this loan
+    pub token_address: Address,            // token used for this loan
 }
 
 #[contracttype]

--- a/QuorumCredit/src/vouch.rs
+++ b/QuorumCredit/src/vouch.rs
@@ -201,7 +201,10 @@ pub fn decrease_stake(
         .expect("vouch not found") as u32;
 
     let mut vouch_rec = vouches.get(idx).unwrap();
-    assert!(amount <= vouch_rec.amount, "decrease amount exceeds staked amount");
+    assert!(
+        amount <= vouch_rec.amount,
+        "decrease amount exceeds staked amount"
+    );
 
     let token_client = require_allowed_token(&env, &vouch_rec.token)?;
     vouch_rec.amount -= amount;
@@ -212,7 +215,9 @@ pub fn decrease_stake(
     }
 
     if vouches.is_empty() {
-        env.storage().persistent().remove(&DataKey::Vouches(borrower));
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Vouches(borrower));
     } else {
         env.storage()
             .persistent()

--- a/QuorumCredit/src/vouch.rs
+++ b/QuorumCredit/src/vouch.rs
@@ -183,6 +183,9 @@ pub fn decrease_stake(
     voucher.require_auth();
     require_not_paused(&env)?;
 
+    if voucher == borrower {
+        return Err(ContractError::SelfVouchNotAllowed);
+    }
     assert!(amount > 0, "decrease amount must be greater than zero");
     assert!(!has_active_loan(&env, &borrower), "loan already active");
 
@@ -494,5 +497,27 @@ mod tests {
         // Test that total_vouched returns correct sum
         let result = client.total_vouched(&borrower);
         assert_eq!(result, 3_500_000);
+    }
+
+    /// Issue #442: decrease_stake() must reject self-vouch (voucher == borrower)
+    #[test]
+    fn test_decrease_stake_self_vouch_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let admin = create_test_admin(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token = create_test_token(&env);
+
+        client.initialize(&deployer, &admins, &1, &token);
+
+        let user = Address::generate(&env);
+
+        let result = client.try_decrease_stake(&user, &user, &1_000);
+        assert_eq!(result, Err(Ok(ContractError::SelfVouchNotAllowed)));
     }
 }

--- a/QuorumCredit/src/vouch_zero_stake_test.rs
+++ b/QuorumCredit/src/vouch_zero_stake_test.rs
@@ -12,12 +12,7 @@ mod vouch_zero_stake_tests {
             .address();
         let contract_id = env.register_contract(None, QuorumCreditContract);
         let client = QuorumCreditContractClient::new(env, &contract_id);
-        client.initialize(
-            &deployer,
-            &Vec::from_array(env, [admin]),
-            &1,
-            &token_id,
-        );
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
         let voucher = Address::generate(env);
         StellarAssetClient::new(env, &token_id).mint(&voucher, &1_000_000);
         (contract_id, token_id, voucher, Address::generate(env))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,4 +44,6 @@ pub enum ContractError {
     MaxVouchersPerBorrowerExceeded = 35,
     /// Voucher has insufficient balance to stake the requested amount.
     InsufficientVoucherBalance = 36,
+    /// Voucher and borrower must be different addresses.
+    SelfVouchNotAllowed = 37,
 }

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -242,6 +242,9 @@ pub fn decrease_stake(
     voucher.require_auth();
     require_not_paused(&env)?;
 
+    if voucher == borrower {
+        return Err(ContractError::SelfVouchNotAllowed);
+    }
     if amount <= 0 {
         panic_with_error!(&env, ContractError::InvalidAmount);
     }
@@ -704,5 +707,27 @@ mod tests {
         // Whitelist is disabled by default, so any voucher can vouch
         let result = client.try_vouch(&voucher, &borrower, &stake, &token);
         assert!(result.is_ok());
+    }
+
+    /// Issue #442: decrease_stake() must reject self-vouch (voucher == borrower)
+    #[test]
+    fn test_decrease_stake_self_vouch_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let deployer = Address::generate(&env);
+        let admin = create_test_admin(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token = create_test_token(&env);
+
+        client.initialize(&deployer, &admins, &1, &token);
+
+        let user = Address::generate(&env);
+
+        let result = client.try_decrease_stake(&user, &user, &1_000);
+        assert_eq!(result, Err(Ok(ContractError::SelfVouchNotAllowed)));
     }
 }


### PR DESCRIPTION
## Summary

Closes #442.

`decrease_stake()` had no check preventing a borrower from acting as their own voucher, bypassing the self-vouch protection that exists in `vouch()`.

## Changes

- **`src/errors.rs` / `QuorumCredit/src/errors.rs`**: Added `SelfVouchNotAllowed = 37` to `ContractError`.
- **`src/vouch.rs` / `QuorumCredit/src/vouch.rs`**: Added guard at the top of `decrease_stake()`:
  ```rust
  if voucher == borrower {
      return Err(ContractError::SelfVouchNotAllowed);
  }
  ```
- Added `test_decrease_stake_self_vouch_rejected` verifying the guard returns `SelfVouchNotAllowed`.

## Testing

All 49 tests pass (`cargo test`). `cargo check` and `cargo clippy` clean.