### PR TITLE
feat: implement #470 #471 #472 #473 — reminders, reputation NFT, insurance pool, dynamic yield

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1015,4 +1015,12 @@ impl QuorumCreditContract {
     pub fn emit_repayment_reminders(env: Env) {
         loan::emit_repayment_reminders(env)
     }
+
+    /// Mint a reputation NFT for a borrower who has repaid at least one loan.
+    ///
+    /// # Errors
+    /// * `NoActiveLoan` — borrower has no successful repayments or no NFT contract configured
+    pub fn mint_reputation_nft(env: Env, borrower: Address) -> Result<(), ContractError> {
+        loan::mint_reputation_nft(env, borrower)
+    }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1007,4 +1007,12 @@ impl QuorumCreditContract {
     pub fn execute_slash_vote(env: Env, borrower: Address) -> Result<(), ContractError> {
         governance::execute_slash_vote(env, borrower)
     }
+
+    /// Emit `repayment_reminder` events for all active loans whose deadline is within 7 days.
+    ///
+    /// Off-chain systems can call this to trigger reminder events for borrowers approaching
+    /// their repayment deadline.
+    pub fn emit_repayment_reminders(env: Env) {
+        loan::emit_repayment_reminders(env)
+    }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3,6 +3,7 @@ use crate::{
     errors::ContractError,
     governance,
     helpers::{self, require_valid_token, validate_admin_config},
+    insurance,
     loan,
     reputation::ReputationNftExternalClient,
     types::*,
@@ -1022,5 +1023,30 @@ impl QuorumCreditContract {
     /// * `NoActiveLoan` — borrower has no successful repayments or no NFT contract configured
     pub fn mint_reputation_nft(env: Env, borrower: Address) -> Result<(), ContractError> {
         loan::mint_reputation_nft(env, borrower)
+    }
+
+    // ── Insurance Pool ────────────────────────────────────────────────────────
+
+    /// Contribute tokens to the insurance pool.
+    pub fn contribute_to_insurance(
+        env: Env,
+        contributor: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        insurance::contribute_to_insurance(env, contributor, amount)
+    }
+
+    /// Claim an insurance payout for a defaulted loan.
+    pub fn claim_insurance(
+        env: Env,
+        voucher: Address,
+        loan_id: u64,
+    ) -> Result<(), ContractError> {
+        insurance::claim_insurance(env, voucher, loan_id)
+    }
+
+    /// Get the current insurance pool balance in stroops.
+    pub fn get_insurance_pool_balance(env: Env) -> i128 {
+        insurance::get_insurance_pool_balance(env)
     }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1025,6 +1025,13 @@ impl QuorumCreditContract {
         loan::mint_reputation_nft(env, borrower)
     }
 
+    /// Calculate the dynamic yield in basis points for a borrower.
+    ///
+    /// Formula: `base_yield_bps + (credit_score / 100) - (default_count * 50)`, floored at 0.
+    pub fn calculate_dynamic_yield(env: Env, borrower: Address) -> i128 {
+        loan::calculate_dynamic_yield(&env, &borrower)
+    }
+
     // ── Insurance Pool ────────────────────────────────────────────────────────
 
     /// Contribute tokens to the insurance pool.

--- a/src/dynamic_yield_test.rs
+++ b/src/dynamic_yield_test.rs
@@ -1,0 +1,148 @@
+/// Dynamic Yield Tests (Issue #473)
+///
+/// Verifies calculate_dynamic_yield and that request_loan locks in the
+/// dynamic yield on the LoanRecord.
+
+#[cfg(test)]
+mod dynamic_yield_tests {
+    use crate::{
+        reputation::{ReputationNftContract, ReputationNftContractClient},
+        QuorumCreditContract, QuorumCreditContractClient,
+    };
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+        admin_vec: Vec<Address>,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund contract generously so all loans can be disbursed.
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &100_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token_id: token_id.address(), admin_vec: admins }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test")
+    }
+
+    /// No score, no defaults → yield equals base (200 bps = 2%).
+    #[test]
+    fn test_dynamic_yield_base_case() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        // 200 bps base, credit_score=0, default_count=0 → 200
+        assert_eq!(s.client.calculate_dynamic_yield(&borrower), 200);
+    }
+
+    /// Credit score of 500 → yield = 200 + (500/100) = 205 bps.
+    #[test]
+    fn test_dynamic_yield_increases_with_credit_score() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+
+        // Register NFT contract and mint 500 reputation points to borrower.
+        let contract_id = s.client.address.clone();
+        let nft_id = s.env.register_contract(None, ReputationNftContract);
+        let nft = ReputationNftContractClient::new(&s.env, &nft_id);
+        nft.initialize(&contract_id);
+        s.client.set_reputation_nft(&s.admin_vec, &nft_id);
+
+        // Mint 500 points directly via the NFT contract (contract is the minter).
+        for _ in 0..500 {
+            nft.mint(&borrower);
+        }
+
+        // 200 + (500/100) = 205
+        assert_eq!(s.client.calculate_dynamic_yield(&borrower), 205);
+    }
+
+    /// 3 defaults → yield = 200 - (3*50) = 50 bps.
+    #[test]
+    fn test_dynamic_yield_decreases_with_defaults() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+
+        // Simulate 3 defaults by running 3 slash cycles.
+        s.client.set_slash_vote_quorum(&s.admin_vec, &1);
+
+        for _ in 0..3 {
+            let voucher = Address::generate(&s.env);
+            do_vouch(&s, &voucher, &borrower, 500_000);
+            s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+            s.client.vote_slash(&voucher, &borrower, &true);
+        }
+
+        // 200 - (3 * 50) = 50
+        assert_eq!(s.client.calculate_dynamic_yield(&borrower), 50);
+    }
+
+    /// Enough defaults to push yield below 0 → floored at 0.
+    #[test]
+    fn test_dynamic_yield_floored_at_zero() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+
+        s.client.set_slash_vote_quorum(&s.admin_vec, &1);
+
+        // 5 defaults → 200 - (5*50) = -50 → clamped to 0
+        for _ in 0..5 {
+            let voucher = Address::generate(&s.env);
+            do_vouch(&s, &voucher, &borrower, 500_000);
+            s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+            s.client.vote_slash(&voucher, &borrower, &true);
+        }
+
+        assert_eq!(s.client.calculate_dynamic_yield(&borrower), 0);
+    }
+
+    /// total_yield on the LoanRecord reflects the dynamic bps at disbursement.
+    #[test]
+    fn test_loan_record_uses_dynamic_yield() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        // 1 default → yield_bps = 200 - 50 = 150
+        s.client.set_slash_vote_quorum(&s.admin_vec, &1);
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+        s.client.vote_slash(&voucher, &borrower, &true);
+
+        // Now request a second loan with dynamic yield = 150 bps.
+        let voucher2 = Address::generate(&s.env);
+        do_vouch(&s, &voucher2, &borrower, 500_000);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+
+        let loan = s.client.get_loan(&borrower).unwrap();
+        // 100_000 * 150 / 10_000 = 1_500
+        assert_eq!(loan.total_yield, 1_500);
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -48,4 +48,6 @@ pub enum ContractError {
     /// Voucher and borrower must be different addresses.
     SelfVouchNotAllowed = 37,
     DuplicateToken = 38,
+    InsuranceClaimAlreadyMade = 39,
+    InsurancePoolEmpty = 40,
 }

