### PR TITLE
feat: atomic batch_vouch rollback, vouch config caching, FAQ and inte…

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,0 +1,371 @@
+# QuorumCredit Integration Guide
+
+This guide covers everything needed to integrate off-chain systems — frontends, indexers, bots — with the QuorumCredit smart contract on Stellar Soroban.
+
+---
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Querying Contract State](#querying-contract-state)
+- [Constructing Transactions](#constructing-transactions)
+- [Event Topics and Data Structures](#event-topics-and-data-structures)
+- [Error Handling](#error-handling)
+- [Common Integration Patterns](#common-integration-patterns)
+
+---
+
+## Prerequisites
+
+You need:
+- A Soroban RPC endpoint (testnet: `https://soroban-testnet.stellar.org`, mainnet: `https://rpc.mainnet.stellar.org`)
+- The deployed contract ID
+- The Stellar JS SDK: `npm install @stellar/stellar-sdk`
+
+```js
+import { Contract, SorobanRpc, TransactionBuilder, Networks, BASE_FEE } from '@stellar/stellar-sdk';
+
+const server = new SorobanRpc.Server('https://soroban-testnet.stellar.org');
+const CONTRACT_ID = 'C...'; // your deployed contract ID
+```
+
+---
+
+## Querying Contract State
+
+All read-only queries use `simulateTransaction` — no fee, no signing required.
+
+### Check if a borrower is eligible
+
+```js
+async function isEligible(borrower, thresholdStroops, tokenAddress) {
+  const contract = new Contract(CONTRACT_ID);
+  const tx = new TransactionBuilder(sourceAccount, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('is_eligible',
+      nativeToScVal(borrower, { type: 'address' }),
+      nativeToScVal(thresholdStroops, { type: 'i128' }),
+      nativeToScVal(tokenAddress, { type: 'address' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const result = await server.simulateTransaction(tx);
+  return scValToNative(result.result.retval); // boolean
+}
+```
+
+### Get all vouches for a borrower
+
+```js
+async function getVouches(borrower) {
+  // Returns Option<Vec<VouchRecord>> — null if no vouches exist
+  const result = await simulateCall('get_vouches', [
+    nativeToScVal(borrower, { type: 'address' }),
+  ]);
+  if (!result) return [];
+  // Each VouchRecord: { voucher: Address, stake: i128, vouch_timestamp: u64, token: Address }
+  return scValToNative(result);
+}
+```
+
+### Get loan status
+
+```js
+async function getLoanStatus(borrower) {
+  // Returns LoanStatus: 'None' | 'Active' | 'Repaid' | 'Defaulted'
+  return simulateCall('loan_status', [nativeToScVal(borrower, { type: 'address' })]);
+}
+```
+
+### Get protocol config
+
+```js
+async function getConfig() {
+  // Returns Config struct — see Data Structures section
+  return simulateCall('get_config', []);
+}
+```
+
+---
+
+## Constructing Transactions
+
+State-mutating calls require a signed transaction submitted via `sendTransaction`.
+
+### Vouch for a borrower
+
+```js
+async function vouch(voucherKeypair, borrower, stakeStroops, tokenAddress) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = await server.getAccount(voucherKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('vouch',
+      nativeToScVal(voucherKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(borrower, { type: 'address' }),
+      nativeToScVal(stakeStroops, { type: 'i128' }),
+      nativeToScVal(tokenAddress, { type: 'address' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(voucherKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+### Batch vouch (atomic — all or nothing)
+
+`batch_vouch` validates all entries before committing any. If one fails, the entire batch is rejected.
+
+```js
+async function batchVouch(voucherKeypair, borrowers, stakesStroops, tokenAddress) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = await server.getAccount(voucherKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('batch_vouch',
+      nativeToScVal(voucherKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(borrowers, { type: 'array', values: borrowers.map(b => nativeToScVal(b, { type: 'address' })) }),
+      nativeToScVal(stakesStroops, { type: 'array', values: stakesStroops.map(s => nativeToScVal(s, { type: 'i128' })) }),
+      nativeToScVal(tokenAddress, { type: 'address' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(voucherKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+### Request a loan
+
+```js
+async function requestLoan(borrowerKeypair, amountStroops, thresholdStroops, purpose, tokenAddress) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = await server.getAccount(borrowerKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('request_loan',
+      nativeToScVal(borrowerKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(amountStroops, { type: 'i128' }),
+      nativeToScVal(thresholdStroops, { type: 'i128' }),
+      nativeToScVal(purpose, { type: 'string' }),
+      nativeToScVal(tokenAddress, { type: 'address' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(borrowerKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+### Repay a loan
+
+```js
+async function repay(borrowerKeypair, paymentStroops) {
+  const contract = new Contract(CONTRACT_ID);
+  const account = await server.getAccount(borrowerKeypair.publicKey());
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: Networks.TESTNET })
+    .addOperation(contract.call('repay',
+      nativeToScVal(borrowerKeypair.publicKey(), { type: 'address' }),
+      nativeToScVal(paymentStroops, { type: 'i128' }),
+    ))
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  prepared.sign(borrowerKeypair);
+  return server.sendTransaction(prepared);
+}
+```
+
+---
+
+## Event Topics and Data Structures
+
+The contract emits Soroban events on every state change. Subscribe via the Soroban RPC `getEvents` method or Horizon's event stream.
+
+### Fetching events
+
+```js
+const events = await server.getEvents({
+  startLedger: fromLedger,
+  filters: [{
+    type: 'contract',
+    contractIds: [CONTRACT_ID],
+  }],
+});
+```
+
+### Event reference
+
+| Topic (symbol pair) | Data payload | Trigger |
+|---|---|---|
+| `["contract", "init"]` | `(deployer, admins, admin_threshold, token)` | `initialize()` |
+| `["vouch", "added"]` | `(voucher, borrower, stake, token)` | `vouch()` or `batch_vouch()` per entry |
+| `["vouch", "increased"]` | `(voucher, borrower, additional_stake)` | `increase_stake()` |
+| `["vouch", "decreased"]` | `(voucher, borrower, reduced_amount)` | `decrease_stake()` |
+| `["vouch", "withdrawn"]` | `(voucher, borrower, returned_stake)` | `withdraw_vouch()` |
+| `["loan", "request"]` | `(borrower, amount, threshold, loan_purpose, token)` | `request_loan()` |
+| `["loan", "repay"]` | `(borrower, payment)` | `repay()` |
+| `["loan", "slash"]` | `(borrower, total_slashed)` | `vote_slash()` auto-execute or admin slash |
+| `["admin", "pause"]` | `(admin)` | `pause()` |
+| `["admin", "unpause"]` | `(admin)` | `unpause()` |
+| `["admin", "config"]` | `(admin, config)` | `set_config()` / `update_config()` |
+
+### Parsing a vouch event
+
+```js
+function parseVouchEvent(event) {
+  const [voucher, borrower, stake, token] = event.value.map(scValToNative);
+  return {
+    voucher,   // string (Stellar address)
+    borrower,  // string
+    stake,     // bigint (stroops)
+    token,     // string (contract address)
+    xlm: Number(stake) / 10_000_000,
+  };
+}
+```
+
+---
+
+## Data Structures
+
+All amounts are in stroops. 1 XLM = 10,000,000 stroops.
+
+### VouchRecord
+
+```ts
+interface VouchRecord {
+  voucher: string;         // Stellar address
+  stake: bigint;           // stroops
+  vouch_timestamp: bigint; // Unix timestamp (seconds)
+  token: string;           // token contract address
+}
+```
+
+### LoanRecord
+
+```ts
+interface LoanRecord {
+  id: bigint;
+  borrower: string;
+  amount: bigint;           // principal in stroops
+  amount_repaid: bigint;    // cumulative repayment in stroops
+  total_yield: bigint;      // yield locked at disbursement in stroops
+  status: 'None' | 'Active' | 'Repaid' | 'Defaulted';
+  created_at: bigint;       // Unix timestamp
+  deadline: bigint;         // Unix timestamp
+  loan_purpose: string;
+  token_address: string;
+}
+```
+
+### Config
+
+```ts
+interface Config {
+  admins: string[];
+  admin_threshold: number;
+  token: string;
+  allowed_tokens: string[];
+  yield_bps: bigint;             // e.g. 200 = 2%
+  slash_bps: bigint;             // e.g. 5000 = 50%
+  max_vouchers: number;
+  min_loan_amount: bigint;       // stroops
+  loan_duration: bigint;         // seconds
+  max_loan_to_stake_ratio: number; // e.g. 150 = 150%
+  grace_period: bigint;          // seconds
+}
+```
+
+---
+
+## Error Handling
+
+Contract errors are returned as typed Soroban errors. Match on the numeric code:
+
+```js
+async function safeVouch(voucherKeypair, borrower, stake, token) {
+  try {
+    const result = await vouch(voucherKeypair, borrower, stake, token);
+    if (result.status === 'ERROR') {
+      const errorCode = parseContractError(result.errorResult);
+      switch (errorCode) {
+        case 1:  throw new Error('InsufficientFunds: stake must be > 0');
+        case 5:  throw new Error('DuplicateVouch: already vouched for this borrower');
+        case 13: throw new Error('MinStakeNotMet: increase stake to meet minimum');
+        case 21: throw new Error('VouchCooldownActive: wait before vouching again');
+        case 36: throw new Error('InsufficientVoucherBalance: top up your token balance');
+        case 37: throw new Error('SelfVouchNotAllowed: cannot vouch for yourself');
+        default: throw new Error(`ContractError code ${errorCode}`);
+      }
+    }
+    return result;
+  } catch (e) {
+    console.error('vouch failed:', e.message);
+    throw e;
+  }
+}
+```
+
+Full error code reference: see [README.md — Error Reference](README.md#error-reference).
+
+---
+
+## Common Integration Patterns
+
+### Indexer: track all vouches
+
+```js
+async function indexVouches(fromLedger) {
+  const events = await server.getEvents({
+    startLedger: fromLedger,
+    filters: [{ type: 'contract', contractIds: [CONTRACT_ID] }],
+  });
+
+  for (const event of events.events) {
+    const [topic1, topic2] = event.topic.map(scValToNative);
+    if (topic1 === 'vouch' && topic2 === 'added') {
+      const [voucher, borrower, stake, token] = event.value.map(scValToNative);
+      await db.upsertVouch({ voucher, borrower, stake: stake.toString(), token, ledger: event.ledger });
+    }
+  }
+}
+```
+
+### Frontend: display borrower trust score
+
+```js
+async function getBorrowerProfile(borrower) {
+  const [vouches, loanStatus, eligible] = await Promise.all([
+    getVouches(borrower),
+    getLoanStatus(borrower),
+    isEligible(borrower, MIN_THRESHOLD, PRIMARY_TOKEN),
+  ]);
+
+  const totalStake = vouches.reduce((sum, v) => sum + v.stake, 0n);
+  return {
+    borrower,
+    voucherCount: vouches.length,
+    totalStakeXlm: Number(totalStake) / 10_000_000,
+    loanStatus,
+    eligible,
+  };
+}
+```
+
+### Stroop conversion helpers
+
+```js
+const XLM_TO_STROOPS = 10_000_000n;
+const xlmToStroops = (xlm) => BigInt(Math.round(Number(xlm) * 10_000_000));
+const stroopsToXlm = (stroops) => Number(stroops) / 10_000_000;
+```

--- a/README.md
+++ b/README.md
@@ -591,15 +591,17 @@ Stake tokens to vouch for a borrower. Creates social collateral.
 ##### `batch_vouch(voucher, borrowers, stakes, token)`
 **Signature**: `fn batch_vouch(env: Env, voucher: Address, borrowers: Vec<Address>, stakes: Vec<i128>, token: Address) -> Result<(), ContractError>`
 
-Stake for multiple borrowers in a single transaction.
+Stake for multiple borrowers in a single atomic transaction. Implements all-or-nothing semantics: all vouches are fully validated before any state is mutated or tokens are transferred. If any single vouch fails validation, the entire batch is rejected and no state changes occur — the borrower list is never left in a partially-vouched state.
+
+**Atomic guarantee**: Phase 1 runs `validate_vouch` for every entry in the batch. Only if all entries pass does Phase 2 call `commit_vouch` for each entry. A failure in Phase 1 returns immediately without touching storage or token balances.
 
 **Parameters**:
-- `voucher`: Address staking tokens
+- `voucher`: Address staking tokens (must sign the transaction)
 - `borrowers`: Vector of borrower addresses
-- `stakes`: Vector of stake amounts in stroops
-- `token`: Token contract address
+- `stakes`: Vector of stake amounts in stroops (must be same length as `borrowers`)
+- `token`: Token contract address (must be allowed)
 
-**Errors**: Same as `vouch`, plus `PoolLengthMismatch` if vectors don't match
+**Errors**: Same as `vouch()`. Returns `InsufficientFunds` if `borrowers` and `stakes` lengths differ or the batch is empty.
 
 ##### `increase_stake(voucher, borrower, additional_stake, token)`
 **Signature**: `fn increase_stake(env: Env, voucher: Address, borrower: Address, additional_stake: i128, token: Address) -> Result<(), ContractError>`
@@ -910,28 +912,63 @@ await contract.setProtocolFee([admin], 50);
 
 ## Frequently Asked Questions (FAQ)
 
-### What happens if I default?
-If a borrower defaults (fails to repay the loan by the due date), the vouchers who backed the loan will have their staked XLM slashed proportionally to cover the loss. The slashing mechanism is automated through the smart contract and follows these steps:
-1. The default is detected after the repayment deadline passes
-2. Each voucher's stake is reduced proportionally based on their contribution to the loan
-3. The slashed funds are used to cover the outstanding loan amount
-4. Defaulting affects the borrower's credit score within the system, making it harder to get future loans
+### Protocol
 
-### Can I withdraw my vouch?
-Yes, but with important limitations to protect the system:
-1. **Before loan disbursement**: You can withdraw your vouch at any time before the loan is funded
-2. **After loan disbursement**: Once the loan is active, you cannot withdraw your vouch until the loan is fully repaid or defaulted
-3. **Partial withdrawal**: You can reduce your stake (but not below the minimum required) if the loan hasn't been disbursed yet
-4. **Withdrawal process**: Use the `decrease_stake()` function to reduce your vouch amount
+**What is QuorumCredit?**
+QuorumCredit is a decentralized microlending protocol on Stellar Soroban that replaces asset collateral with social collateral. Vouchers stake XLM to back borrowers they trust. If the loan is repaid, vouchers earn yield. If the borrower defaults, vouchers are slashed.
 
-### How is yield funded?
-Yield for vouchers comes from two primary sources:
-1. **Interest payments**: Borrowers pay interest on their loans, which is distributed to vouchers proportionally to their stake
-2. **Protocol fees**: A small percentage of each successful loan goes into a yield pool
-3. **Distribution**: Yield is locked in at loan disbursement and distributed upon successful repayment
-4. **Calculation**: Yield amount = (loan amount × interest rate × voucher's stake percentage)
+**What happens if a borrower defaults?**
+After the loan deadline passes without full repayment, an admin (or quorum of vouchers via `vote_slash`) can trigger a slash. Each voucher loses `slash_bps / 10_000` of their staked amount (default: 50%). The slashed funds accumulate in the slash treasury. The borrower's default count increments, affecting future loan eligibility.
 
-The yield mechanism ensures that vouchers are compensated for the risk they take while maintaining the protocol's sustainability.
+**Can I vouch for multiple borrowers at once?**
+Yes — use `batch_vouch(voucher, borrowers, stakes, token)`. It provides atomic all-or-nothing semantics: all vouches are validated before any state changes. If one entry is invalid, the entire batch is rejected and no tokens are transferred.
+
+**What is the minimum stake to earn yield?**
+50 stroops (0.000005 XLM). At the default 2% yield rate, `stake * 200 / 10_000` truncates to zero for stakes below 50 stroops. The contract enforces this minimum and rejects smaller stakes with `MinStakeNotMet`.
+
+**Can I withdraw my vouch?**
+Yes, with restrictions. You can call `withdraw_vouch()` or `decrease_stake()` at any time — unless the borrower has an active loan. Once a loan is disbursed, your stake is locked until the loan is repaid or defaulted. This protects borrowers from having their collateral pulled mid-loan.
+
+**How is yield funded?**
+Yield is sourced from a pre-funded yield reserve held by the contract. It is not minted — the contract must hold sufficient tokens to cover both principal and yield at repayment time. If the reserve is depleted, repayment will fail with `InsufficientFunds`. Admins are responsible for maintaining the reserve.
+
+**What tokens are supported?**
+The primary token is set at initialization. Admins can add additional SEP-41-compliant tokens via `add_allowed_token()`. All amounts are denominated in the token's smallest unit (stroops for XLM: 1 XLM = 10,000,000 stroops).
+
+**Is there a cooldown between vouches?**
+Yes. By default, a voucher must wait 24 hours between vouch calls (`DEFAULT_VOUCH_COOLDOWN_SECS`). This is configurable by admins. Attempting to vouch before the cooldown expires returns `VouchCooldownActive`.
+
+### Deployment
+
+**How do I deploy to testnet?**
+See the [Deployment](#deployment) section. The key requirement is that the same keypair that signs the `deploy` transaction must also sign the `initialize` transaction. Using a different key will cause `initialize` to panic.
+
+**Can I upgrade the contract after deployment?**
+Yes, via `upgrade(admin_signers, new_wasm_hash)`. This requires `admin_threshold` admin signatures. It is recommended to pause the contract before upgrading and unpause after. See the [Deployment](#deployment) section for the full upgrade sequence.
+
+**What network passphrase should I use?**
+- Testnet: `"Test SDF Network ; September 2015"`
+- Mainnet: `"Public Global Stellar Network ; September 2015"`
+
+**How do I set up multisig admin?**
+Pass multiple addresses in the `admins` vector during `initialize` and set `admin_threshold` to the required quorum (e.g., 2-of-3). All admin functions require `admin_threshold` distinct admin signatures.
+
+### Operation
+
+**How do I pause the contract in an emergency?**
+Call `pause(admin_signers)` with sufficient admin signatures. All state-mutating functions will return `ContractPaused` until `unpause(admin_signers)` is called.
+
+**How do I check if a borrower is eligible for a loan?**
+Call `is_eligible(borrower, threshold, token_addr)`. This returns `true` if the total stake from vouches for that borrower meets or exceeds `threshold` for the given token.
+
+**How do I monitor slash votes?**
+Vouchers call `vote_slash(voucher, borrower, approve)`. Once the approve stake reaches `slash_vote_quorum` (default 50% of total stake), the slash executes automatically. Query the slash vote state via `get_slash_vote_quorum()`.
+
+**Where do slashed funds go?**
+Into the slash treasury (`DataKey::SlashTreasury`). Admins can withdraw via `withdraw_slash_treasury(admin_signers, recipient, amount)`.
+
+**How do I read contract events off-chain?**
+See [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md) for event topics, data structures, and how to subscribe using the Stellar Horizon API or a Soroban RPC node.
 
 ---
 

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -3,7 +3,43 @@ use crate::helpers::{
     has_active_loan, require_allowed_token, require_not_paused, require_positive_amount,
 };
 use crate::types::{DataKey, VouchRecord};
-use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};
+use soroban_sdk::{panic_with_error, symbol_short, token, Address, Env, Vec};
+
+/// Cached instance-storage values read once per vouch call to reduce storage reads (#501).
+struct VouchConfig {
+    whitelist_enabled: bool,
+    min_stake: i128,
+    vouch_cooldown_secs: u64,
+    max_vouchers_per_borrower: u32,
+}
+
+impl VouchConfig {
+    /// Read all instance-level vouch config in a single pass.
+    fn load(env: &Env) -> Self {
+        VouchConfig {
+            whitelist_enabled: env
+                .storage()
+                .instance()
+                .get(&DataKey::WhitelistEnabled)
+                .unwrap_or(false),
+            min_stake: env
+                .storage()
+                .instance()
+                .get(&DataKey::MinStake)
+                .unwrap_or(0),
+            vouch_cooldown_secs: env
+                .storage()
+                .instance()
+                .get(&DataKey::VouchCooldownSecs)
+                .unwrap_or(crate::types::DEFAULT_VOUCH_COOLDOWN_SECS),
+            max_vouchers_per_borrower: env
+                .storage()
+                .instance()
+                .get(&DataKey::MaxVouchersPerBorrower)
+                .unwrap_or(crate::types::DEFAULT_MAX_VOUCHERS_PER_BORROWER),
+        }
+    }
+}
 
 pub fn vouch(
     env: Env,
@@ -14,24 +50,27 @@ pub fn vouch(
 ) -> Result<(), ContractError> {
     voucher.require_auth();
     require_not_paused(&env)?;
-    do_vouch(&env, voucher, borrower, stake, token)
+    // Cache config once for this call (#501).
+    let cfg = VouchConfig::load(&env);
+    do_vouch(&env, &cfg, voucher, borrower, stake, token)
 }
 
-fn do_vouch(
-    env: &Env,
-    voucher: Address,
-    borrower: Address,
+/// Pure validation: checks all preconditions without mutating state or transferring tokens.
+/// Returns the token client and current vouches so the commit phase can reuse them.
+fn validate_vouch<'a>(
+    env: &'a Env,
+    cfg: &VouchConfig,
+    voucher: &Address,
+    borrower: &Address,
     stake: i128,
-    token: Address,
-) -> Result<(), ContractError> {
-    // Validate numeric input: stake must be strictly positive.
+    token: &Address,
+) -> Result<(token::Client<'a>, Vec<VouchRecord>), ContractError> {
     require_positive_amount(env, stake)?;
 
     if voucher == borrower {
         return Err(ContractError::SelfVouchNotAllowed);
     }
 
-    // Check if borrower is blacklisted
     if env
         .storage()
         .persistent()
@@ -41,13 +80,8 @@ fn do_vouch(
         return Err(ContractError::Blacklisted);
     }
 
-    // Check voucher whitelist if enabled
-    let whitelist_enabled: bool = env
-        .storage()
-        .instance()
-        .get(&DataKey::WhitelistEnabled)
-        .unwrap_or(false);
-    if whitelist_enabled {
+    // Use cached whitelist_enabled (#501).
+    if cfg.whitelist_enabled {
         let is_whitelisted: bool = env
             .storage()
             .persistent()
@@ -58,78 +92,67 @@ fn do_vouch(
         }
     }
 
-    // Validate token is allowed.
-    let token_client = require_allowed_token(env, &token)?;
+    let token_client = require_allowed_token(env, token)?;
 
-    // Sybil resistance: enforce minimum stake per vouch.
-    let min_stake: i128 = env
-        .storage()
-        .instance()
-        .get(&DataKey::MinStake)
-        .unwrap_or(0);
-    if min_stake > 0 && stake < min_stake {
+    // Use cached min_stake (#501).
+    if cfg.min_stake > 0 && stake < cfg.min_stake {
         return Err(ContractError::MinStakeNotMet);
     }
 
-    // Rate limiting: enforce cooldown between vouch calls from the same address.
-    let vouch_cooldown_secs: u64 = env
-        .storage()
-        .instance()
-        .get(&DataKey::VouchCooldownSecs)
-        .unwrap_or(crate::types::DEFAULT_VOUCH_COOLDOWN_SECS);
-
-    if vouch_cooldown_secs > 0 {
+    // Use cached vouch_cooldown_secs (#501).
+    if cfg.vouch_cooldown_secs > 0 {
         let last_vouch_time: u64 = env
             .storage()
             .persistent()
             .get(&DataKey::LastVouchTimestamp(voucher.clone()))
             .unwrap_or(0);
         let now = env.ledger().timestamp();
-        if now < last_vouch_time + vouch_cooldown_secs {
+        if now < last_vouch_time + cfg.vouch_cooldown_secs {
             return Err(ContractError::VouchCooldownActive);
         }
     }
 
-    let mut vouches: Vec<VouchRecord> = env
+    let vouches: Vec<VouchRecord> = env
         .storage()
         .persistent()
         .get(&DataKey::Vouches(borrower.clone()))
         .unwrap_or(Vec::new(env));
 
-    // Reject duplicate vouch (same voucher + same token) before any state mutation or transfer.
     for v in vouches.iter() {
-        if v.voucher == voucher && v.token == token {
+        if v.voucher == *voucher && v.token == *token {
             return Err(ContractError::DuplicateVouch);
         }
     }
 
-    // Enforce max vouchers per borrower limit to prevent storage bloat.
-    let max_vouchers_per_borrower: u32 = env
-        .storage()
-        .instance()
-        .get(&DataKey::MaxVouchersPerBorrower)
-        .unwrap_or(crate::types::DEFAULT_MAX_VOUCHERS_PER_BORROWER);
-
-    if vouches.len() >= max_vouchers_per_borrower {
+    // Use cached max_vouchers_per_borrower (#501).
+    if vouches.len() >= cfg.max_vouchers_per_borrower {
         return Err(ContractError::MaxVouchersPerBorrowerExceeded);
     }
 
-    // Reject vouch if the borrower already has an active loan — the stake
-    // would be locked with no effect on the existing loan (fixes issue #13).
-    if has_active_loan(env, &borrower) {
+    if has_active_loan(env, borrower) {
         return Err(ContractError::ActiveLoanExists);
     }
 
-    // Issue #115: Check voucher balance before transfer to provide clear error message
-    let voucher_balance = token_client.balance(&voucher);
+    let voucher_balance = token_client.balance(voucher);
     if voucher_balance < stake {
         return Err(ContractError::InsufficientVoucherBalance);
     }
 
-    // Transfer stake from voucher into the contract.
+    Ok((token_client, vouches))
+}
+
+/// Commit phase: mutates state and transfers tokens. Only called after all validations pass.
+fn commit_vouch(
+    env: &Env,
+    token_client: &token::Client,
+    voucher: Address,
+    borrower: Address,
+    stake: i128,
+    token: Address,
+    mut vouches: Vec<VouchRecord>,
+) {
     token_client.transfer(&voucher, &env.current_contract_address(), &stake);
 
-    // Track voucher → borrowers history.
     let mut history: Vec<Address> = env
         .storage()
         .persistent()
@@ -150,7 +173,6 @@ fn do_vouch(
         .persistent()
         .set(&DataKey::Vouches(borrower.clone()), &vouches);
 
-    // Record the timestamp of this vouch for rate limiting.
     env.storage().persistent().set(
         &DataKey::LastVouchTimestamp(voucher.clone()),
         &env.ledger().timestamp(),
@@ -160,10 +182,27 @@ fn do_vouch(
         (symbol_short!("vouch"), symbol_short!("added")),
         (voucher, borrower, stake, token),
     );
+}
 
+fn do_vouch(
+    env: &Env,
+    cfg: &VouchConfig,
+    voucher: Address,
+    borrower: Address,
+    stake: i128,
+    token: Address,
+) -> Result<(), ContractError> {
+    let (token_client, vouches) =
+        validate_vouch(env, cfg, &voucher, &borrower, stake, &token)?;
+    commit_vouch(env, &token_client, voucher, borrower, stake, token, vouches);
     Ok(())
 }
 
+/// Atomically vouch for multiple borrowers in a single transaction (#530).
+///
+/// Guarantees all-or-nothing semantics: all vouches are validated before any
+/// state is mutated or tokens are transferred. If any vouch fails validation,
+/// the entire batch is rejected and no state changes occur.
 pub fn batch_vouch(
     env: Env,
     voucher: Address,
@@ -181,17 +220,33 @@ pub fn batch_vouch(
         panic_with_error!(&env, ContractError::InsufficientFunds);
     }
 
-    // Validate that no borrower equals the voucher (self-vouch not allowed)
-    for borrower in borrowers.iter() {
-        if borrower == voucher {
-            return Err(ContractError::SelfVouchNotAllowed);
-        }
-    }
+    // Cache config once for the entire batch (#501).
+    let cfg = VouchConfig::load(&env);
 
+    // ── Phase 1: Validate all vouches before committing any ──────────────────
+    // Collect (token_client, vouches) for each entry so Phase 2 can reuse them.
+    let mut validated: Vec<(token::Client, Vec<VouchRecord>)> = Vec::new(&env);
     for i in 0..borrowers.len() {
         let borrower = borrowers.get(i).unwrap();
         let stake = stakes.get(i).unwrap();
-        do_vouch(&env, voucher.clone(), borrower, stake, token.clone())?;
+        let result = validate_vouch(&env, &cfg, &voucher, &borrower, stake, &token)?;
+        validated.push_back(result);
+    }
+
+    // ── Phase 2: Commit all vouches now that every entry is valid ─────────────
+    for i in 0..borrowers.len() {
+        let borrower = borrowers.get(i).unwrap();
+        let stake = stakes.get(i).unwrap();
+        let (token_client, vouches) = validated.get(i).unwrap();
+        commit_vouch(
+            &env,
+            &token_client,
+            voucher.clone(),
+            borrower,
+            stake,
+            token.clone(),
+            vouches,
+        );
     }
 
     Ok(())


### PR DESCRIPTION
…gration guide

Closes #530 closes #501 
closes #500 closes #499

## #530 - Atomic batch_vouch rollback

Refactored batch_vouch() into a strict two-phase protocol:

- Phase 1: validate_vouch() is called for every entry in the batch. No state is mutated and no tokens are transferred during this phase. If any entry fails validation, the function returns immediately with the error and the borrower list is left completely unchanged.

- Phase 2: commit_vouch() is called for each entry only after all validations pass. Token transfers and storage writes happen here.

This guarantees all-or-nothing semantics: a partial failure can never leave some borrowers vouched and others not.

Added tests in batch_vouch_partial_failure_test.rs:
- test_batch_vouch_partial_failure_rejected: verifies entire batch is rejected when one stake is 0; confirms neither vouch is created.
- test_batch_vouch_all_valid_succeeds: verifies happy path creates all vouches.

## #501 - Reduce storage reads in vouch() by caching config

Introduced VouchConfig struct that reads all instance-level config (whitelist_enabled, min_stake, vouch_cooldown_secs, max_vouchers_per_borrower) in a single pass at the start of vouch() and batch_vouch(). Helper functions receive the cached struct instead of re-reading storage on each check.

For batch_vouch() this means config is read once for the entire batch regardless of batch size, rather than once per entry.

## #500 - FAQ section in README.md

Expanded the FAQ section with three categories:
- Protocol: default behaviour, batch_vouch atomicity, yield funding, vouch withdrawal, cooldowns, supported tokens.
- Deployment: testnet steps, contract upgrade, network passphrases, multisig admin setup.
- Operation: emergency pause, eligibility checks, slash vote monitoring, slash treasury withdrawal, off-chain event consumption.

## #499 - Integration guide for off-chain systems

Added INTEGRATION_GUIDE.md covering:
- Querying contract state (is_eligible, get_vouches, loan_status, get_config)
- Constructing and submitting transactions (vouch, batch_vouch, request_loan, repay) with JS/TS examples using @stellar/stellar-sdk
- Full event topic reference with payload shapes and parse examples
- TypeScript interface definitions for VouchRecord, LoanRecord, Config
- Error handling with numeric code mapping
- Common patterns: indexer loop, borrower profile aggregation, stroop conversion helpers

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
