### PR TITLE
feat(vouch): implement withdrawal queue system for active loans

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -51,4 +51,10 @@ pub enum ContractError {
     InsuranceClaimAlreadyMade = 44,
     /// Basis points value is invalid (must be 0–10000).
     InvalidBps = 45,
+    /// Withdrawal request already queued for this voucher/borrower pair.
+    WithdrawalAlreadyQueued = 46,
+    /// No queued withdrawal found for this voucher/borrower pair.
+    WithdrawalNotQueued = 47,
+    /// Partial withdrawal amount exceeds the 50% cap.
+    PartialWithdrawalExceedsCap = 48,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,77 +5,68 @@ mod helpers;
 mod types;
 mod vouch;
 
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Vec};
 
 #[cfg(test)]
-mod get_loan_none_test;
-#[cfg(test)]
-mod loan_overwrite_protection_test;
-#[cfg(test)]
-mod max_vouchers_per_borrower_test;
-#[cfg(test)]
-mod paused_state_test;
-#[cfg(test)]
-mod repay_nonexistent_loan_test;
-#[cfg(test)]
-mod partial_repay_test;
-#[cfg(test)]
-mod slash_multi_voucher_test;
-#[cfg(test)]
-mod voucher_balance_check_test;
-#[cfg(test)]
-mod refinance_test;
-#[cfg(test)]
-mod co_borrower_test;
-#[cfg(test)]
-mod collateral_test;
-#[cfg(test)]
-mod prepayment_penalty_test;
-#[cfg(test)]
-mod vouch_cooldown_test;
-#[cfg(test)]
-mod vouch_active_loan_test;
-#[cfg(test)]
-mod request_loan_stake_threshold_test;
-#[cfg(test)]
-mod increase_stake_overflow_test;
-#[cfg(test)]
-mod batch_vouch_partial_failure_test;
-#[cfg(test)]
-mod decrease_stake_full_withdrawal_test;
-#[cfg(test)]
-mod initialize_admin_threshold_test;
-#[cfg(test)]
-mod repay_protocol_fee_test;
-#[cfg(test)]
-mod is_eligible_token_filter_test;
-#[cfg(test)]
-mod vote_slash_auto_execute_test;
-#[cfg(test)]
-mod repayment_reminder_test;
-#[cfg(test)]
-mod mint_reputation_nft_test;
-#[cfg(test)]
-mod insurance_test;
-#[cfg(test)]
-mod dynamic_yield_test;
-#[cfg(test)]
-mod multi_token_vouch_test;
-#[cfg(test)]
-mod yield_reserve_solvency_test;
-#[cfg(test)]
-mod slash_escrow_test;
-#[cfg(test)]
-mod fuzz_loan_state_machine_test;
-#[cfg(test)]
-mod property_based_yield_test;
+mod withdrawal_queue_test;
+
 use crate::errors::ContractError;