--- a/src/insurance.rs
+++ b/src/insurance.rs
@@ -1,0 +1,130 @@
+use crate::{
+    errors::ContractError,
+    helpers::{config, require_not_paused},
+    types::{DataKey, LoanStatus},
+};
+use soroban_sdk::{symbol_short, Address, Env};
+
+/// Contribute tokens to the insurance pool.
+///
+/// Anyone can contribute. Funds are held by the contract and used to
+/// compensate vouchers when a borrower defaults.
+///
+/// # Arguments
+/// * `contributor` - Address funding the pool (must sign; tokens transferred from here)
+/// * `amount` - Amount in stroops to add to the pool (must be > 0)
+pub fn contribute_to_insurance(
+    env: Env,
+    contributor: Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    contributor.require_auth();
+    require_not_paused(&env)?;
+
+    if amount <= 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    let token = soroban_sdk::token::Client::new(&env, &config(&env).token);
+    token.transfer(&contributor, &env.current_contract_address(), &amount);
+
+    let pool: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::InsurancePool)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::InsurancePool, &(pool + amount));
+
+    env.events().publish(
+        (symbol_short!("ins"), symbol_short!("contrib")),
+        (contributor, amount),
+    );
+
+    Ok(())
+}
+
+/// Claim insurance payout for a defaulted loan.
+///
+/// The claimant must have been a voucher on the defaulted loan. One claim is
+/// allowed per loan. The payout is `min(pool_balance, loan.amount)`.
+///
+/// # Arguments
+/// * `voucher` - Address of the voucher claiming (must sign; must appear in loan's vouch history)
+/// * `loan_id` - ID of the defaulted loan
+pub fn claim_insurance(env: Env, voucher: Address, loan_id: u64) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    // Verify the loan exists and is defaulted.
+    let loan = env
+        .storage()
+        .persistent()
+        .get::<DataKey, crate::types::LoanRecord>(&DataKey::Loan(loan_id))
+        .ok_or(ContractError::NoActiveLoan)?;
+
+    if loan.status != LoanStatus::Defaulted {
+        return Err(ContractError::InvalidStateTransition);
+    }
+
+    // Prevent double-claim on the same loan.
+    if env
+        .storage()
+        .persistent()
+        .has(&DataKey::InsuranceClaim(loan_id))
+    {
+        return Err(ContractError::InsuranceClaimAlreadyMade);
+    }
+
+    // Verify the claimant vouched for this borrower (check voucher history).
+    let history: soroban_sdk::Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(voucher.clone()))
+        .unwrap_or(soroban_sdk::Vec::new(&env));
+
+    let was_voucher = history.iter().any(|b| b == loan.borrower);
+    if !was_voucher {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let pool: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::InsurancePool)
+        .unwrap_or(0);
+
+    if pool <= 0 {
+        return Err(ContractError::InsurancePoolEmpty);
+    }
+
+    let payout = pool.min(loan.amount);
+
+    env.storage()
+        .instance()
+        .set(&DataKey::InsurancePool, &(pool - payout));
+
+    // Record the claim to prevent double-claiming.
+    env.storage()
+        .persistent()
+        .set(&DataKey::InsuranceClaim(loan_id), &voucher);
+
+    let token = soroban_sdk::token::Client::new(&env, &loan.token_address);
+    token.transfer(&env.current_contract_address(), &voucher, &payout);
+
+    env.events().publish(
+        (symbol_short!("ins"), symbol_short!("claim")),
+        (voucher, loan_id, payout),
+    );
+
+    Ok(())
+}
+
+/// Returns the current insurance pool balance in stroops.
+pub fn get_insurance_pool_balance(env: Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::InsurancePool)
+        .unwrap_or(0)
+}

