### PR TITLE
test: verify set_max_loan_to_stake_ratio rejects zero ratio

### DIFF
--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -18,6 +18,8 @@ mod bug_condition_test;
 #[cfg(test)]
 mod config_bps_test;
 #[cfg(test)]
+mod max_loan_to_stake_ratio_test;
+#[cfg(test)]
 mod double_repay_test;
 #[cfg(test)]
 mod duplicate_loan_test;

--- a/QuorumCredit/src/max_loan_to_stake_ratio_test.rs
+++ b/QuorumCredit/src/max_loan_to_stake_ratio_test.rs
@@ -1,0 +1,38 @@
+/// Tests verifying that set_max_loan_to_stake_ratio rejects a zero ratio.
+#[cfg(test)]
+mod max_loan_to_stake_ratio_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn setup() -> (Env, QuorumCreditContractClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token.address());
+
+        (env, client, admin)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_set_max_loan_to_stake_ratio_rejects_zero() {
+        let (env, client, admin) = setup();
+        let admin_signers = Vec::from_array(&env, [admin]);
+        client.set_max_loan_to_stake_ratio(&admin_signers, &0);
+    }
+
+    #[test]
+    fn test_set_max_loan_to_stake_ratio_accepts_positive() {
+        let (env, client, admin) = setup();
+        let admin_signers = Vec::from_array(&env, [admin]);
+        client.set_max_loan_to_stake_ratio(&admin_signers, &200);
+        assert_eq!(client.get_config().max_loan_to_stake_ratio, 200);
+    }
+}


### PR DESCRIPTION
closes #455 

Guard already present; adds explicit test coverage for zero rejection and positive value acceptance.

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