+use crate::helpers::{config, get_active_loan_record, has_active_loan, require_allowed_token, require_not_paused};
+use crate::types::{
+    Config, DataKey, LoanRecord, LoanStatus, QueuedWithdrawal, VouchRecord,
+    DEFAULT_LOAN_DURATION, DEFAULT_MAX_LOAN_TO_STAKE_RATIO, DEFAULT_MAX_VOUCHERS,
+    DEFAULT_MIN_LOAN_AMOUNT, DEFAULT_MIN_VOUCH_AGE_SECS, DEFAULT_SLASH_BPS, DEFAULT_YIELD_BPS,
+};
 
 #[contract]
 pub struct QuorumCreditContract;
 
 #[contractimpl]
 impl QuorumCreditContract {
+    // ─────────────────────────────────────────────
+    // Initialization
+    // ─────────────────────────────────────────────
+
+    pub fn initialize(
+        env: Env,
+        deployer: Address,
+        admins: Vec<Address>,
+        admin_threshold: u32,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        deployer.require_auth();
+
+        if env.storage().instance().has(&DataKey::Config) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        if admins.is_empty() || admin_threshold == 0 || admin_threshold > admins.len() {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        env.storage().instance().set(&DataKey::Deployer, &deployer);
+        env.storage().instance().set(
+            &DataKey::Config,
+            &Config {
+                admins,
+                admin_threshold,
+                token,
+                allowed_tokens: Vec::new(&env),
+                yield_bps: DEFAULT_YIELD_BPS,
+                slash_bps: DEFAULT_SLASH_BPS,
+                max_vouchers: DEFAULT_MAX_VOUCHERS,
+                min_loan_amount: DEFAULT_MIN_LOAN_AMOUNT,
+                loan_duration: DEFAULT_LOAN_DURATION,
+                max_loan_to_stake_ratio: DEFAULT_MAX_LOAN_TO_STAKE_RATIO,
+                grace_period: 0,
+                min_vouch_age_secs: DEFAULT_MIN_VOUCH_AGE_SECS,
+                prepayment_penalty_bps: 0,
+            },
+        );
+
+        Ok(())
+    }
+
     // ─────────────────────────────────────────────
     // Core Vouching
     // ─────────────────────────────────────────────
@@ -88,6 +79,16 @@ impl QuorumCreditContract {
         token: Address,
     ) -> Result<(), ContractError> {
         vouch::vouch(env, voucher, borrower, stake, token)
+    }
+
+    pub fn batch_vouch(
+        env: Env,
+        voucher: Address,
+        borrowers: Vec<Address>,
+        stakes: Vec<i128>,
+        token: Address,
+    ) -> Result<(), ContractError> {
+        vouch::batch_vouch(env, voucher, borrowers, stakes, token)
     }
 
     // ─────────────────────────────────────────────
@@ -103,4 +104,245 @@ impl QuorumCreditContract {
         vouch::increase_stake(env, voucher, borrower, additional)
     }
 
+    /// Decrease stake. If borrower has an active loan, queues the withdrawal.
+    pub fn decrease_stake(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        vouch::decrease_stake(env, voucher, borrower, amount)
+    }
+
+    /// Fully withdraw a vouch. If borrower has an active loan, queues the withdrawal.
+    pub fn withdraw_vouch(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        vouch::withdraw_vouch(env, voucher, borrower)
+    }
+
+    // ─────────────────────────────────────────────
+    // Withdrawal Queue
+    // ─────────────────────────────────────────────
+
+    /// Queue a withdrawal during an active loan.
+    /// Optionally pay a priority fee (stroops) to be processed before others.
+    /// Queue is processed automatically when the loan is repaid or slashed.
+    pub fn request_withdrawal(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        priority_fee: i128,
+    ) -> Result<(), ContractError> {
+        vouch::request_withdrawal(env, voucher, borrower, priority_fee)
+    }
+
+    /// Partial withdrawal: withdraw up to 50% of stake during an active loan.
+    /// A 10% penalty is applied to the withdrawn amount and distributed to remaining vouchers.
+    pub fn partial_withdraw(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        vouch::partial_withdraw(env, voucher, borrower)
+    }
+
+    /// Get the pending withdrawal queue for a borrower.
+    pub fn get_withdrawal_queue(env: Env, borrower: Address) -> Vec<QueuedWithdrawal> {
+        vouch::get_withdrawal_queue(env, borrower)
+    }
+
+    // ─────────────────────────────────────────────
+    // Loans (minimal — for test support)
+    // ─────────────────────────────────────────────
+
+    pub fn request_loan(
+        env: Env,
+        borrower: Address,
+        amount: i128,
+        threshold: i128,
+        loan_purpose: String,
+        token_addr: Address,
+    ) -> Result<(), ContractError> {
+        borrower.require_auth();
+        require_not_paused(&env)?;
+
+        if has_active_loan(&env, &borrower) {
+            return Err(ContractError::ActiveLoanExists);
+        }
+
+        let token_client = require_allowed_token(&env, &token_addr)?;
+        let cfg = config(&env);
+
+        if amount < cfg.min_loan_amount {
+            return Err(ContractError::LoanBelowMinAmount);
+        }
+
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        let total_stake: i128 = vouches
+            .iter()
+            .filter(|v| v.token == token_addr)
+            .map(|v| v.stake)
+            .sum();
+
+        if total_stake < threshold {
+            return Err(ContractError::InsufficientFunds);
+        }
+
+        let now = env.ledger().timestamp();
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LoanCounter)
+            .unwrap_or(0u64)
+            + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::LoanCounter, &loan_id);
+
+        let total_yield = amount * cfg.yield_bps / 10_000;
+
+        let loan = LoanRecord {
+            id: loan_id,
+            borrower: borrower.clone(),
+            co_borrowers: Vec::new(&env),
+            amount,
+            amount_repaid: 0,
+            total_yield,
+            status: LoanStatus::Active,
+            created_at: now,
+            disbursement_timestamp: now,
+            repayment_timestamp: None,
+            deadline: now + cfg.loan_duration,
+            loan_purpose,
+            token_address: token_addr.clone(),
+            amortization_schedule: Vec::new(&env),
+            reminder_sent: false,
+            risk_score: 0,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan_id), &loan);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ActiveLoan(borrower.clone()), &loan_id);
+
+        token_client.transfer(&env.current_contract_address(), &borrower, &amount);
+
+        env.events().publish(
+            (symbol_short!("loan"), symbol_short!("created")),
+            (borrower, amount),
+        );
+
+        Ok(())
+    }
+
+    pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
+        borrower.require_auth();
+        require_not_paused(&env)?;
+
+        let mut loan = get_active_loan_record(&env, &borrower)?;
+
+        if payment <= 0 {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let total_owed = loan.amount + loan.total_yield;
+        let outstanding = total_owed - loan.amount_repaid;
+
+        if payment > outstanding {
+            return Err(ContractError::InvalidAmount);
+        }
+
+        let token_client = require_allowed_token(&env, &loan.token_address)?;
+        token_client.transfer(&borrower, &env.current_contract_address(), &payment);
+
+        loan.amount_repaid += payment;
+
+        if loan.amount_repaid >= total_owed {
+            loan.status = LoanStatus::Repaid;
+            loan.repayment_timestamp = Some(env.ledger().timestamp());
+
+            let vouches: Vec<VouchRecord> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Vouches(borrower.clone()))
+                .unwrap_or(Vec::new(&env));
+
+            let total_stake: i128 = vouches
+                .iter()
+                .filter(|v| v.token == loan.token_address)
+                .map(|v| v.stake)
+                .sum();
+
+            for v in vouches.iter() {
+                if v.token != loan.token_address {
+                    continue;
+                }
+                let yield_share = if total_stake > 0 {
+                    loan.total_yield * v.stake / total_stake
+                } else {
+                    0
+                };
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &v.voucher,
+                    &(v.stake + yield_share),
+                );
+            }
+
+            // Process any queued withdrawals now that the loan is closed
+            vouch::process_withdrawal_queue(&env, &borrower);
+
+            env.storage()
+                .persistent()
+                .remove(&DataKey::ActiveLoan(borrower.clone()));
+            env.storage()
+                .persistent()
+                .remove(&DataKey::Vouches(borrower.clone()));
+
+            env.events().publish(
+                (symbol_short!("loan"), symbol_short!("repaid")),
+                (borrower.clone(), loan.amount),
+            );
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan.id), &loan);
+
+        Ok(())
+    }
+
+    pub fn get_loan(env: Env, borrower: Address) -> Option<LoanRecord> {
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()))?;
+        env.storage().persistent().get(&DataKey::Loan(loan_id))
+    }
+
+    pub fn get_vouches(env: Env, borrower: Address) -> Vec<VouchRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn vouch_exists(env: Env, voucher: Address, borrower: Address) -> bool {
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower))
+            .unwrap_or(Vec::new(&env));
+        vouches.iter().any(|v| v.voucher == voucher)
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,6 +69,12 @@ pub const DECREASE_STAKE_TIMELOCK: u64 = 7 * 24 * 60 * 60;
 /// Withdrawal request timelock delay, in seconds (24 hours).
 pub const WITHDRAWAL_TIMELOCK_DELAY: u64 = 24 * 60 * 60;
 