--- a/src/insurance_test.rs
+++ b/src/insurance_test.rs
@@ -1,0 +1,200 @@
+/// Insurance Pool Tests (Issue #472)
+///
+/// Covers: contribute, claim after default, double-claim rejection,
+/// claim by non-voucher rejection, and empty pool rejection.
+
+#[cfg(test)]
+mod insurance_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+        admin_vec: Vec<Address>,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Set quorum to 1 bps so a single voucher vote triggers slash.
+        client.set_slash_vote_quorum(&admins, &1);
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token_id: token_id.address(), admin_vec: admins }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    /// Trigger a slash so the loan is Defaulted and voucher history is recorded.
+    fn do_slash(s: &Setup, voucher: &Address, borrower: &Address) {
+        s.client.vote_slash(voucher, borrower, &true);
+    }
+
+    // ── contribute ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_contribute_increases_pool_balance() {
+        let s = setup();
+        let contributor = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&contributor, &500_000);
+
+        assert_eq!(s.client.get_insurance_pool_balance(), 0);
+        s.client.contribute_to_insurance(&contributor, &500_000).unwrap();
+        assert_eq!(s.client.get_insurance_pool_balance(), 500_000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_contribute_zero_amount_fails() {
+        let s = setup();
+        let contributor = Address::generate(&s.env);
+        s.client.contribute_to_insurance(&contributor, &0).unwrap();
+    }
+
+    // ── claim ─────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_claim_after_default_pays_voucher() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let contributor = Address::generate(&s.env);
+
+        // Fund the insurance pool.
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&contributor, &200_000);
+        s.client.contribute_to_insurance(&contributor, &200_000).unwrap();
+
+        // Set up loan and trigger default.
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(
+            &borrower, &100_000, &500_000,
+            &String::from_str(&s.env, "test"), &s.token_id,
+        );
+        let loan = s.client.get_loan(&borrower).unwrap();
+        do_slash(&s, &voucher, &borrower);
+
+        assert_eq!(s.client.loan_status(&borrower), crate::LoanStatus::Defaulted);
+
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        let balance_before = token.balance(&voucher);
+
+        s.client.claim_insurance(&voucher, &loan.id).unwrap();
+
+        let balance_after = token.balance(&voucher);
+        // Payout = min(pool=200_000, loan.amount=100_000) = 100_000
+        assert_eq!(balance_after - balance_before, 100_000);
+        assert_eq!(s.client.get_insurance_pool_balance(), 100_000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_double_claim_fails() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let contributor = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&contributor, &500_000);
+        s.client.contribute_to_insurance(&contributor, &500_000).unwrap();
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(
+            &borrower, &100_000, &500_000,
+            &String::from_str(&s.env, "test"), &s.token_id,
+        );
+        let loan = s.client.get_loan(&borrower).unwrap();
+        do_slash(&s, &voucher, &borrower);
+
+        s.client.claim_insurance(&voucher, &loan.id).unwrap();
+        // Second claim must fail.
+        s.client.claim_insurance(&voucher, &loan.id).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_claim_by_non_voucher_fails() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let outsider = Address::generate(&s.env);
+        let contributor = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&contributor, &500_000);
+        s.client.contribute_to_insurance(&contributor, &500_000).unwrap();
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(
+            &borrower, &100_000, &500_000,
+            &String::from_str(&s.env, "test"), &s.token_id,
+        );
+        let loan = s.client.get_loan(&borrower).unwrap();
+        do_slash(&s, &voucher, &borrower);
+
+        // Outsider was not a voucher — must fail.
+        s.client.claim_insurance(&outsider, &loan.id).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_claim_on_empty_pool_fails() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(
+            &borrower, &100_000, &500_000,
+            &String::from_str(&s.env, "test"), &s.token_id,
+        );
+        let loan = s.client.get_loan(&borrower).unwrap();
+        do_slash(&s, &voucher, &borrower);
+
+        // Pool is empty — must fail.
+        s.client.claim_insurance(&voucher, &loan.id).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_claim_on_active_loan_fails() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let contributor = Address::generate(&s.env);
+
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&contributor, &500_000);
+        s.client.contribute_to_insurance(&contributor, &500_000).unwrap();
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(
+            &borrower, &100_000, &500_000,
+            &String::from_str(&s.env, "test"), &s.token_id,
+        );
+        let loan = s.client.get_loan(&borrower).unwrap();
+
+        // Loan is still Active — claim must fail.
+        s.client.claim_insurance(&voucher, &loan.id).unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ mod is_eligible_token_filter_test;
 mod vote_slash_auto_execute_test;
 #[cfg(test)]
 mod repayment_reminder_test;
