### PR TITLE
feat: voucher reputation & history stats tracking

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1035,6 +1035,18 @@ impl QuorumCreditContract {
         vouch::voucher_history(env, voucher)
     }
 
+    /// Get cumulative reputation statistics for a voucher (issue #602).
+    ///
+    /// # Arguments
+    /// * `voucher` - Address of the voucher
+    ///
+    /// # Returns
+    /// * `VoucherStats` - Struct with successful_vouches, total_vouches_slashed,
+    ///   total_yield_earned, and total_slashed. Returns zeroed stats if no history.
+    pub fn get_voucher_stats(env: Env, voucher: Address) -> VoucherStats {
+        vouch::get_voucher_stats(env, voucher)
+    }
+
     /// Get the reputation score for a borrower.
     ///
     /// # Arguments

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -236,6 +236,23 @@ fn execute_slash(env: &Env, borrower: &Address) -> Result<(), ContractError> {
         if remaining > 0 {
             loan_token.transfer(&env.current_contract_address(), &v.voucher, &remaining);
         }
+
+        // Issue #602: Update voucher reputation stats on slash.
+        let mut stats: crate::types::VoucherStats = env
+            .storage()
+            .persistent()
+            .get(&DataKey::VoucherStats(v.voucher.clone()))
+            .unwrap_or(crate::types::VoucherStats {
+                successful_vouches: 0,
+                total_vouches_slashed: 0,
+                total_yield_earned: 0,
+                total_slashed: 0,
+            });
+        stats.total_vouches_slashed += 1;
+        stats.total_slashed += slash_amount;
+        env.storage()
+            .persistent()
+            .set(&DataKey::VoucherStats(v.voucher.clone()), &stats);
     }
 
     // Store slashed funds in escrow instead of immediately burning

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,8 @@ mod multi_token_vouch_test;
 #[cfg(test)]
 mod yield_reserve_solvency_test;
 #[cfg(test)]
+mod voucher_stats_test;
+#[cfg(test)]
 mod slash_escrow_test;
 #[cfg(test)]
 mod fuzz_loan_state_machine_test;

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -370,6 +370,23 @@ pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractE
                 &v.voucher,
                 &(v.stake + voucher_yield),
             );
+
+            // Issue #602: Update voucher reputation stats on successful repayment.
+            let mut stats: crate::types::VoucherStats = env
+                .storage()
+                .persistent()
+                .get(&DataKey::VoucherStats(v.voucher.clone()))
+                .unwrap_or(crate::types::VoucherStats {
+                    successful_vouches: 0,
+                    total_vouches_slashed: 0,
+                    total_yield_earned: 0,
+                    total_slashed: 0,
+                });
+            stats.successful_vouches += 1;
+            stats.total_yield_earned += voucher_yield;
+            env.storage()
+                .persistent()
+                .set(&DataKey::VoucherStats(v.voucher.clone()), &stats);
         }
 
         // Issue #553: Store yield distribution for this loan

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,6 +119,7 @@ pub enum DataKey {
     YieldReserve,            // i128 balance of the yield reserve
     SlashEscrow(Address),    // borrower → (i128 amount, u64 release_timestamp)
     SlashAudit(Address),     // borrower → SlashAuditRecord
+    VoucherStats(Address),   // voucher → VoucherStats (reputation/history tracking)
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -348,6 +349,23 @@ pub struct PaginatedVouches {
     pub total: u32,
     pub limit: u32,
     pub offset: u32,
+}
+
+// ── Voucher Stats ─────────────────────────────────────────────────────────────
+
+/// Cumulative reputation statistics for a voucher address.
+/// Updated on every repayment (success) and slash (default) event.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VoucherStats {
+    /// Total number of vouches that ended in a successful repayment.
+    pub successful_vouches: u32,
+    /// Total number of vouches that ended in a slash (default).
+    pub total_vouches_slashed: u32,
+    /// Cumulative yield earned across all successful repayments, in stroops.
+    pub total_yield_earned: i128,
+    /// Cumulative stake amount slashed across all defaults, in stroops.
+    pub total_slashed: i128,
 }
 
 // ── Pause Mode ────────────────────────────────────────────────────────────────

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -769,6 +769,27 @@ pub fn get_vouch_history(
         .unwrap_or(Vec::new(&env))
 }
 