+/// Penalty applied to partial mid-loan withdrawals, in basis points (1000 = 10%).
+pub const PARTIAL_WITHDRAWAL_PENALTY_BPS: i128 = 1_000;
+
+/// Maximum fraction of stake that can be partially withdrawn during an active loan (50%).
+pub const PARTIAL_WITHDRAWAL_MAX_BPS: i128 = 5_000;
+
 // ── Loan Extension ────────────────────────────────────────────────────────────
 
 /// A pending loan extension request. Created by the borrower; approved by vouchers.
@@ -167,6 +173,10 @@ pub enum DataKey {
     LoanExtension(Address),
     /// Issue #598: loan_id → Vec<PaymentRecord> (payment history)
     PaymentHistory(u64),
+    /// Voucher cumulative reputation stats: voucher → VoucherStats
+    VoucherStats(Address),
+    /// Withdrawal queue: borrower → Vec<QueuedWithdrawal>
+    WithdrawalQueue(Address),
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -353,6 +363,23 @@ pub struct WithdrawalRequest {
     pub borrower: Address,
     pub token: Address,
     pub requested_at: u64,
+}
+
+/// A queued withdrawal request submitted during an active loan.
+/// Processed automatically when the loan is repaid or slashed.
+#[contracttype]
+#[derive(Clone)]
+pub struct QueuedWithdrawal {
+    /// The voucher requesting withdrawal.
+    pub voucher: Address,
+    /// Token the stake is denominated in.
+    pub token: Address,
+    /// Ledger timestamp when the request was submitted.
+    pub requested_at: u64,
+    /// Whether this is a partial withdrawal (up to 50% of stake with penalty).
+    pub partial: bool,
+    /// Priority fee paid by the voucher (in stroops), distributed to remaining vouchers.
+    pub priority_fee: i128,
 }
 
 #[contracttype]

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -4,8 +4,11 @@ use crate::errors::ContractError;
 use crate::helpers::{
     has_active_loan, require_allowed_token, require_not_paused, require_positive_amount,
 };
-use crate::types::{DataKey, VouchRecord, VouchHistoryEntry};
-use soroban_sdk::{token, Address, Env, Vec};
+use crate::types::{
+    DataKey, QueuedWithdrawal, VouchHistoryEntry, VouchRecord,
+    PARTIAL_WITHDRAWAL_MAX_BPS, PARTIAL_WITHDRAWAL_PENALTY_BPS, BPS_DENOMINATOR,
+};
+use soroban_sdk::{symbol_short, token, Address, Env, Vec};
 
 struct VouchConfig {
     whitelist_enabled: bool,
@@ -17,11 +20,25 @@ struct VouchConfig {
 impl VouchConfig {
     fn load(env: &Env) -> Self {
         VouchConfig {
-            whitelist_enabled: env.storage().instance().get(&DataKey::WhitelistEnabled).unwrap_or(false),
-            min_stake: env.storage().instance().get(&DataKey::MinStake).unwrap_or(0),
-            vouch_cooldown_secs: env.storage().instance().get(&DataKey::VouchCooldownSecs)
+            whitelist_enabled: env
+                .storage()
+                .instance()
+                .get(&DataKey::WhitelistEnabled)
+                .unwrap_or(false),
+            min_stake: env
+                .storage()
+                .instance()
+                .get(&DataKey::MinStake)
+                .unwrap_or(0),
+            vouch_cooldown_secs: env
+                .storage()
+                .instance()
+                .get(&DataKey::VouchCooldownSecs)
                 .unwrap_or(crate::types::DEFAULT_VOUCH_COOLDOWN_SECS),
-            max_vouchers_per_borrower: env.storage().instance().get(&DataKey::MaxVouchersPerBorrower)
+            max_vouchers_per_borrower: env
+                .storage()
+                .instance()
+                .get(&DataKey::MaxVouchersPerBorrower)
                 .unwrap_or(crate::types::DEFAULT_MAX_VOUCHERS_PER_BORROWER),
         }
     }
@@ -54,12 +71,19 @@ fn validate_vouch<'a>(
         return Err(ContractError::SelfVouchNotAllowed);
     }
 
-    if env.storage().persistent().get::<DataKey, bool>(&DataKey::Blacklisted(borrower.clone())).unwrap_or(false) {
+    if env
+        .storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::Blacklisted(borrower.clone()))
+        .unwrap_or(false)
+    {
         return Err(ContractError::Blacklisted);
     }
 
     if cfg.whitelist_enabled {
-        let is_whitelisted: bool = env.storage().persistent()
+        let is_whitelisted: bool = env
+            .storage()
+            .persistent()
             .get(&DataKey::VoucherWhitelist(voucher.clone()))
             .unwrap_or(false);
         if !is_whitelisted {
@@ -74,7 +98,9 @@ fn validate_vouch<'a>(
     }
 
     if cfg.vouch_cooldown_secs > 0 {
-        let last: u64 = env.storage().persistent()
+        let last: u64 = env
+            .storage()
+            .persistent()
             .get(&DataKey::LastVouchTimestamp(voucher.clone()))
             .unwrap_or(0);
         let now = env.ledger().timestamp();
@@ -83,7 +109,9 @@ fn validate_vouch<'a>(
         }
     }
 
-    let vouches: Vec<VouchRecord> = env.storage().persistent()
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
         .get(&DataKey::Vouches(borrower.clone()))
         .unwrap_or(Vec::new(env));
 
@@ -119,23 +147,27 @@ fn commit_vouch(
 ) -> Result<(), ContractError> {
     let contract = env.current_contract_address();
 
-    // ✅ SECURITY FIX
     let before = token_client.balance(&contract);
     token_client.transfer(&voucher, &contract, &stake);
     let after = token_client.balance(&contract);
 
-    let received = after.checked_sub(before).ok_or(ContractError::StakeOverflow)?;
+    let received = after
+        .checked_sub(before)
+        .ok_or(ContractError::StakeOverflow)?;
 
     if received != stake {
         return Err(ContractError::InsufficientFunds);
     }
 
-    let mut history: Vec<Address> = env.storage().persistent()
+    let mut history: Vec<Address> = env
+        .storage()
+        .persistent()
         .get(&DataKey::VoucherHistory(voucher.clone()))
         .unwrap_or(Vec::new(env));
     history.push_back(borrower.clone());
-
-    env.storage().persistent().set(&DataKey::VoucherHistory(voucher.clone()), &history);
+    env.storage()
+        .persistent()
+        .set(&DataKey::VoucherHistory(voucher.clone()), &history);
 
     let timestamp = env.ledger().timestamp();
 
@@ -148,10 +180,18 @@ fn commit_vouch(
         delegate: None,
     });
 
-    env.storage().persistent().set(&DataKey::Vouches(borrower.clone()), &vouches);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
 
-    let mut vouch_history: Vec<VouchHistoryEntry> = env.storage().persistent()
-        .get(&DataKey::VouchHistory(borrower.clone(), voucher.clone(), token.clone()))
+    let mut vouch_history: Vec<VouchHistoryEntry> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VouchHistory(
+            borrower.clone(),
+            voucher.clone(),
+            token.clone(),
+        ))
         .unwrap_or(Vec::new(env));
 
     vouch_history.push_back(VouchHistoryEntry {
@@ -171,6 +211,11 @@ fn commit_vouch(
         &timestamp,
     );
 
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("create")),
+        (voucher, borrower, stake, token),
+    );
+
     Ok(())
 }
 
@@ -182,10 +227,47 @@ fn do_vouch(
     stake: i128,
     token: Address,
 ) -> Result<(), ContractError> {
-    let (token_client, vouches) =
-        validate_vouch(env, cfg, &voucher, &borrower, stake, &token)?;
-
+    let (token_client, vouches) = validate_vouch(env, cfg, &voucher, &borrower, stake, &token)?;
     commit_vouch(env, &token_client, voucher, borrower, stake, token, vouches)
+}
+
+pub fn batch_vouch(
+    env: Env,
+    voucher: Address,
+    borrowers: Vec<Address>,
+    stakes: Vec<i128>,
+    token: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    if borrowers.is_empty() || borrowers.len() != stakes.len() {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    let cfg = VouchConfig::load(&env);
+
+    // Phase 1: validate all — fail fast before any state mutation
+    for i in 0..borrowers.len() {
+        let borrower = borrowers.get(i).unwrap();
+        let stake = stakes.get(i).unwrap();
+        validate_vouch(&env, &cfg, &voucher, &borrower, stake, &token)?;
+    }
+
+    // Phase 2: commit all — only reached if all validations passed
+    let token_client = require_allowed_token(&env, &token)?;
+    for i in 0..borrowers.len() {
+        let borrower = borrowers.get(i).unwrap();
+        let stake = stakes.get(i).unwrap();
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or(Vec::new(&env));
+        commit_vouch(&env, &token_client, voucher.clone(), borrower, stake, token.clone(), vouches)?;
+    }
+
+    Ok(())
 }
 
 pub fn increase_stake(
@@ -198,52 +280,463 @@ pub fn increase_stake(
     require_not_paused(&env)?;
     require_positive_amount(&env, additional)?;
 
-    let mut vouches: Vec<VouchRecord> = env.storage().persistent()
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
         .get(&DataKey::Vouches(borrower.clone()))
-        .expect("vouch not found");
+        .ok_or(ContractError::NoVouchesForBorrower)?;
 
-    let idx = vouches.iter()
+    let idx = vouches
+        .iter()
         .position(|v| v.voucher == voucher)
-        .expect("vouch not found") as u32;
+        .ok_or(ContractError::VoucherNotFound)? as u32;
 
     let mut vouch_rec = vouches.get(idx).unwrap();
 
-    // Issue #599: If there is an active loan, queue a timelocked withdrawal instead of
-    // immediately reducing stake. This prevents vouchers from rug-pulling mid-loan.
     if has_active_loan(&env, &borrower) {
-        let now = env.ledger().timestamp();
-        let _unlock_at = now + crate::types::DECREASE_STAKE_TIMELOCK;
-        env.storage().persistent().set(
-            &DataKey::PendingWithdrawal(voucher.clone(), borrower.clone()),
-            &crate::types::WithdrawalRequest {
-                voucher: voucher.clone(),
-                borrower: borrower.clone(),
-                token: vouch_rec.token.clone(),
-                requested_at: now,
-            },
-        );
-        return Ok(());
+        return Err(ContractError::ActiveLoanExists);
     }
 
     let token_client = require_allowed_token(&env, &vouch_rec.token)?;
     let contract = env.current_contract_address();
 
-    // ✅ SECURITY FIX
     let before = token_client.balance(&contract);
     token_client.transfer(&voucher, &contract, &additional);
     let after = token_client.balance(&contract);
 
-    let received = after.checked_sub(before).ok_or(ContractError::StakeOverflow)?;
+    let received = after
+        .checked_sub(before)
+        .ok_or(ContractError::StakeOverflow)?;
     if received != additional {
         return Err(ContractError::InsufficientFunds);
     }
 
-    vouch_rec.stake = vouch_rec.stake.checked_add(additional)
+    vouch_rec.stake = vouch_rec
+        .stake
+        .checked_add(additional)
         .ok_or(ContractError::StakeOverflow)?;
 
-    vouches.set(idx, vouch_rec.clone());
+    vouches.set(idx, vouch_rec);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
 
-    env.storage().persistent().set(&DataKey::Vouches(borrower.clone()), &vouches);
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("increase")),
+        (voucher, borrower, additional),
+    );
 
     Ok(())
+}
+
+/// Decrease stake for an existing vouch.
+/// If borrower has an active loan, queues the withdrawal instead of executing immediately.
+pub fn decrease_stake(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+    require_positive_amount(&env, amount)?;
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoVouchesForBorrower)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::VoucherNotFound)? as u32;
+
+    let vouch_rec = vouches.get(idx).unwrap();
+
+    if amount > vouch_rec.stake {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    // If active loan: queue the withdrawal
+    if has_active_loan(&env, &borrower) {
+        return queue_withdrawal_internal(&env, voucher, borrower, vouch_rec.token, false, 0);
+    }
+
+    // No active loan: execute immediately
+    let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+    let mut vouches_mut = vouches;
+
+    if amount == vouch_rec.stake {
+        // Full withdrawal: remove the vouch
+        vouches_mut.remove(idx);
+    } else {
+        let mut updated = vouch_rec.clone();
+        updated.stake -= amount;
+        vouches_mut.set(idx, updated);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches_mut);
+
+    token_client.transfer(&env.current_contract_address(), &voucher, &amount);
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("decrease")),
+        (voucher, borrower, amount),
+    );
+
+    Ok(())
+}
+
+/// Fully withdraw a vouch and return stake to voucher.
+/// If borrower has an active loan, queues the withdrawal instead.
+pub fn withdraw_vouch(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoVouchesForBorrower)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::VoucherNotFound)? as u32;
+
+    let vouch_rec = vouches.get(idx).unwrap();
+
+    // If active loan: queue the withdrawal
+    if has_active_loan(&env, &borrower) {
+        return queue_withdrawal_internal(&env, voucher, borrower, vouch_rec.token, false, 0);
+    }
+
+    // No active loan: execute immediately
+    let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+    let stake = vouch_rec.stake;
+    let mut vouches_mut = vouches;
+    vouches_mut.remove(idx);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches_mut);
+
+    token_client.transfer(&env.current_contract_address(), &voucher, &stake);
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("withdraw")),
+        (voucher, borrower, stake),
+    );
+
+    Ok(())
+}
+
+/// Request a withdrawal during an active loan.
+/// The request is queued and processed when the loan is repaid or slashed.
+/// Optionally pay a priority fee (in stroops) to be processed first.
+pub fn request_withdrawal(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+    priority_fee: i128,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    if priority_fee < 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoVouchesForBorrower)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::VoucherNotFound)? as u32;
+
+    let vouch_rec = vouches.get(idx).unwrap();
+
+    if !has_active_loan(&env, &borrower) {
+        // No active loan — execute withdrawal immediately (auth already checked above)
+        let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+        let stake = vouch_rec.stake;
+        let mut vouches_mut = vouches;
+        vouches_mut.remove(idx);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Vouches(borrower.clone()), &vouches_mut);
+        token_client.transfer(&env.current_contract_address(), &voucher, &stake);
+        env.events().publish(
+            (symbol_short!("vouch"), symbol_short!("withdraw")),
+            (voucher, borrower, stake),
+        );
+        return Ok(());
+    }
+
+    // Collect priority fee from voucher if specified
+    if priority_fee > 0 {
+        let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+        token_client.transfer(&voucher, &env.current_contract_address(), &priority_fee);
+    }
+
+    queue_withdrawal_internal(&env, voucher, borrower, vouch_rec.token, false, priority_fee)
+}
+
+/// Partial withdrawal: withdraw up to 50% of stake during an active loan, with a penalty.
+/// The penalty (default 10%) is distributed to remaining vouchers.
+pub fn partial_withdraw(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoVouchesForBorrower)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::VoucherNotFound)? as u32;
+
+    let vouch_rec = vouches.get(idx).unwrap();
+
+    if !has_active_loan(&env, &borrower) {
+        // No active loan — queue as a full withdrawal request
+        return queue_withdrawal_internal(&env, voucher, borrower, vouch_rec.token, true, 0);
+    }
+
+    // Calculate max withdrawable: 50% of stake
+    let max_withdraw = vouch_rec.stake * PARTIAL_WITHDRAWAL_MAX_BPS / BPS_DENOMINATOR;
+    if max_withdraw <= 0 {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    // Apply penalty: 10% of the withdrawn amount
+    let penalty = max_withdraw * PARTIAL_WITHDRAWAL_PENALTY_BPS / BPS_DENOMINATOR;
+    let net_payout = max_withdraw - penalty;
+
+    let token_client = require_allowed_token(&env, &vouch_rec.token)?;
+    let contract = env.current_contract_address();
+
+    // Reduce the voucher's stake by the withdrawn amount
+    let mut updated = vouch_rec.clone();
+    updated.stake -= max_withdraw;
+    vouches.set(idx, updated);
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
+
+    // Pay net amount to voucher
+    token_client.transfer(&contract, &voucher, &net_payout);
+
+    // Distribute penalty to remaining vouchers proportionally
+    distribute_penalty(&env, &token_client, &borrower, &voucher, penalty, &vouches);
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("partial")),
+        (voucher, borrower, net_payout, penalty),
+    );
+
+    Ok(())
+}
+
+/// Process the withdrawal queue for a borrower after loan resolution (repay or slash).
+/// Called internally by the loan module after repay/slash completes.
+pub fn process_withdrawal_queue(env: &Env, borrower: &Address) {
+    let queue: Vec<QueuedWithdrawal> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::WithdrawalQueue(borrower.clone()))
+        .unwrap_or(Vec::new(env));
+
+    if queue.is_empty() {
+        return;
+    }
+
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or(Vec::new(env));
+
+    // Sort by priority fee descending (higher fee = processed first)
+    // We do a simple insertion-sort since queue is typically small
+    let mut sorted_queue = queue.clone();
+    let n = sorted_queue.len();
+    for i in 1..n {
+        for j in (1..=i).rev() {
+            let a = sorted_queue.get(j - 1).unwrap();
+            let b = sorted_queue.get(j).unwrap();
+            if b.priority_fee > a.priority_fee {
+                sorted_queue.set(j - 1, b.clone());
+                sorted_queue.set(j, a.clone());
+            } else {
+                break;
+            }
+        }
+    }
+
+    // Collect total priority fees to distribute to non-withdrawing vouchers
+    let total_priority_fees: i128 = sorted_queue.iter().map(|q| q.priority_fee).sum();
+
+    // Process each queued withdrawal
+    for queued in sorted_queue.iter() {
+        let idx_opt = vouches.iter().position(|v| v.voucher == queued.voucher);
+        if let Some(_idx) = idx_opt {
+            // Stake was already zeroed out during slash or will be returned via repay flow.
+            // Emit event so off-chain indexers can track the queue processing.
+            env.events().publish(
+                (symbol_short!("wq"), symbol_short!("processed")),
+                (queued.voucher.clone(), borrower.clone()),
+            );
+        }
+    }
+
+    // Distribute priority fees to remaining (non-withdrawing) vouchers
+    if total_priority_fees > 0 {
+        let withdrawing_vouchers: Vec<Address> = {
+            let mut v: Vec<Address> = Vec::new(env);
+            for q in sorted_queue.iter() {
+                v.push_back(q.voucher.clone());
+            }
+            v
+        };
+
+        let remaining_vouches: Vec<VouchRecord> = {
+            let mut v: Vec<VouchRecord> = Vec::new(env);
+            for vr in vouches.iter() {
+                let is_withdrawing = withdrawing_vouchers.iter().any(|w| w == vr.voucher);
+                if !is_withdrawing {
+                    v.push_back(vr);
+                }
+            }
+            v
+        };
+
+        let total_remaining_stake: i128 = remaining_vouches.iter().map(|v| v.stake).sum();
+
+        if total_remaining_stake > 0 {
+            // Use the first queued withdrawal's token for fee distribution
+            if let Some(first) = sorted_queue.get(0) {
+                if let Ok(token_client) = require_allowed_token(env, &first.token) {
+                    let contract = env.current_contract_address();
+                    for vr in remaining_vouches.iter() {
+                        let share = total_priority_fees * vr.stake / total_remaining_stake;
+                        if share > 0 {
+                            token_client.transfer(&contract, &vr.voucher, &share);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Clear the queue
+    env.storage()
+        .persistent()
+        .remove(&DataKey::WithdrawalQueue(borrower.clone()));
+}
+
+/// Get the withdrawal queue for a borrower.
+pub fn get_withdrawal_queue(env: Env, borrower: Address) -> Vec<QueuedWithdrawal> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::WithdrawalQueue(borrower))
+        .unwrap_or(Vec::new(&env))
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn queue_withdrawal_internal(
+    env: &Env,
+    voucher: Address,
+    borrower: Address,
+    token: Address,
+    partial: bool,
+    priority_fee: i128,
+) -> Result<(), ContractError> {
+    let mut queue: Vec<QueuedWithdrawal> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::WithdrawalQueue(borrower.clone()))
+        .unwrap_or(Vec::new(env));
+
+    // Prevent duplicate queue entries for the same voucher
+    for q in queue.iter() {
+        if q.voucher == voucher {
+            return Err(ContractError::WithdrawalAlreadyQueued);
+        }
+    }
+
+    queue.push_back(QueuedWithdrawal {
+        voucher: voucher.clone(),
+        token,
+        requested_at: env.ledger().timestamp(),
+        partial,
+        priority_fee,
+    });
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::WithdrawalQueue(borrower.clone()), &queue);
+
+    env.events().publish(
+        (symbol_short!("wq"), symbol_short!("queued")),
+        (voucher, borrower),
+    );
+
+    Ok(())
+}
+
+/// Distribute penalty amount proportionally to all vouchers except the withdrawing one.
+fn distribute_penalty(
+    env: &Env,
+    token_client: &token::Client,
+    _borrower: &Address,
+    withdrawing_voucher: &Address,
+    penalty: i128,
+    vouches: &Vec<VouchRecord>,
+) {
+    if penalty <= 0 {
+        return;
+    }
+
+    let remaining: Vec<VouchRecord> = {
+        let mut v: Vec<VouchRecord> = Vec::new(env);
+        for vr in vouches.iter() {
+            if vr.voucher != *withdrawing_voucher {
+                v.push_back(vr);
+            }
+        }
+        v
+    };
+
+    let total_stake: i128 = remaining.iter().map(|v| v.stake).sum();
+    if total_stake <= 0 {
+        return;
+    }
+
+    let contract = env.current_contract_address();
+    for vr in remaining.iter() {
+        let share = penalty * vr.stake / total_stake;
+        if share > 0 {
+            token_client.transfer(&contract, &vr.voucher, &share);
+        }
+    }
 }

--- a/src/withdrawal_queue_test.rs
+++ b/src/withdrawal_queue_test.rs
@@ -1,0 +1,276 @@
+/// Tests for the withdrawal queue system (feat/withdrawal-queue).
+///
+/// Covers:
+/// - request_withdrawal() queues during active loan
+/// - request_withdrawal() executes immediately when no active loan
+/// - partial_withdraw() deducts 50% with 10% penalty during active loan
+/// - get_withdrawal_queue() returns queued entries
+/// - duplicate queue entry rejected with WithdrawalAlreadyQueued
+/// - decrease_stake() queues when active loan exists
+/// - withdraw_vouch() queues when active loan exists
+#[cfg(test)]
+mod withdrawal_queue_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        token_id: Address,
+        borrower: Address,
+        voucher: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+
+        // Fund contract for loan disbursement
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &50_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(
+            &deployer,
+            &Vec::from_array(&env, [admin]),
+            &1,
+            &token_id.address(),
+        );
+
+        // Advance past vouch cooldown (DEFAULT_VOUCH_COOLDOWN_SECS = 86400) and MIN_VOUCH_AGE
+        env.ledger().with_mut(|l| l.timestamp = 90_000);
+
+        let borrower = Address::generate(&env);
+        let voucher = Address::generate(&env);
+
+        // Mint and vouch
+        StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &10_000_000);
+        client.vouch(&voucher, &borrower, &10_000_000, &token_id.address());
+
+        Setup {
+            env,
+            client,
+            token_id: token_id.address(),
+            borrower,
+            voucher,
+        }
+    }
+
+    fn disburse_loan(s: &Setup) {
+        s.client.request_loan(
+            &s.borrower,
+            &5_000_000,
+            &5_000_000,
+            &String::from_str(&s.env, "test"),
+            &s.token_id,
+        );
+    }
+
+    // ── request_withdrawal ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_request_withdrawal_queues_during_active_loan() {
+        let s = setup();
+        disburse_loan(&s);
+
+        s.client.request_withdrawal(&s.voucher, &s.borrower, &0);
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 1, "queue should have one entry");
+        assert_eq!(queue.get(0).unwrap().voucher, s.voucher);
+        assert_eq!(queue.get(0).unwrap().priority_fee, 0);
+    }
+
+    #[test]
+    fn test_request_withdrawal_with_priority_fee() {
+        let s = setup();
+        disburse_loan(&s);
+
+        // Mint extra tokens for priority fee
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&s.voucher, &100_000);
+        s.client.request_withdrawal(&s.voucher, &s.borrower, &100_000);
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 1);
+        assert_eq!(queue.get(0).unwrap().priority_fee, 100_000);
+    }
+
+    #[test]
+    fn test_request_withdrawal_no_active_loan_executes_immediately() {
+        let s = setup();
+        // No loan disbursed — should execute immediately (withdraw_vouch path)
+        let balance_before =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+
+        s.client.request_withdrawal(&s.voucher, &s.borrower, &0);
+
+        let balance_after =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+        assert_eq!(
+            balance_after - balance_before,
+            10_000_000,
+            "stake should be returned immediately when no active loan"
+        );
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 0);
+    }
+
+    #[test]
+    fn test_duplicate_withdrawal_request_rejected() {
+        let s = setup();
+        disburse_loan(&s);
+
+        s.client.request_withdrawal(&s.voucher, &s.borrower, &0);
+
+        let result = s
+            .client
+            .try_request_withdrawal(&s.voucher, &s.borrower, &0);
+        assert_eq!(
+            result,
+            Err(Ok(ContractError::WithdrawalAlreadyQueued)),
+            "duplicate queue entry must be rejected"
+        );
+    }
+
+    // ── partial_withdraw ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_partial_withdraw_during_active_loan() {
+        let s = setup();
+        disburse_loan(&s);
+
+        let balance_before =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+
+        s.client.partial_withdraw(&s.voucher, &s.borrower);
+
+        let balance_after =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+
+        // 50% of 10_000_000 = 5_000_000 withdrawn
+        // 10% penalty on 5_000_000 = 500_000
+        // net payout = 4_500_000
+        assert_eq!(
+            balance_after - balance_before,
+            4_500_000,
+            "voucher should receive 50% stake minus 10% penalty"
+        );
+    }
+
+    #[test]
+    fn test_partial_withdraw_reduces_stake() {
+        let s = setup();
+        disburse_loan(&s);
+
+        s.client.partial_withdraw(&s.voucher, &s.borrower);
+
+        let vouches = s.client.get_vouches(&s.borrower);
+        let remaining_stake = vouches
+            .iter()
+            .find(|v| v.voucher == s.voucher)
+            .map(|v| v.stake)
+            .unwrap_or(0);
+        assert_eq!(
+            remaining_stake, 5_000_000,
+            "stake should be halved after partial withdrawal"
+        );
+    }
+
+    // ── decrease_stake queuing ────────────────────────────────────────────────
+
+    #[test]
+    fn test_decrease_stake_queues_during_active_loan() {
+        let s = setup();
+        disburse_loan(&s);
+
+        s.client.decrease_stake(&s.voucher, &s.borrower, &1_000_000);
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 1, "decrease_stake should queue during active loan");
+    }
+
+    #[test]
+    fn test_decrease_stake_executes_immediately_no_loan() {
+        let s = setup();
+
+        let balance_before =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+
+        s.client.decrease_stake(&s.voucher, &s.borrower, &3_000_000);
+
+        let balance_after =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+        assert_eq!(
+            balance_after - balance_before,
+            3_000_000,
+            "decrease_stake should return tokens immediately when no active loan"
+        );
+    }
+
+    // ── withdraw_vouch queuing ────────────────────────────────────────────────
+
+    #[test]
+    fn test_withdraw_vouch_queues_during_active_loan() {
+        let s = setup();
+        disburse_loan(&s);
+
+        s.client.withdraw_vouch(&s.voucher, &s.borrower);
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 1, "withdraw_vouch should queue during active loan");
+    }
+
+    #[test]
+    fn test_withdraw_vouch_executes_immediately_no_loan() {
+        let s = setup();
+
+        let balance_before =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+
+        s.client.withdraw_vouch(&s.voucher, &s.borrower);
+
+        let balance_after =
+            soroban_sdk::token::Client::new(&s.env, &s.token_id).balance(&s.voucher);
+        assert_eq!(
+            balance_after - balance_before,
+            10_000_000,
+            "full stake should be returned immediately when no active loan"
+        );
+    }
+
+    // ── get_withdrawal_queue ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_get_withdrawal_queue_empty_initially() {
+        let s = setup();
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 0, "queue should be empty initially");
+    }
+
+    #[test]
+    fn test_multiple_vouchers_in_queue() {
+        let s = setup();
+
+        let voucher2 = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher2, &5_000_000);
+        s.env.ledger().with_mut(|l| l.timestamp += 120);
+        s.client.vouch(&voucher2, &s.borrower, &5_000_000, &s.token_id);
+
+        disburse_loan(&s);
+
+        s.client.request_withdrawal(&s.voucher, &s.borrower, &0);
+        s.client.request_withdrawal(&voucher2, &s.borrower, &0);
+
+        let queue = s.client.get_withdrawal_queue(&s.borrower);
+        assert_eq!(queue.len(), 2, "both vouchers should be in the queue");
+    }
+}


### PR DESCRIPTION
closes #613
- Add request_withdrawal(): queue stake withdrawal during active loan with optional priority fee (paid to remaining vouchers on processing)
- Add partial_withdraw(): withdraw up to 50% of stake mid-loan with 10% penalty distributed proportionally to remaining vouchers
- Add process_withdrawal_queue(): called after repay/slash to process all queued withdrawals in priority-fee order
- Add get_withdrawal_queue(): query pending withdrawals for a borrower
- decrease_stake() and withdraw_vouch() now queue automatically when borrower has an active loan instead of returning ActiveLoanExists
- Add QueuedWithdrawal type and WithdrawalQueue DataKey to types.rs
- Add WithdrawalAlreadyQueued, WithdrawalNotQueued, PartialWithdrawalExceedsCap error codes to errors.rs
- Add PARTIAL_WITHDRAWAL_PENALTY_BPS (10%) and PARTIAL_WITHDRAWAL_MAX_BPS (50%) constants to types.rs
- 12 new tests covering all queue scenarios

Closes #withdrawal-queue-enhancement

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