+#[cfg(test)]
+mod mint_reputation_nft_test;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ mod repay_protocol_fee_test;
 mod is_eligible_token_filter_test;
 #[cfg(test)]
 mod vote_slash_auto_execute_test;
+#[cfg(test)]
+mod repayment_reminder_test;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod contract;
 pub mod errors;
 pub mod governance;
 pub mod helpers;
+pub mod insurance;
 pub mod loan;
 pub mod reputation;
 #[cfg(test)]
@@ -45,6 +46,8 @@ mod vote_slash_auto_execute_test;
 mod repayment_reminder_test;
 #[cfg(test)]
 mod mint_reputation_nft_test;
+#[cfg(test)]
+mod insurance_test;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@ mod repayment_reminder_test;
 mod mint_reputation_nft_test;
 #[cfg(test)]
 mod insurance_test;
+#[cfg(test)]
+mod dynamic_yield_test;
 
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -430,3 +430,34 @@ pub fn default_count(env: Env, borrower: Address) -> u32 {
         .get(&DataKey::DefaultCount(borrower))
         .unwrap_or(0)
 }
+
+/// Emit `repayment_reminder` events for all active loans whose deadline is within 7 days.
+///
+/// Off-chain systems can listen for these events to notify borrowers.
+pub fn emit_repayment_reminders(env: Env) {
+    const SEVEN_DAYS: u64 = 7 * 24 * 60 * 60;
+    let now = env.ledger().timestamp();
+    let counter: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::LoanCounter)
+        .unwrap_or(0);
+
+    for id in 1..=counter {
+        if let Some(loan) = env
+            .storage()
+            .persistent()
+            .get::<DataKey, crate::types::LoanRecord>(&DataKey::Loan(id))
+        {
+            if loan.status == LoanStatus::Active
+                && loan.deadline > now
+                && loan.deadline - now <= SEVEN_DAYS
+            {
+                env.events().publish(
+                    (symbol_short!("repay"), symbol_short!("reminder")),
+                    (loan.borrower, loan.deadline),
+                );
+            }
+        }
+    }
+}

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -461,3 +461,37 @@ pub fn emit_repayment_reminders(env: Env) {
         }
     }
 }
