### PR TITLE
test: add comprehensive validation tests for vouch(), request_loan(), and repay()

### DIFF
--- a/QuorumCredit/src/duplicate_vouch_test.rs
+++ b/QuorumCredit/src/duplicate_vouch_test.rs
@@ -1,0 +1,48 @@
+#[cfg(test)]
+mod duplicate_vouch_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    /// Issue #476: second vouch from same voucher+borrower pair must return DuplicateVouch.
+    #[test]
+    fn test_duplicate_vouch_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_id);
+        assert_eq!(result, Err(Ok(ContractError::DuplicateVouch)));
+    }
+
+    /// Issue #476: increase_stake() is the correct path to add more stake to an existing vouch.
+    #[test]
+    fn test_increase_stake_succeeds_after_vouch() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+
+        let result = client.try_increase_stake(&voucher, &borrower, &500_000);
+        assert!(result.is_ok());
+    }
+}

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -42,6 +42,8 @@ mod multi_asset_test;
 #[cfg(test)]
 mod referral_test;
 #[cfg(test)]
+mod repay_overpayment_test;
+#[cfg(test)]
 mod request_loan_insufficient_stake_test;
 #[cfg(test)]
 mod security_fixes_test;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -48,6 +48,8 @@ mod set_min_loan_amount_test;
 #[cfg(test)]
 mod simple_double_repay_test;
 #[cfg(test)]
+mod vouch_min_stake_test;
+#[cfg(test)]
 mod vouch_zero_stake_test;
 #[cfg(test)]
 mod voucher_whitelist_test;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -44,6 +44,8 @@ mod request_loan_insufficient_stake_test;
 #[cfg(test)]
 mod security_fixes_test;
 #[cfg(test)]
+mod max_loan_amount_test;
+#[cfg(test)]
 mod set_min_loan_amount_test;
 #[cfg(test)]
 mod simple_double_repay_test;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -28,6 +28,8 @@ mod double_repay_test;
 #[cfg(test)]
 mod duplicate_loan_test;
 #[cfg(test)]
+mod duplicate_vouch_test;
+#[cfg(test)]
 mod get_loan_status_test;
 #[cfg(test)]
 mod governance_test;

--- a/QuorumCredit/src/max_loan_amount_test.rs
+++ b/QuorumCredit/src/max_loan_amount_test.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod max_loan_amount_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec};
+
+    const MAX: i128 = 1_000_000;
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin.clone()]), &1, &token_id);
+        // Set max_loan_amount to 1,000,000 stroops
+        client.set_max_loan_amount(&Vec::from_array(env, [admin.clone()]), &MAX);
+        // Fund contract so it can disburse loans
+        StellarAssetClient::new(env, &token_id).mint(&contract_id, &10_000_000);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, admin, voucher, Address::generate(env))
+    }
+
+    /// Issue #475: request_loan() with 1,000,001 stroops must be rejected.
+    #[test]
+    fn test_loan_exceeds_max_amount_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+
+        let result = client.try_request_loan(
+            &borrower,
+            &(MAX + 1),
+            &5_000_000,
+            &String::from_str(&env, "test loan"),
+            &token_id,
+        );
+        assert_eq!(result, Err(Ok(ContractError::LoanExceedsMaxAmount)));
+    }
+
+    /// Issue #475: request_loan() with exactly 1,000,000 stroops must succeed.
+    #[test]
+    fn test_loan_at_max_amount_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+
+        let result = client.try_request_loan(
+            &borrower,
+            &MAX,
+            &5_000_000,
+            &String::from_str(&env, "test loan"),
+            &token_id,
+        );
+        assert!(result.is_ok());
+    }
+}

