### PR TITLE
fix(#449): validate SEP-41 interface in add_allowed_token

### DIFF
--- a/QuorumCredit/src/admin.rs
+++ b/QuorumCredit/src/admin.rs
@@ -1,6 +1,6 @@
-use crate::helpers::{config, extend_ttl, require_admin_approval, validate_admin_config};
+use crate::helpers::{config, extend_ttl, require_admin_approval, require_valid_token, validate_admin_config};
 use crate::types::{Config, DataKey};
-use soroban_sdk::{symbol_short, Address, BytesN, Env, Vec};
+use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env, Vec};
 
 pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
     require_admin_approval(&env, &admin_signers);
@@ -339,6 +339,7 @@ pub fn get_config(env: Env) -> Config {
 
 pub fn add_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
     require_admin_approval(&env, &admin_signers);
+    require_valid_token(&env, &token).unwrap_or_else(|e| panic_with_error!(&env, e));
     let mut cfg = config(&env);
     assert!(
         !cfg.allowed_tokens.iter().any(|t| t == token) && token != cfg.token,

--- a/QuorumCredit/src/multi_asset_test.rs
+++ b/QuorumCredit/src/multi_asset_test.rs
@@ -126,6 +126,15 @@ mod multi_asset_tests {
     }
 
     #[test]
+    fn test_add_allowed_token_rejects_invalid_token() {
+        let s = setup();
+        let admins = Vec::from_array(&s.env, [s.admin.clone()]);
+        let invalid = Address::generate(&s.env); // not a token contract
+        let result = s.client.try_add_allowed_token(&admins, &invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_primary_token_always_allowed() {
         let s = setup();
         let voucher = Address::generate(&s.env);


### PR DESCRIPTION
## Summary

Fixes #449

`add_allowed_token()` previously accepted any address without verifying it implements the SEP-41 token interface. An invalid address stored in `allowed_tokens` would cause a panic later when the contract attempted a transfer.

## Changes

**`QuorumCredit/src/admin.rs`**
- Added `require_valid_token` to imports
- Added `panic_with_error!` to imports  
- Called `require_valid_token(&env, &token)` at the top of `add_allowed_token()`, before any storage mutation — panics with `ContractError::InvalidToken` if the address doesn't implement SEP-41

**`QuorumCredit/src/multi_asset_test.rs`**
- Added `test_add_allowed_token_rejects_invalid_token`: passes a plain `Address::generate()` (not a token contract) to `try_add_allowed_token` and asserts the call fails

## Test

```
cargo test test_add_allowed_token_rejects_invalid_token
```