+
+/// Mint a reputation NFT for a borrower who has successfully repaid at least one loan.
+///
+/// # Errors
+/// * `NoActiveLoan` — borrower has never repaid a loan (repayment_count == 0)
+/// * `NoActiveLoan` — no reputation NFT contract is configured
+pub fn mint_reputation_nft(env: Env, borrower: Address) -> Result<(), ContractError> {
+    borrower.require_auth();
+
+    let repaid: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RepaymentCount(borrower.clone()))
+        .unwrap_or(0);
+
+    if repaid == 0 {
+        return Err(ContractError::NoActiveLoan);
+    }
+
+    let nft_addr: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::ReputationNft)
+        .ok_or(ContractError::NoActiveLoan)?;
+
+    ReputationNftExternalClient::new(&env, &nft_addr).mint(&borrower);
+
+    env.events().publish(
+        (symbol_short!("rep"), symbol_short!("minted")),
+        borrower,
+    );
+
+    Ok(())
+}

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -10,6 +10,33 @@ use crate::types::{
 };
 use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};
 
+/// Calculate dynamic yield in basis points for a borrower.
+///
+/// Formula: `base_yield_bps + (credit_score / 100) - (default_count * 50)`
+/// Result is floored at 0.
+///
+/// * `credit_score` — reputation NFT balance (0 if no NFT contract configured)
+/// * `default_count` — number of past defaults for the borrower
+pub fn calculate_dynamic_yield(env: &Env, borrower: &Address) -> i128 {
+    let base_bps = config(env).yield_bps;
+
+    let credit_score: i128 = env
+        .storage()
+        .instance()
+        .get::<DataKey, Address>(&DataKey::ReputationNft)
+        .map(|nft_addr| ReputationNftExternalClient::new(env, &nft_addr).balance(borrower) as i128)
+        .unwrap_or(0);
+
+    let default_count: i128 = env
+        .storage()
+        .persistent()
+        .get::<DataKey, u32>(&DataKey::DefaultCount(borrower.clone()))
+        .unwrap_or(0) as i128;
+
+    let dynamic_bps = base_bps + (credit_score / 100) - (default_count * 50);
+    dynamic_bps.max(0)
+}
+
 /// Register a referrer for a borrower. Must be called before `request_loan`.
 /// The referrer cannot be the borrower themselves.
 pub fn register_referral(
@@ -153,7 +180,8 @@ pub fn request_loan(
 
     let deadline = now + cfg.loan_duration;
     let loan_id = next_loan_id(&env);
-    let total_yield = amount * cfg.yield_bps / 10_000; // stroops
+    let dynamic_yield_bps = calculate_dynamic_yield(&env, &borrower);
+    let total_yield = amount * dynamic_yield_bps / 10_000; // stroops
 
     env.storage().persistent().set(
         &DataKey::Loan(loan_id),

--- a/src/mint_reputation_nft_test.rs
+++ b/src/mint_reputation_nft_test.rs
@@ -1,0 +1,121 @@
+/// Reputation NFT Minting Tests (Issue #471)
+///
+/// Verify that `mint_reputation_nft` mints an NFT for borrowers who have
+/// repaid at least one loan, and rejects those who haven't.
+
+#[cfg(test)]
+mod mint_reputation_nft_tests {
+    use crate::{
+        reputation::{ReputationNftContract, ReputationNftContractClient},
+        QuorumCreditContract, QuorumCreditContractClient,
+    };
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        nft_client: ReputationNftContractClient<'static>,
+        token_id: Address,
+        admin: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let nft_id = env.register_contract(None, ReputationNftContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Register the NFT contract and set the lending contract as its minter.
+        let nft_client = ReputationNftContractClient::new(&env, &nft_id);
+        nft_client.initialize(&contract_id);
+        client.set_reputation_nft(&admins, &nft_id);
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, nft_client, token_id: token_id.address(), admin }
+    }
+
+    fn do_full_repay(s: &Setup, borrower: &Address, voucher: &Address) {
+        let token = StellarAssetClient::new(&s.env, &s.token_id);
+        token.mint(voucher, &500_000);
+        s.client.vouch(voucher, borrower, &500_000, &s.token_id);
+        s.client.request_loan(borrower, &100_000, &500_000, &String::from_str(&s.env, "test"), &s.token_id);
+        // principal 100_000 + 2% yield 2_000 = 102_000
+        token.mint(borrower, &102_000);
+        s.client.repay(borrower, &102_000);
+    }
+
+    /// Borrower who repaid a loan can mint a reputation NFT.
+    #[test]
+    fn test_mint_after_repayment_succeeds() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_full_repay(&s, &borrower, &voucher);
+
+        assert_eq!(s.client.repayment_count(&borrower), 1);
+
+        // Score already incremented by repay(); mint_reputation_nft adds another point.
+        let score_before = s.nft_client.balance(&borrower);
+        s.client.mint_reputation_nft(&borrower).unwrap();
+        assert_eq!(s.nft_client.balance(&borrower), score_before + 1);
+    }
+
+    /// Borrower with no repayments cannot mint.
+    #[test]
+    #[should_panic]
+    fn test_mint_without_repayment_fails() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        s.client.mint_reputation_nft(&borrower).unwrap();
+    }
+
+    /// Calling mint_reputation_nft without an NFT contract configured panics.
+    #[test]
+    #[should_panic]
+    fn test_mint_without_nft_contract_fails() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Manually set repayment_count to 1 via a full repay cycle.
+        env.ledger().with_mut(|l| l.timestamp = 120);
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+        let token = StellarAssetClient::new(&env, &token_id.address());
+        token.mint(&voucher, &500_000);
+        client.vouch(&voucher, &borrower, &500_000, &token_id.address());
+        client.request_loan(&borrower, &100_000, &500_000, &String::from_str(&env, "t"), &token_id.address());
+        token.mint(&borrower, &102_000);
+        client.repay(&borrower, &102_000);
+
+        // No NFT contract set — should fail.
+        client.mint_reputation_nft(&borrower).unwrap();
+    }
+}