--- a/QuorumCredit/src/repay_overpayment_test.rs
+++ b/QuorumCredit/src/repay_overpayment_test.rs
@@ -1,0 +1,88 @@
+/// Issue #477: repay() overpayment handling tests.
+///
+/// The contract rejects payment > outstanding (principal + yield - already_repaid)
+/// with InvalidAmount, protecting borrowers from accidental overpayment.
+/// Exact repayment marks the loan as Repaid.
+#[cfg(test)]
+mod repay_overpayment_tests {
+    use crate::errors::ContractError;
+    use crate::{LoanStatus, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec,
+    };
+
+    /// principal=1_000_000, yield_bps=200 → yield=20_000, total_owed=1_020_000
+    const PRINCIPAL: i128 = 1_000_000;
+    const YIELD: i128 = 20_000;
+    const TOTAL_OWED: i128 = PRINCIPAL + YIELD;
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
+        // Fund contract for disbursement + yield payouts
+        StellarAssetClient::new(env, &token_id).mint(&contract_id, &10_000_000);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    fn open_loan(
+        client: &QuorumCreditContractClient,
+        env: &Env,
+        token_id: &Address,
+        voucher: &Address,
+        borrower: &Address,
+    ) {
+        client.vouch(voucher, borrower, &5_000_000, token_id);
+        client.request_loan(
+            borrower,
+            &PRINCIPAL,
+            &5_000_000,
+            &String::from_str(env, "test loan"),
+            token_id,
+        );
+        // Give borrower enough to attempt repayment
+        StellarAssetClient::new(env, token_id).mint(borrower, &2_000_000);
+    }
+
+    /// Issue #477: repay() with payment > total_owed must be rejected with InvalidAmount.
+    /// The contract protects borrowers from accidental overpayment.
+    #[test]
+    fn test_overpayment_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        open_loan(&client, &env, &token_id, &voucher, &borrower);
+
+        // 1,100,000 > 1,020,000 (total owed) — must be rejected
+        let result = client.try_repay(&borrower, &1_100_000);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
+    }
+
+    /// Issue #477: repay() with exact total_owed marks loan as Repaid.
+    #[test]
+    fn test_exact_repayment_marks_loan_repaid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        open_loan(&client, &env, &token_id, &voucher, &borrower);
+
+        client.repay(&borrower, &TOTAL_OWED);
+
+        let loan = client.get_loan(&borrower).expect("loan record should exist");
+        assert_eq!(loan.status, LoanStatus::Repaid);
+        assert_eq!(loan.amount_repaid, TOTAL_OWED);
+    }
+}

--- a/QuorumCredit/src/vouch_min_stake_test.rs
+++ b/QuorumCredit/src/vouch_min_stake_test.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+mod vouch_min_stake_tests {
+    use crate::errors::ContractError;
+    use crate::types::DEFAULT_MIN_YIELD_STAKE;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin.clone()]), &1, &token_id);
+        // Set min_stake to DEFAULT_MIN_YIELD_STAKE (50 stroops)
+        client.set_min_stake(
+            &Vec::from_array(env, [admin]),
+            &DEFAULT_MIN_YIELD_STAKE,
+        );
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &1_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    /// Issue #474: vouch() with 49 stroops (below DEFAULT_MIN_YIELD_STAKE) must be rejected.
+    #[test]
+    fn test_vouch_below_min_stake_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &(DEFAULT_MIN_YIELD_STAKE - 1), &token_id);
+        assert_eq!(result, Err(Ok(ContractError::MinStakeNotMet)));
+    }
+
+    /// Issue #474: vouch() with exactly 50 stroops (DEFAULT_MIN_YIELD_STAKE) must succeed.
+    #[test]
+    fn test_vouch_exact_min_stake_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &DEFAULT_MIN_YIELD_STAKE, &token_id);
+        assert!(result.is_ok());
+    }
+}

--- a/src/duplicate_vouch_test.rs
+++ b/src/duplicate_vouch_test.rs
@@ -1,0 +1,48 @@
+#[cfg(test)]
+mod duplicate_vouch_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    /// Issue #476: second vouch from same voucher+borrower pair must return DuplicateVouch.
+    #[test]
+    fn test_duplicate_vouch_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_id);
+        assert_eq!(result, Err(Ok(ContractError::DuplicateVouch)));
+    }
+
+    /// Issue #476: increase_stake() is the correct path to add more stake to an existing vouch.
+    #[test]
+    fn test_increase_stake_succeeds_after_vouch() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+
+        let result = client.try_increase_stake(&voucher, &borrower, &500_000);
+        assert!(result.is_ok());
+    }
+}

