### PR TITLE
feat(#467): implement multi-token loan support with token-specific co…

### DIFF
--- a/QuorumCredit/src/admin.rs
+++ b/QuorumCredit/src/admin.rs
@@ -1,5 +1,5 @@
 use crate::helpers::{config, extend_ttl, require_admin_approval, require_valid_token, validate_admin_config};
-use crate::types::{Config, DataKey};
+use crate::types::{Config, DataKey, TokenConfig};
 use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env, Vec};
 
 pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
@@ -469,6 +469,37 @@ pub fn remove_allowed_token(env: Env, admin_signers: Vec<Address>, token: Addres
         .expect("token not in allowed list") as u32;
     cfg.allowed_tokens.remove(idx);
     env.storage().instance().set(&DataKey::Config, &cfg);
+}
+
+pub fn set_token_config(
+    env: Env,
+    admin_signers: Vec<Address>,
+    token: Address,
+    token_cfg: TokenConfig,
+) {
+    require_admin_approval(&env, &admin_signers);
+    assert!(
+        token_cfg.yield_bps >= 0 && token_cfg.yield_bps <= 10_000,
+        "yield_bps must be 0-10000"
+    );
+    assert!(
+        token_cfg.slash_bps > 0 && token_cfg.slash_bps <= 10_000,
+        "slash_bps must be 1-10000"
+    );
+    env.storage()
+        .persistent()
+        .set(&DataKey::TokenConfig(token.clone()), &token_cfg);
+    extend_ttl(&env, &DataKey::TokenConfig(token.clone()));
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("tkcfg")),
+        (admin_signers.get(0).unwrap(), token),
+    );
+}
+
+pub fn get_token_config(env: Env, token: Address) -> Option<TokenConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TokenConfig(token))
 }
 
 pub fn get_admins(env: Env) -> Vec<Address> {

--- a/QuorumCredit/src/governance.rs
+++ b/QuorumCredit/src/governance.rs
@@ -192,13 +192,21 @@ fn execute_slash(env: &Env, borrower: &Address) -> Result<(), ContractError> {
     validate_loan_active(&loan)?;
     let loan_token = soroban_sdk::token::Client::new(env, &loan.token_address);
 
+    // Use token-specific slash_bps if configured, otherwise fall back to global.
+    let slash_bps = env
+        .storage()
+        .persistent()
+        .get::<DataKey, crate::types::TokenConfig>(&DataKey::TokenConfig(loan.token_address.clone()))
+        .map(|tc| tc.slash_bps)
+        .unwrap_or(cfg.slash_bps);
+
     let mut total_slashed: i128 = 0;
 
     for v in vouches.iter() {
         if v.token != loan.token_address {
             continue;
         }
-        let slash_amount = v.amount * cfg.slash_bps / 10_000;
+        let slash_amount = v.amount * slash_bps / 10_000;
         let remaining = v.amount - slash_amount;
         total_slashed += slash_amount;
 

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -54,6 +54,8 @@ mod set_min_loan_amount_test;
 #[cfg(test)]
 mod simple_double_repay_test;
 #[cfg(test)]
+mod token_config_test;
+#[cfg(test)]
 mod vouch_min_stake_test;
 #[cfg(test)]
 mod vouch_zero_stake_test;
@@ -348,6 +350,19 @@ impl QuorumCreditContract {
 
     pub fn remove_allowed_token(env: Env, admin_signers: Vec<Address>, token: Address) {
         admin::remove_allowed_token(env, admin_signers, token)
+    }
+
+    pub fn set_token_config(
+        env: Env,
+        admin_signers: Vec<Address>,
+        token: Address,
+        token_cfg: TokenConfig,
+    ) {
+        admin::set_token_config(env, admin_signers, token, token_cfg)
+    }
+
+    pub fn get_token_config(env: Env, token: Address) -> Option<TokenConfig> {
+        admin::get_token_config(env, token)
     }
 
     // ── Governance ────────────────────────────────────────────────────────────

--- a/QuorumCredit/src/loan.rs
+++ b/QuorumCredit/src/loan.rs
@@ -159,7 +159,13 @@ pub fn request_loan(
 
     let deadline = now + cfg.loan_duration;
     let loan_id = next_loan_id(&env);
-    let total_yield = bps_of(amount, cfg.yield_bps);
+    let yield_bps = env
+        .storage()
+        .persistent()
+        .get::<crate::types::DataKey, crate::types::TokenConfig>(&crate::types::DataKey::TokenConfig(token_addr.clone()))
+        .map(|tc| tc.yield_bps)
+        .unwrap_or(cfg.yield_bps);
+    let total_yield = bps_of(amount, yield_bps);
 
     env.storage().persistent().set(
         &DataKey::Loan(loan_id),

--- a/QuorumCredit/src/token_config_test.rs
+++ b/QuorumCredit/src/token_config_test.rs
@@ -1,0 +1,197 @@
+#[cfg(test)]
+mod token_config_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient, TokenConfig};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        xlm: Address,
+        usdc: Address,
+        admin: Address,
+        admins: Vec<Address>,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let xlm_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let usdc_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund contract with enough for loans + yield
+        StellarAssetClient::new(&env, &xlm_id.address()).mint(&contract_id, &10_000_000);
+        StellarAssetClient::new(&env, &usdc_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &xlm_id.address());
+        client.add_allowed_token(&admins, &usdc_id.address());
+
+        // Advance past MIN_VOUCH_AGE
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup {
+            env,
+            client,
+            xlm: xlm_id.address(),
+            usdc: usdc_id.address(),
+            admin,
+            admins,
+        }
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test")
+    }
+
+    // ── set_token_config / get_token_config ───────────────────────────────────
+
+    #[test]
+    fn test_set_and_get_token_config() {
+        let s = setup();
+        let cfg = TokenConfig {
+            yield_bps: 500,
+            slash_bps: 3000,
+        };
+        s.client.set_token_config(&s.admins, &s.usdc, &cfg);
+
+        let stored = s.client.get_token_config(&s.usdc).unwrap();
+        assert_eq!(stored.yield_bps, 500);
+        assert_eq!(stored.slash_bps, 3000);
+    }
+
+    #[test]
+    fn test_get_token_config_returns_none_when_unset() {
+        let s = setup();
+        assert!(s.client.get_token_config(&s.usdc).is_none());
+    }
+
+    // ── Token-specific yield BPS ──────────────────────────────────────────────
+
+    #[test]
+    fn test_token_specific_yield_applied_on_repay() {
+        let s = setup();
+
+        // Set USDC yield to 500 bps (5%) — different from global 200 bps (2%)
+        s.client.set_token_config(
+            &s.admins,
+            &s.usdc,
+            &TokenConfig {
+                yield_bps: 500,
+                slash_bps: 5000,
+            },
+        );
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.usdc);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client
+            .request_loan(&borrower, &loan_amount, &stake, &purpose(&s.env), &s.usdc);
+
+        let loan = s.client.get_loan(&borrower).unwrap();
+        // Expected yield = 500_000 * 500 / 10_000 = 25_000
+        assert_eq!(loan.total_yield, 25_000);
+
+        // Repay in full
+        let total_owed = loan_amount + loan.total_yield;
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&borrower, &total_owed);
+        s.client.repay(&borrower, &total_owed);
+
+        // Voucher should receive stake + yield
+        let usdc_client =
+            soroban_sdk::token::TokenClient::new(&s.env, &s.usdc);
+        let voucher_balance = usdc_client.balance(&voucher);
+        assert_eq!(voucher_balance, stake + 25_000);
+    }
+
+    #[test]
+    fn test_global_yield_used_when_no_token_config() {
+        let s = setup();
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake: i128 = 1_000_000;
+        let loan_amount: i128 = 500_000;
+
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.usdc);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client
+            .request_loan(&borrower, &loan_amount, &stake, &purpose(&s.env), &s.usdc);
+
+        let loan = s.client.get_loan(&borrower).unwrap();
+        // Global yield_bps = 200 → 500_000 * 200 / 10_000 = 10_000
+        assert_eq!(loan.total_yield, 10_000);
+    }
+
+    // ── Token-specific slash BPS ──────────────────────────────────────────────
+
+    #[test]
+    fn test_token_specific_slash_applied() {
+        let s = setup();
+
+        // Set USDC slash to 2000 bps (20%) — different from global 5000 bps (50%)
+        s.client.set_token_config(
+            &s.admins,
+            &s.usdc,
+            &TokenConfig {
+                yield_bps: 200,
+                slash_bps: 2000,
+            },
+        );
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake: i128 = 1_000_000;
+
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.usdc);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client
+            .request_loan(&borrower, &500_000, &stake, &purpose(&s.env), &s.usdc);
+
+        // Trigger slash via governance vote (voucher approves)
+        s.client.vote_slash(&voucher, &borrower, &true);
+
+        // Voucher should receive 80% of stake back (20% slashed)
+        let usdc_client = soroban_sdk::token::TokenClient::new(&s.env, &s.usdc);
+        let voucher_balance = usdc_client.balance(&voucher);
+        assert_eq!(voucher_balance, 800_000); // 1_000_000 * (1 - 0.20)
+    }
+
+    #[test]
+    fn test_global_slash_used_when_no_token_config() {
+        let s = setup();
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        let stake: i128 = 1_000_000;
+
+        StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &stake);
+        s.client.vouch(&voucher, &borrower, &stake, &s.usdc);
+        s.env.ledger().with_mut(|l| l.timestamp += 61);
+        s.client
+            .request_loan(&borrower, &500_000, &stake, &purpose(&s.env), &s.usdc);
+
+        // Trigger slash — global slash_bps = 5000 (50%)
+        s.client.vote_slash(&voucher, &borrower, &true);
+
+        let usdc_client = soroban_sdk::token::TokenClient::new(&s.env, &s.usdc);
+        let voucher_balance = usdc_client.balance(&voucher);
+        assert_eq!(voucher_balance, 500_000); // 1_000_000 * (1 - 0.50)
+    }
+}

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -63,7 +63,7 @@ pub enum DataKey {
     VoucherWhitelistEnabled,   // bool: true when voucher whitelist is enforced
     BorrowerWhitelist(Address), // borrower → bool allowed to request loans
     BorrowerWhitelistEnabled,  // bool: true when borrower whitelist is enforced
-    BorrowerWhitelist(Address), // borrower → bool allowed to request loans
+    TokenConfig(Address),      // token → TokenConfig (per-token yield/slash overrides)
     ExtensionConsents(Address), // borrower → Vec<Address> vouchers who consented to extension
     SlashVote(Address), // borrower → SlashVoteRecord
     SlashVoteQuorum, // u32 quorum in basis points (e.g. 5000 = 50%)
@@ -98,6 +98,17 @@ pub struct Config {
     pub loan_duration: u64,
     pub max_loan_to_stake_ratio: u32,
     pub grace_period: u64,
+}
+
+// ── Per-Token Config ──────────────────────────────────────────────────────────
+
+/// Per-token overrides for yield and slash parameters.
+/// When set, these values take precedence over the global `Config` values.
+#[contracttype]
+#[derive(Clone)]
+pub struct TokenConfig {
+    pub yield_bps: i128,
+    pub slash_bps: i128,
 }
 
 // ── Data Types ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
What changed                                                                   
                                                                                 
  Each token can now have its own yield and slash parameters instead of sharing  
  the global config values.                                                      
                                                                                 
  New storage key: DataKey::TokenConfig(Address) stores a TokenConfig {          
  yield_bps, slash_bps } per token.                                              
                                                                                 
  New admin functions:                                                           
                                                                                 
  - set_token_config(admin_signers, token, token_cfg) — set per-token yield/slash
  BPS                                                                            
  - get_token_config(token) — read current per-token config                      
                                                                                 
  Updated behaviour:                                                             
                                                                                 
  - request_loan() — uses token-specific yield_bps when locking in total_yield at
  disbursement; falls back to global Config.yield_bps if no override is set      
  - execute_slash() — uses token-specific slash_bps when burning voucher stakes; 
  falls back to global Config.slash_bps                                          
                                                                                 
  Bug fix: Removed a duplicate DataKey::BorrowerWhitelist variant that would have
  caused a compile error.                                                        
                                                                                 
  ───────────────────────────────────────────────────────────────────────────────
                                                                                 
  Tests added (`src/token_config_test.rs`)                                       
                                                                                 
  ┌──────┬──────────┐                                                            
  │ Test │ Verifies │                                                            
  ├──────┼──────────┤                                                            
  │  │                                                                           
  │  │                                                                           
  ──────────────┤                                                                
  │ `test_set_and_get_token_config`                 │ Config is stored and       
  retrieved correctly │                                                          
  │ `test_get_token_config_returns_none_when_unset` │                            
  └─────────────────────────────────────────────────┴────────────────────────────
  │  │                                                                           
  └─────────────────────────────────────────────────┴────────────────────────────
  │  │                                                                           
  └─────────────────────────────────────────────────┴────────────────────────────
  │  │                                                                           
  └─────────────────────────────────────────────────┴────────────────────────────
  │  │                                                                           
  └─────────────────────────────────────────────────┴────────────────────────────
  └─────────────────────────────────────────────────┴────────────────────────────
  ────────────────────────────┘                                                  
                                                                                 
  ───────────────────────────────────────────────────────────────────────────────
                                                                                 
  Notes                                                                          
                                                                                 
  - Fallback to global config is intentional — tokens without an explicit        
  TokenConfig continue to work as before, making this fully backwards-compatible.
  - yield_bps is validated to 0–10000; slash_bps to 1–10000 (zero slash is not   
  allowed).                                                                      
  - total_yield is locked in at disbursement time, so changing TokenConfig after 
  a loan is active has no effect on that loan.

Closes #467 