--- a/src/repayment_reminder_test.rs
+++ b/src/repayment_reminder_test.rs
@@ -1,0 +1,110 @@
+/// Repayment Reminder Tests (Issue #470)
+///
+/// Verify that `emit_repayment_reminders` emits events only for active loans
+/// whose deadline is within 7 days.
+
+#[cfg(test)]
+mod repayment_reminder_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Start after MIN_VOUCH_AGE (60s)
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token_id: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test loan")
+    }
+
+    /// A loan with deadline within 7 days should produce a reminder event.
+    #[test]
+    fn test_reminder_emitted_for_loan_near_deadline() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+
+        // Advance time so deadline is 3 days away (within 7-day window).
+        // Default loan_duration = 30 days. Created at t=120.
+        // deadline = 120 + 30*24*3600 = 2_592_120
+        // Set now = deadline - 3 days
+        let loan = s.client.get_loan(&borrower).unwrap();
+        let three_days: u64 = 3 * 24 * 60 * 60;
+        s.env.ledger().with_mut(|l| l.timestamp = loan.deadline - three_days);
+
+        let events_before = s.env.events().all().len();
+        s.client.emit_repayment_reminders();
+        let events_after = s.env.events().all().len();
+
+        assert!(
+            events_after > events_before,
+            "expected a reminder event to be emitted"
+        );
+    }
+
+    /// A loan with deadline more than 7 days away should NOT produce a reminder.
+    #[test]
+    fn test_no_reminder_for_loan_far_from_deadline() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher, &borrower, 500_000);
+        s.client.request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.token_id);
+
+        // Stay at t=120 — deadline is 30 days away, well outside the 7-day window.
+        let events_before = s.env.events().all().len();
+        s.client.emit_repayment_reminders();
+        let events_after = s.env.events().all().len();
+
+        assert_eq!(
+            events_after, events_before,
+            "expected no reminder event for loan far from deadline"
+        );
+    }
+
+    /// No loans → no events emitted.
+    #[test]
+    fn test_no_reminders_when_no_loans() {
+        let s = setup();
+        let events_before = s.env.events().all().len();
+        s.client.emit_repayment_reminders();
+        let events_after = s.env.events().all().len();
+        assert_eq!(events_after, events_before, "expected no events when no loans exist");
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,6 +102,8 @@ pub enum DataKey {
     ReferredBy(Address), // borrower → Address of referrer
     ReferralBonusBps, // u32 referral bonus in basis points (default 100 = 1%)
     MaxVouchersPerBorrower, // u32 maximum number of vouchers per borrower (default 50)
+    InsurancePool,           // i128 total funds contributed to the insurance pool
+    InsuranceClaim(u64),     // loan_id → Address of voucher who claimed (prevents double-claim)
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR closes four issues in a single branch:

---

### #470 — Repayment Reminders via Events

**File:** `src/loan.rs`, `src/contract.rs`

- Added `emit_repayment_reminders(env)` to `loan.rs`
- Iterates all loan IDs via `DataKey::LoanCounter`
- Emits a `(repay, reminder)` event with `(borrower, deadline)` for every `Active` loan whose deadline is within **7 days** of the current ledger timestamp
- Exposed as a public contract entry point in `contract.rs`

**Tests:** `src/repayment_reminder_test.rs`
- `test_reminder_emitted_for_loan_near_deadline` — advances time to 3 days before deadline, asserts event emitted
- `test_no_reminder_for_loan_far_from_deadline` — stays at t=120 (30 days out), asserts no event
- `test_no_reminders_when_no_loans` — empty state, no panic, no events

---

### #471 — Borrower Reputation NFT Minting

**File:** `src/loan.rs`, `src/contract.rs`

- Added `mint_reputation_nft(env, borrower)` to `loan.rs`
- Requires `borrower.require_auth()`
- Returns `ContractError::NoActiveLoan` if `RepaymentCount == 0`
- Returns `ContractError::NoActiveLoan` if no `DataKey::ReputationNft` contract is configured
- Calls `ReputationNftExternalClient::mint(&borrower)` on the external NFT contract
- Emits `(rep, minted)` event

**Tests:** `src/mint_reputation_nft_test.rs`
- `test_mint_after_repayment_succeeds`
- `test_mint_without_repayment_fails`
- `test_mint_without_nft_contract_fails`

---

### #472 — Loan Insurance Pool

**Files:** `src/insurance.rs` (new), `src/types.rs`, `src/errors.rs`, `src/contract.rs`, `src/lib.rs`

**Storage additions:**
- `DataKey::InsurancePool` — `i128` running total of pooled funds
- `DataKey::InsuranceClaim(loan_id: u64)` — records claimant per loan to prevent double-claims

**Error additions:**
- `InsuranceClaimAlreadyMade = 39`
- `InsurancePoolEmpty = 40`

**Functions:**
- `contribute_to_insurance(env, contributor, amount)` — transfers tokens into pool; emits `(ins, contrib)`
- `claim_insurance(env, voucher, loan_id)` — verifies loan is `Defaulted`, voucher is in `VoucherHistory`, no prior claim; pays `min(pool_balance, loan.amount)`; emits `(ins, claim)`
- `get_insurance_pool_balance(env)` — read-only view

**Tests:** `src/insurance_test.rs` — 7 tests covering contribute, claim, double-claim, non-voucher, empty pool, active loan

---

### #473 — Dynamic Yield Calculation Based on Risk

**File:** `src/loan.rs`, `src/contract.rs`

- Added `calculate_dynamic_yield(env, borrower) -> i128`
- Formula: `base_yield_bps + (credit_score / 100) - (default_count * 50)`, floored at `0`
- Updated `request_loan` to use `calculate_dynamic_yield` instead of fixed `cfg.yield_bps`
- Exposed as a public view in `contract.rs`

**Tests:** `src/dynamic_yield_test.rs`
- `test_dynamic_yield_base_case` — 200 bps
- `test_dynamic_yield_increases_with_credit_score` — score 500 → 205 bps
- `test_dynamic_yield_decreases_with_defaults` — 3 defaults → 50 bps
- `test_dynamic_yield_floored_at_zero` — 5 defaults → 0 bps
- `test_loan_record_uses_dynamic_yield` — `LoanRecord.total_yield` reflects dynamic rate

---

## Files Changed

| File | Change |
|------|--------|
| `src/loan.rs` | +`emit_repayment_reminders`, +`mint_reputation_nft`, +`calculate_dynamic_yield`, updated `request_loan` |
| `src/contract.rs` | Exposed all new entry points + insurance functions |
| `src/insurance.rs` | New module |
| `src/types.rs` | +`DataKey::InsurancePool`, +`DataKey::InsuranceClaim(u64)` |
| `src/errors.rs` | +`InsuranceClaimAlreadyMade = 39`, +`InsurancePoolEmpty = 40` |
| `src/lib.rs` | Registered `insurance` module + 4 test modules |
| `src/repayment_reminder_test.rs` | New — 3 tests |
| `src/mint_reputation_nft_test.rs` | New — 3 tests |
| `src/insurance_test.rs` | New — 7 tests |
| `src/dynamic_yield_test.rs` | New — 5 tests |

Closes #470
Closes #471
Closes #472
Closes #473