--- a/src/max_loan_amount_test.rs
+++ b/src/max_loan_amount_test.rs
@@ -1,0 +1,68 @@
+#[cfg(test)]
+mod max_loan_amount_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec};
+
+    const MAX: i128 = 1_000_000;
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin.clone()]), &1, &token_id);
+        // Set max_loan_amount to 1,000,000 stroops
+        client.set_max_loan_amount(&Vec::from_array(env, [admin.clone()]), &MAX);
+        // Fund contract so it can disburse loans
+        StellarAssetClient::new(env, &token_id).mint(&contract_id, &10_000_000);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, admin, voucher, Address::generate(env))
+    }
+
+    /// Issue #475: request_loan() with 1,000,001 stroops must be rejected.
+    #[test]
+    fn test_loan_exceeds_max_amount_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+
+        let result = client.try_request_loan(
+            &borrower,
+            &(MAX + 1),
+            &5_000_000,
+            &String::from_str(&env, "test loan"),
+            &token_id,
+        );
+        assert_eq!(result, Err(Ok(ContractError::LoanExceedsMaxAmount)));
+    }
+
+    /// Issue #475: request_loan() with exactly 1,000,000 stroops must succeed.
+    #[test]
+    fn test_loan_at_max_amount_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+
+        let result = client.try_request_loan(
+            &borrower,
+            &MAX,
+            &5_000_000,
+            &String::from_str(&env, "test loan"),
+            &token_id,
+        );
+        assert!(result.is_ok());
+    }
+}