+/// Issue #602: Get cumulative reputation statistics for a voucher.
+///
+/// Returns a `VoucherStats` struct with:
+/// - `successful_vouches`: number of vouches that ended in full repayment
+/// - `total_vouches_slashed`: number of vouches that ended in a slash
+/// - `total_yield_earned`: cumulative yield earned in stroops
+/// - `total_slashed`: cumulative stake slashed in stroops
+///
+/// Returns zeroed stats if the voucher has no history.
+pub fn get_voucher_stats(env: Env, voucher: Address) -> crate::types::VoucherStats {
+    env.storage()
+        .persistent()
+        .get(&DataKey::VoucherStats(voucher))
+        .unwrap_or(crate::types::VoucherStats {
+            successful_vouches: 0,
+            total_vouches_slashed: 0,
+            total_yield_earned: 0,
+            total_slashed: 0,
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/voucher_stats_test.rs
+++ b/src/voucher_stats_test.rs
@@ -1,0 +1,187 @@
+/// Voucher reputation/history tracking tests (Issue #602)
+///
+/// Verifies that `VoucherStats` is correctly updated on:
+/// - Successful loan repayment (successful_vouches, total_yield_earned)
+/// - Slash execution (total_vouches_slashed, total_slashed)
+/// - No history (zeroed defaults)
+#[cfg(test)]
+mod voucher_stats_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund contract for loan disbursement + yield payouts
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &100_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        // Advance past MIN_VOUCH_AGE (60s)
+        env.ledger().with_mut(|l| l.timestamp = 120);
+
+        Setup { env, client, token_id: token_id.address() }
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn purpose(env: &Env) -> String {
+        String::from_str(env, "test loan")
+    }
+
+    /// A voucher with no activity should return zeroed stats.
+    #[test]
+    fn test_get_voucher_stats_default_zeroed() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let stats = s.client.get_voucher_stats(&voucher);
+        assert_eq!(stats.successful_vouches, 0);
+        assert_eq!(stats.total_vouches_slashed, 0);
+        assert_eq!(stats.total_yield_earned, 0);
+        assert_eq!(stats.total_slashed, 0);
+    }
+
+    /// After a successful repayment, the voucher's successful_vouches and
+    /// total_yield_earned should be incremented.
+    #[test]
+    fn test_voucher_stats_incremented_on_repay() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan_amount = 500_000i128;
+        let yield_bps = 200i128;
+        let total_yield = loan_amount * yield_bps / 10_000; // 10_000
+        let total_repay = loan_amount + total_yield;
+
+        do_vouch(&s, &voucher, &borrower, stake);
+        s.client.request_loan(&borrower, &loan_amount, &stake, &purpose(&s.env), &s.token_id);
+
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&borrower, &total_repay);
+        s.client.repay(&borrower, &total_repay);
+
+        let stats = s.client.get_voucher_stats(&voucher);
+        assert_eq!(stats.successful_vouches, 1, "should record one successful vouch");
+        assert_eq!(stats.total_vouches_slashed, 0, "no slashes");
+        assert_eq!(stats.total_yield_earned, total_yield, "yield earned should match");
+        assert_eq!(stats.total_slashed, 0, "no slashed amount");
+    }
+
+    /// After a slash, the voucher's total_vouches_slashed and total_slashed
+    /// should be incremented.
+    #[test]
+    fn test_voucher_stats_incremented_on_slash() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan_amount = 500_000i128;
+
+        do_vouch(&s, &voucher, &borrower, stake);
+        s.client.request_loan(&borrower, &loan_amount, &stake, &purpose(&s.env), &s.token_id);
+
+        // Trigger slash via vote (voucher votes approve, quorum met)
+        s.client.vote_slash(&voucher, &borrower, &true);
+
+        let stats = s.client.get_voucher_stats(&voucher);
+        assert_eq!(stats.successful_vouches, 0, "no successful repayments");
+        assert_eq!(stats.total_vouches_slashed, 1, "should record one slash");
+        assert!(stats.total_slashed > 0, "slashed amount should be positive");
+        assert_eq!(stats.total_yield_earned, 0, "no yield earned");
+    }
+
+    /// Stats accumulate correctly across multiple loans for the same voucher.
+    #[test]
+    fn test_voucher_stats_accumulate_across_multiple_loans() {
+        let s = setup();
+        let voucher = Address::generate(&s.env);
+        let stake = 1_000_000i128;
+        let loan_amount = 500_000i128;
+        let yield_bps = 200i128;
+        let total_yield = loan_amount * yield_bps / 10_000;
+        let total_repay = loan_amount + total_yield;
+
+        // First loan: repaid
+        let borrower1 = Address::generate(&s.env);
+        do_vouch(&s, &voucher, &borrower1, stake);
+        s.client.request_loan(&borrower1, &loan_amount, &stake, &purpose(&s.env), &s.token_id);
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&borrower1, &total_repay);
+        s.client.repay(&borrower1, &total_repay);
+
+        // Advance time past vouch cooldown for second vouch
+        s.env.ledger().with_mut(|l| l.timestamp += 24 * 60 * 60 + 1);
+
+        // Second loan: slashed
+        let borrower2 = Address::generate(&s.env);
+        do_vouch(&s, &voucher, &borrower2, stake);
+        s.client.request_loan(&borrower2, &loan_amount, &stake, &purpose(&s.env), &s.token_id);
+        s.client.vote_slash(&voucher, &borrower2, &true);
+
+        let stats = s.client.get_voucher_stats(&voucher);
+        assert_eq!(stats.successful_vouches, 1, "one successful repayment");
+        assert_eq!(stats.total_vouches_slashed, 1, "one slash");
+        assert_eq!(stats.total_yield_earned, total_yield, "yield from first loan");
+        assert!(stats.total_slashed > 0, "slashed amount from second loan");
+    }
+
+    /// With two vouchers, each gets independent stats.
+    #[test]
+    fn test_voucher_stats_independent_per_voucher() {
+        let s = setup();
+        let borrower = Address::generate(&s.env);
+        let voucher1 = Address::generate(&s.env);
+        let voucher2 = Address::generate(&s.env);
+        let stake1 = 600_000i128;
+        let stake2 = 400_000i128;
+        let loan_amount = 500_000i128;
+        let total_stake = stake1 + stake2;
+        let yield_bps = 200i128;
+        let total_yield = loan_amount * yield_bps / 10_000;
+        let total_repay = loan_amount + total_yield;
+
+        do_vouch(&s, &voucher1, &borrower, stake1);
+        do_vouch(&s, &voucher2, &borrower, stake2);
+        s.client.request_loan(&borrower, &loan_amount, &total_stake, &purpose(&s.env), &s.token_id);
+
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&borrower, &total_repay);
+        s.client.repay(&borrower, &total_repay);
+
+        let stats1 = s.client.get_voucher_stats(&voucher1);
+        let stats2 = s.client.get_voucher_stats(&voucher2);
+
+        assert_eq!(stats1.successful_vouches, 1);
+        assert_eq!(stats2.successful_vouches, 1);
+
+        // Yield is proportional to stake
+        let expected_yield1 = total_yield * stake1 / total_stake;
+        let expected_yield2 = total_yield * stake2 / total_stake;
+        assert_eq!(stats1.total_yield_earned, expected_yield1);
+        assert_eq!(stats2.total_yield_earned, expected_yield2);
+
+        // No slashes
+        assert_eq!(stats1.total_vouches_slashed, 0);
+        assert_eq!(stats2.total_vouches_slashed, 0);
+    }
+}


### PR DESCRIPTION
## Problem
  
  The protocol had no way to track voucher performance over time. Good vouchers backing
  reliable borrowers earned no recognition, and bad vouchers backing defaulters faced no
  cumulative consequences beyond individual slashes.
  
 ## Solution
  
  Adds a VoucherStats struct stored per voucher address, updated automatically on every
  repayment and slash event.
  
 ## Changes
  
  - types.rs — new VoucherStats struct (successful_vouches, total_vouches_slashed,
  total_yield_earned, total_slashed) and DataKey::VoucherStats(Address) storage key
  - loan.rs — on full repayment, increments successful_vouches and total_yield_earned for
  each voucher that received yield
  - governance.rs — in execute_slash, increments total_vouches_slashed and total_slashed
  for each slashed voucher
  - vouch.rs — new get_voucher_stats(voucher) query function
  - contract.rs — exposes get_voucher_stats as a public contract function
  - voucher_stats_test.rs — 4 tests: default zeroed stats, repay increments, slash
  increments, accumulation across multiple loans, independence between vouchers
  
Closes #602 

  ## Testing
  
  All existing tests unmodified. New tests in voucher_stats_test.rs cover the full
  lifecycle.