### PR TITLE
feat(#466): add get_loan_purpose(loan_id) query function

### DIFF
--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -38,6 +38,8 @@ mod initialize_test;
 #[cfg(test)]
 mod loan_purpose_test;
 #[cfg(test)]
+mod loan_purpose_query_test;
+#[cfg(test)]
 mod multi_asset_test;
 #[cfg(test)]
 mod referral_test;
@@ -477,6 +479,10 @@ impl QuorumCreditContract {
 
     pub fn get_loan_by_id(env: Env, loan_id: u64) -> Option<LoanRecord> {
         loan::get_loan_by_id(env, loan_id)
+    }
+
+    pub fn get_loan_purpose(env: Env, loan_id: u64) -> Option<soroban_sdk::String> {
+        loan::get_loan_purpose(env, loan_id)
     }
 
     pub fn get_loan_status(env: Env, loan_id: u64) -> LoanStatus {

--- a/QuorumCredit/src/loan.rs
+++ b/QuorumCredit/src/loan.rs
@@ -415,6 +415,13 @@ pub fn is_eligible(env: Env, borrower: Address, threshold: i128) -> bool {
     total_stake >= threshold
 }
 
+pub fn get_loan_purpose(env: Env, loan_id: u64) -> Option<soroban_sdk::String> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, LoanRecord>(&DataKey::Loan(loan_id))
+        .map(|l| l.loan_purpose)
+}
+
 pub fn repayment_count(env: Env, borrower: Address) -> u32 {
     env.storage()
         .persistent()

--- a/QuorumCredit/src/loan_purpose_query_test.rs
+++ b/QuorumCredit/src/loan_purpose_query_test.rs
@@ -1,0 +1,54 @@
+#[cfg(test)]
+mod loan_purpose_query_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    fn setup() -> (Env, QuorumCreditContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        (env, client, token_id.address(), admin)
+    }
+
+    #[test]
+    fn test_get_loan_purpose_returns_correct_string() {
+        let (env, client, token, _admin) = setup();
+
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let stake: i128 = 1_000_000;
+        let purpose_str = String::from_str(&env, "buy farming equipment");
+
+        StellarAssetClient::new(&env, &token).mint(&voucher, &stake);
+        client.vouch(&voucher, &borrower, &stake, &token);
+        env.ledger().with_mut(|l| l.timestamp += 61);
+        client.request_loan(&borrower, &100_000, &stake, &purpose_str, &token);
+
+        let loan = client.get_loan(&borrower).unwrap();
+        let returned = client.get_loan_purpose(&loan.id).unwrap();
+        assert_eq!(returned, purpose_str);
+    }
+
+    #[test]
+    fn test_get_loan_purpose_returns_none_for_unknown_id() {
+        let (_env, client, _token, _admin) = setup();
+        assert!(client.get_loan_purpose(&9999).is_none());
+    }
+}


### PR DESCRIPTION
Problem                                                                        
                                                                                 
  LoanRecord.loan_purpose was stored on-chain but had no public accessor.        
  Off-chain systems (indexers, frontends, analytics) had no way to read it       
  without fetching the full loan record.                                         
                                                                                 
  What changed                                                                   
                                                                                 
  `src/loan.rs` — Added get_loan_purpose(env, loan_id) -> Option<String>. Looks  
  up the loan by ID and returns its loan_purpose, or None if the ID doesn't      
  exist.                                                                         
                                                                                 
  `src/lib.rs` — Exposed get_loan_purpose in the contract interface.             
  ───────────────────────────────────────────────────────────────────────────────
                                                                                 
  Tests (`src/loan_purpose_query_test.rs`)                                       
                                                                                 
  ┌──────┬──────────┐                                                            
  │ Test │ Verifies │                                                            
  ├──────┼──────────┤                                                            
                                               │                                 
  ├────────────────────────────────────────────────┼─────────────────────────────
  ─────────────────────────┤                                                     
  │ `test_get_loan_purpose_returns_correct_string` │ Returns the exact purpose   
  string set at disbursement │                                                   
  │  │                                                                           
  loan ID that doesn't exist      │                                              
  └─────────────────────────────────────────────────────┴────────────────────────
  ──────────────────────────────┘                                                
                                                                                 
Closes #466                                                       
                                        