--- a/src/repay_overpayment_test.rs
+++ b/src/repay_overpayment_test.rs
@@ -1,0 +1,88 @@
+/// Issue #477: repay() overpayment handling tests.
+///
+/// The contract rejects payment > outstanding (principal + yield - already_repaid)
+/// with InvalidAmount, protecting borrowers from accidental overpayment.
+/// Exact repayment marks the loan as Repaid.
+#[cfg(test)]
+mod repay_overpayment_tests {
+    use crate::errors::ContractError;
+    use crate::{LoanStatus, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec,
+    };
+
+    /// principal=1_000_000, yield_bps=200 → yield=20_000, total_owed=1_020_000
+    const PRINCIPAL: i128 = 1_000_000;
+    const YIELD: i128 = 20_000;
+    const TOTAL_OWED: i128 = PRINCIPAL + YIELD;
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin]), &1, &token_id);
+        // Fund contract for disbursement + yield payouts
+        StellarAssetClient::new(env, &token_id).mint(&contract_id, &10_000_000);
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &10_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    fn open_loan(
+        client: &QuorumCreditContractClient,
+        env: &Env,
+        token_id: &Address,
+        voucher: &Address,
+        borrower: &Address,
+    ) {
+        client.vouch(voucher, borrower, &5_000_000, token_id);
+        client.request_loan(
+            borrower,
+            &PRINCIPAL,
+            &5_000_000,
+            &String::from_str(env, "test loan"),
+            token_id,
+        );
+        // Give borrower enough to attempt repayment
+        StellarAssetClient::new(env, token_id).mint(borrower, &2_000_000);
+    }
+
+    /// Issue #477: repay() with payment > total_owed must be rejected with InvalidAmount.
+    /// The contract protects borrowers from accidental overpayment.
+    #[test]
+    fn test_overpayment_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        open_loan(&client, &env, &token_id, &voucher, &borrower);
+
+        // 1,100,000 > 1,020,000 (total owed) — must be rejected
+        let result = client.try_repay(&borrower, &1_100_000);
+        assert_eq!(result, Err(Ok(ContractError::InvalidAmount)));
+    }
+
+    /// Issue #477: repay() with exact total_owed marks loan as Repaid.
+    #[test]
+    fn test_exact_repayment_marks_loan_repaid() {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        open_loan(&client, &env, &token_id, &voucher, &borrower);
+
+        client.repay(&borrower, &TOTAL_OWED);
+
+        let loan = client.get_loan(&borrower).expect("loan record should exist");
+        assert_eq!(loan.status, LoanStatus::Repaid);
+        assert_eq!(loan.amount_repaid, TOTAL_OWED);
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -30,6 +30,8 @@ mod min_loan_amount_test;
 mod multi_asset_test;
 #[path = "partial_repay_test.rs"]
 mod partial_repay_test;
+#[path = "repay_overpayment_test.rs"]
+mod repay_overpayment_test;
 #[path = "paused_state_test.rs"]
 mod paused_state_test;
 #[path = "referral_test.rs"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -44,6 +44,8 @@ mod slash_auth_test;
 mod slash_multi_voucher_test;
 #[path = "vouch_cooldown_test.rs"]
 mod vouch_cooldown_test;
+#[path = "vouch_min_stake_test.rs"]
+mod vouch_min_stake_test;
 #[path = "vouch_zero_stake_test.rs"]
 mod vouch_zero_stake_test;
 #[path = "voucher_balance_check_test.rs"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,6 +20,8 @@ mod loan_overwrite_protection_test;
 mod loan_purpose_test;
 #[path = "max_vouchers_per_borrower_test.rs"]
 mod max_vouchers_per_borrower_test;
+#[path = "max_loan_amount_test.rs"]
+mod max_loan_amount_test;
 #[path = "min_loan_amount_test.rs"]
 mod min_loan_amount_test;
 #[path = "multi_asset_test.rs"]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,6 +4,8 @@ mod bug_condition_test;
 mod double_slash_panic_test;
 #[path = "duplicate_loan_test.rs"]
 mod duplicate_loan_test;
+#[path = "duplicate_vouch_test.rs"]
+mod duplicate_vouch_test;
 #[path = "full_lifecycle_test.rs"]
 mod full_lifecycle_test;
 #[path = "get_loan_none_test.rs"]

--- a/src/vouch_min_stake_test.rs
+++ b/src/vouch_min_stake_test.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+mod vouch_min_stake_tests {
+    use crate::errors::ContractError;
+    use crate::types::DEFAULT_MIN_YIELD_STAKE;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, token::StellarAssetClient, Address, Env, Vec};
+
+    fn setup(env: &Env) -> (Address, Address, Address, Address) {
+        let deployer = Address::generate(env);
+        let admin = Address::generate(env);
+        let token_id = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(&deployer, &Vec::from_array(env, [admin.clone()]), &1, &token_id);
+        // Set min_stake to DEFAULT_MIN_YIELD_STAKE (50 stroops)
+        client.set_min_stake(
+            &Vec::from_array(env, [admin]),
+            &DEFAULT_MIN_YIELD_STAKE,
+        );
+        let voucher = Address::generate(env);
+        StellarAssetClient::new(env, &token_id).mint(&voucher, &1_000_000);
+        (contract_id, token_id, voucher, Address::generate(env))
+    }
+
+    /// Issue #474: vouch() with 49 stroops (below DEFAULT_MIN_YIELD_STAKE) must be rejected.
+    #[test]
+    fn test_vouch_below_min_stake_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &(DEFAULT_MIN_YIELD_STAKE - 1), &token_id);
+        assert_eq!(result, Err(Ok(ContractError::MinStakeNotMet)));
+    }
+
+    /// Issue #474: vouch() with exactly 50 stroops (DEFAULT_MIN_YIELD_STAKE) must succeed.
+    #[test]
+    fn test_vouch_exact_min_stake_accepted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, token_id, voucher, borrower) = setup(&env);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let result = client.try_vouch(&voucher, &borrower, &DEFAULT_MIN_YIELD_STAKE, &token_id);
+        assert!(result.is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Adds missing test coverage for four untested contract guards, resolving issues #474–#477.

---

## Changes

### #474 — `vouch()` minimum stake validation
**File:** `src/vouch_min_stake_test.rs`, `QuorumCredit/src/vouch_min_stake_test.rs`
- `test_vouch_below_min_stake_rejected`: vouching with 49 stroops (below `DEFAULT_MIN_YIELD_STAKE`) returns `ContractError::MinStakeNotMet`
- `test_vouch_exact_min_stake_accepted`: vouching with exactly 50 stroops succeeds

### #475 — `request_loan()` max loan amount validation
**File:** `src/max_loan_amount_test.rs`, `QuorumCredit/src/max_loan_amount_test.rs`
- `test_loan_exceeds_max_amount_rejected`: requesting 1,000,001 stroops when max is 1,000,000 returns `ContractError::LoanExceedsMaxAmount`
- `test_loan_at_max_amount_accepted`: requesting exactly 1,000,000 stroops succeeds

### #476 — `vouch()` duplicate vouch rejection
**File:** `src/duplicate_vouch_test.rs`, `QuorumCredit/src/duplicate_vouch_test.rs`
- `test_duplicate_vouch_rejected`: second vouch from the same voucher+borrower pair returns `ContractError::DuplicateVouch`
- `test_increase_stake_succeeds_after_vouch`: verifies `increase_stake()` is the correct path for adding more stake to an existing vouch

### #477 — `repay()` overpayment handling
**File:** `src/repay_overpayment_test.rs`, `QuorumCredit/src/repay_overpayment_test.rs`
- `test_overpayment_rejected`: payment of 1,100,000 stroops on a 1,020,000 total-owed loan (1,000,000 principal + 20,000 yield at 2%) returns `ContractError::InvalidAmount` — the contract rejects overpayment to protect borrowers from accidental fund loss
- `test_exact_repayment_marks_loan_repaid`: exact payment of 1,020,000 stroops marks the loan as `LoanStatus::Repaid`

---

## Closes
Closes #474, Closes #475, Closes #476, Closes #477