### PR TITLE
feat: add chain_id to VouchRecord and implement bridge validation for…

### DIFF
--- a/src/cross_chain_vouch_test.rs
+++ b/src/cross_chain_vouch_test.rs
@@ -1,0 +1,160 @@
+#[cfg(test)]
+mod cross_chain_vouch_tests {
+    use crate::errors::ContractError;
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::Address as _, token::StellarAssetClient, Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        admin: Address,
+        /// Primary token — also used as the bridge address in tests for simplicity.
+        token: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = env
+            .register_stellar_asset_contract_v2(admin.clone())
+            .address();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        client.initialize(
+            &deployer,
+            &Vec::from_array(&env, [admin.clone()]),
+            &1,
+            &token,
+        );
+
+        Setup { env, client, admin, token }
+    }
+
+    #[test]
+    fn test_register_bridge_and_cross_chain_vouch() {
+        let s = setup();
+        let chain_id: u32 = 1; // Ethereum mainnet
+
+        // Register the primary token as the bridge address for chain 1.
+        // In production the bridge address would be a separate wrapped-token contract.
+        s.client.register_bridge(
+            &Vec::from_array(&s.env, [s.admin.clone()]),
+            &chain_id,
+            &String::from_str(&s.env, "ethereum"),
+            &s.token,
+        );
+
+        // Verify bridge is registered
+        let bridges = s.client.get_bridges();
+        assert_eq!(bridges.len(), 1);
+        assert_eq!(bridges.get(0).unwrap().chain_id, chain_id);
+        assert!(bridges.get(0).unwrap().active);
+
+        // Voucher stakes using the bridge token with chain_id
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
+
+        s.client
+            .vouch(&voucher, &borrower, &1_000_000, &s.token, &Some(chain_id));
+
+        // Verify vouch was recorded with chain_id
+        let vouches = s.client.get_vouches(&borrower);
+        assert_eq!(vouches.len(), 1);
+        let vouch = vouches.get(0).unwrap();
+        assert_eq!(vouch.chain_id, Some(chain_id));
+        assert_eq!(vouch.stake, 1_000_000);
+    }
+
+    #[test]
+    fn test_vouch_with_unregistered_chain_id_rejected() {
+        let s = setup();
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
+
+        // chain_id 99 is not registered — should fail
+        let result = s
+            .client
+            .try_vouch(&voucher, &borrower, &1_000_000, &s.token, &Some(99u32));
+        assert_eq!(result, Err(Ok(ContractError::InvalidChain)));
+    }
+
+    #[test]
+    fn test_remove_bridge_prevents_new_vouches() {
+        let s = setup();
+        let chain_id: u32 = 137; // Polygon
+
+        s.client.register_bridge(
+            &Vec::from_array(&s.env, [s.admin.clone()]),
+            &chain_id,
+            &String::from_str(&s.env, "polygon"),
+            &s.token,
+        );
+
+        // Deactivate the bridge
+        s.client.remove_bridge(
+            &Vec::from_array(&s.env, [s.admin.clone()]),
+            &chain_id,
+        );
+
+        let bridges = s.client.get_bridges();
+        assert!(!bridges.get(0).unwrap().active);
+
+        // New vouch with deactivated bridge should fail
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
+
+        let result = s
+            .client
+            .try_vouch(&voucher, &borrower, &1_000_000, &s.token, &Some(chain_id));
+        assert_eq!(result, Err(Ok(ContractError::InvalidChain)));
+    }
+
+    #[test]
+    fn test_duplicate_bridge_registration_rejected() {
+        let s = setup();
+        let chain_id: u32 = 1;
+
+        s.client.register_bridge(
+            &Vec::from_array(&s.env, [s.admin.clone()]),
+            &chain_id,
+            &String::from_str(&s.env, "ethereum"),
+            &s.token,
+        );
+
+        let result = s.client.try_register_bridge(
+            &Vec::from_array(&s.env, [s.admin.clone()]),
+            &chain_id,
+            &String::from_str(&s.env, "ethereum"),
+            &s.token,
+        );
+        assert_eq!(result, Err(Ok(ContractError::BridgeAlreadyRegistered)));
+    }
+
+    #[test]
+    fn test_native_vouch_no_chain_id_unaffected() {
+        let s = setup();
+
+        let voucher = Address::generate(&s.env);
+        let borrower = Address::generate(&s.env);
+        StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
+
+        // Native vouch with no chain_id — should succeed without any bridge registered
+        s.client
+            .vouch(&voucher, &borrower, &1_000_000, &s.token, &None);
+
+        let vouches = s.client.get_vouches(&borrower);
+        assert_eq!(vouches.len(), 1);
+        assert_eq!(vouches.get(0).unwrap().chain_id, None);
+    }
+}

--- a/src/decrease_stake_full_withdrawal_test.rs
+++ b/src/decrease_stake_full_withdrawal_test.rs
@@ -37,7 +37,7 @@ mod decrease_stake_full_withdrawal_tests {
 
         // Step 1: Voucher A vouches with 1,000,000 stroops.
         StellarAssetClient::new(&env, &token_id).mint(&voucher_a, &1_000_000);
-        client.vouch(&voucher_a, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher_a, &borrower, &1_000_000, &token_id, &None);
 
         let balance_before = soroban_sdk::token::Client::new(&env, &token_id).balance(&voucher_a);
 

--- a/src/double_slash_panic_test.rs
+++ b/src/double_slash_panic_test.rs
@@ -58,7 +58,7 @@ mod double_slash_panic_tests {
         let borrower = Address::generate(&s.env);
 
         StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
-        s.client.vouch(&voucher, &borrower, &1_000_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.token, &None);
         s.client.request_loan(
             &borrower,
             &100_000,
@@ -133,7 +133,7 @@ mod double_slash_panic_tests {
         let voucher = Address::generate(&s.env);
         let borrower = Address::generate(&s.env);
         StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &1_000_000);
-        s.client.vouch(&voucher, &borrower, &1_000_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.token, &None);
 
         let result = s.client.try_vote_slash(&voucher, &borrower, &true);
         assert!(

--- a/src/duplicate_loan_test.rs
+++ b/src/duplicate_loan_test.rs
@@ -44,7 +44,7 @@ mod duplicate_loan_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address) {

--- a/src/duplicate_vouch_test.rs
+++ b/src/duplicate_vouch_test.rs
@@ -26,9 +26,9 @@ mod duplicate_vouch_tests {
         let (contract_id, token_id, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
-        let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
         assert_eq!(result, Err(Ok(ContractError::DuplicateVouch)));
     }
 
@@ -40,7 +40,7 @@ mod duplicate_vouch_tests {
         let (contract_id, token_id, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         let result = client.try_increase_stake(&voucher, &borrower, &500_000);
         assert!(result.is_ok());

--- a/src/dynamic_yield_test.rs
+++ b/src/dynamic_yield_test.rs
@@ -46,7 +46,7 @@ mod dynamic_yield_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,4 +57,8 @@ pub enum ContractError {
     WithdrawalNotQueued = 47,
     /// Partial withdrawal amount exceeds the 50% cap.
     PartialWithdrawalExceedsCap = 48,
+    /// The chain_id supplied for a cross-chain vouch is not registered or inactive.
+    InvalidChain = 49,
+    /// A bridge with this chain_id is already registered.
+    BridgeAlreadyRegistered = 50,
 }

--- a/src/execute_slash_vote_quorum_test.rs
+++ b/src/execute_slash_vote_quorum_test.rs
@@ -64,7 +64,7 @@ mod execute_slash_vote_quorum_tests {
         // Step 2: Create loan with 3 vouchers, each staking 1_000_000
         for voucher in [&voucher_a, &voucher_b, &voucher_c] {
             StellarAssetClient::new(&env, &token_id).mint(voucher, &1_000_000);
-            client.vouch(voucher, &borrower, &1_000_000, &token_id);
+            client.vouch(voucher, &borrower, &1_000_000, &token_id, &None);
         }
         client.request_loan(
             &borrower,

--- a/src/full_lifecycle_test.rs
+++ b/src/full_lifecycle_test.rs
@@ -39,8 +39,8 @@ mod full_lifecycle_tests {
         token_client.mint(&borrower, &1_000);
 
         // Step 3: Vouch for borrower
-        client.vouch(&voucher1, &borrower, &5_000, &token);
-        client.vouch(&voucher2, &borrower, &5_000, &token);
+        client.vouch(&voucher1, &borrower, &5_000, &token, &None);
+        client.vouch(&voucher2, &borrower, &5_000, &token, &None);
 
         // Verify vouches exist
         assert!(client.vouch_exists(&voucher1, &borrower), "Voucher1 vouch should exist");
@@ -133,9 +133,9 @@ mod full_lifecycle_tests {
         token_client.mint(&borrower, &1_000);
 
         // Vouch with different amounts
-        client.vouch(&voucher1, &borrower, &3_000, &token);
-        client.vouch(&voucher2, &borrower, &4_000, &token);
-        client.vouch(&voucher3, &borrower, &3_000, &token);
+        client.vouch(&voucher1, &borrower, &3_000, &token, &None);
+        client.vouch(&voucher2, &borrower, &4_000, &token, &None);
+        client.vouch(&voucher3, &borrower, &3_000, &token, &None);
 
         // Verify total vouched
         let total_vouched = client.total_vouched(&borrower);
@@ -214,7 +214,7 @@ mod full_lifecycle_tests {
         assert_eq!(stored_referrer, Some(referrer.clone()), "Referrer should be set");
 
         // Vouch for borrower
-        client.vouch(&voucher, &borrower, &10_000, &token);
+        client.vouch(&voucher, &borrower, &10_000, &token, &None);
 
         // Request loan
         let loan_amount = 5_000;

--- a/src/fuzz_loan_state_machine_test.rs
+++ b/src/fuzz_loan_state_machine_test.rs
@@ -39,7 +39,7 @@ mod tests {
         );
 
         // Setup: Create vouches
-        contract.vouch(&env, voucher.clone(), borrower.clone(), 1_000_000_000, token.clone());
+        contract.vouch(&env, voucher.clone(), borrower.clone(), 1_000_000_000, token.clone(), None);
 
         // Verify initial state is None
         let status = contract.loan_status(&env, borrower.clone());
@@ -94,8 +94,8 @@ mod tests {
         );
 
         // Setup: Multiple vouchers
-        contract.vouch(&env, voucher1.clone(), borrower.clone(), 500_000_000, token.clone());
-        contract.vouch(&env, voucher2.clone(), borrower.clone(), 500_000_000, token.clone());
+        contract.vouch(&env, voucher1.clone(), borrower.clone(), 500_000_000, token.clone(), None);
+        contract.vouch(&env, voucher2.clone(), borrower.clone(), 500_000_000, token.clone(), None);
 
         // Request loan
         contract.request_loan(
@@ -172,6 +172,7 @@ mod tests {
                 borrower_i.clone(),
                 loan_amount * 2,
                 token.clone(),
+                None,
             );
 
             // Request loan
@@ -227,6 +228,7 @@ mod tests {
             borrower.clone(),
             stake_amount,
             token.clone(),
+            None,
         );
 
         // Request loan
@@ -287,7 +289,7 @@ mod tests {
         ];
 
         for (voucher, stake) in vouchers.iter() {
-            contract.vouch(&env, voucher.clone(), borrower.clone(), stake, token.clone());
+            contract.vouch(&env, voucher.clone(), borrower.clone(), stake, token.clone(), None);
         }
 
         // Request loan
@@ -341,7 +343,7 @@ mod tests {
             let borrower = Address::random(&env);
 
             // Vouch
-            contract.vouch(&env, voucher.clone(), borrower.clone(), 1_000_000_000, token.clone());
+            contract.vouch(&env, voucher.clone(), borrower.clone(), 1_000_000_000, token.clone(), None);
 
             // Request loan
             contract.request_loan(

--- a/src/fuzz_request_loan_test.rs
+++ b/src/fuzz_request_loan_test.rs
@@ -49,7 +49,7 @@ mod fuzz_request_loan_tests {
         let voucher = Address::generate(&s.env);
         let borrower = Address::generate(&s.env);
         StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &stake);
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
         // Advance past MIN_VOUCH_AGE.
         s.env.ledger().with_mut(|l| l.timestamp += 61);
         StellarAssetClient::new(&s.env, &s.token).mint(&s.client.address, &fund);

--- a/src/fuzz_vouch_test.rs
+++ b/src/fuzz_vouch_test.rs
@@ -61,7 +61,7 @@ mod fuzz_vouch_tests {
                 StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &stake);
             }
 
-            let result = client.try_vouch(&voucher, &borrower, &stake, &token_id.address());
+            let result = client.try_vouch(&voucher, &borrower, &stake, &token_id.address(), &None);
 
             match stake {
                 s if s <= 0 => {

--- a/src/governance_test.rs
+++ b/src/governance_test.rs
@@ -47,7 +47,7 @@ mod governance_tests {
     /// Vouch for `borrower` from `voucher` with `stake`, minting tokens first.
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// Request a loan for `borrower` (vouches must already meet threshold).

--- a/src/input_validation_test.rs
+++ b/src/input_validation_test.rs
@@ -95,7 +95,7 @@ mod input_validation_tests {
 
         // Give voucher some tokens and vouch (but no loan is ever requested)
         StellarAssetClient::new(&env, &token_id).mint(&voucher, &1_000_000);
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         // borrower has no active loan → vote_slash must fail
         let result = client.try_vote_slash(&voucher, &borrower, &true);
@@ -117,7 +117,7 @@ mod input_validation_tests {
         let voucher = Address::generate(&env);
         let borrower = Address::generate(&env);
 
-        let result = client.try_vouch(&voucher, &borrower, &0i128, &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &0i128, &token_id, &None);
         assert_eq!(
             result,
             Err(Ok(ContractError::InsufficientFunds)),
@@ -134,7 +134,7 @@ mod input_validation_tests {
         let voucher = Address::generate(&env);
         let borrower = Address::generate(&env);
 
-        let result = client.try_vouch(&voucher, &borrower, &-1_000_000i128, &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &-1_000_000i128, &token_id, &None);
         assert_eq!(
             result,
             Err(Ok(ContractError::InsufficientFunds)),
@@ -154,7 +154,7 @@ mod input_validation_tests {
         let borrower = Address::generate(&env);
 
         StellarAssetClient::new(&env, &token_id).mint(&voucher, &1_000_000);
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         let result = client.try_increase_stake(&voucher, &borrower, &0i128);
         assert_eq!(
@@ -174,7 +174,7 @@ mod input_validation_tests {
         let borrower = Address::generate(&env);
 
         StellarAssetClient::new(&env, &token_id).mint(&voucher, &1_000_000);
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         let result = client.try_increase_stake(&voucher, &borrower, &-500_000i128);
         assert_eq!(

--- a/src/insufficient_balance_test.rs
+++ b/src/insufficient_balance_test.rs
@@ -53,7 +53,7 @@ mod insufficient_balance_tests {
 
         // Fund voucher and vouch — stake is transferred into the contract.
         StellarAssetClient::new(&s.env, &s.token).mint(&voucher, &stake);
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
 
         // Advance time past MIN_VOUCH_AGE (60s) so the vouch is eligible.
         s.env.ledger().with_mut(|l| l.timestamp += 61);

--- a/src/insurance_pool_test.rs
+++ b/src/insurance_pool_test.rs
@@ -57,7 +57,7 @@ mod insurance_pool_tests {
         let voucher = Address::generate(&env);
 
         StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &10_000_000);
-        client.vouch(&voucher, &borrower, &10_000_000, &token_id.address());
+        client.vouch(&voucher, &borrower, &10_000_000, &token_id.address(), &None);
 
         Setup { env, client, token_id: token_id.address(), admin, borrower, voucher }
     }

--- a/src/insurance_test.rs
+++ b/src/insurance_test.rs
@@ -45,7 +45,7 @@ mod insurance_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// Trigger a slash so the loan is Defaulted and voucher history is recorded.

--- a/src/invariants_test.rs
+++ b/src/invariants_test.rs
@@ -147,7 +147,7 @@ mod invariants_tests {
         let voucher = Address::generate(&s.env);
         mint(&s, &voucher, 10_000);
 
-        s.client.vouch(&voucher, &borrower, &5_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &5_000, &s.token, &None);
         verify_invariants(&s, &[borrower]);
     }
 
@@ -158,7 +158,7 @@ mod invariants_tests {
         let voucher = Address::generate(&s.env);
         mint(&s, &voucher, 10_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
         verify_invariants(&s, &[borrower.clone()]);
 
         s.client
@@ -174,7 +174,7 @@ mod invariants_tests {
         mint(&s, &voucher, 10_000);
         mint(&s, &borrower, 1_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
         s.client
             .request_loan(&borrower, &5_000, &5_000, &purpose(&s.env), &s.token);
         verify_invariants(&s, &[borrower.clone()]);
@@ -192,7 +192,7 @@ mod invariants_tests {
         let voucher = Address::generate(&s.env);
         mint(&s, &voucher, 10_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
         s.client
             .request_loan(&borrower, &5_000, &5_000, &purpose(&s.env), &s.token);
         verify_invariants(&s, &[borrower.clone()]);
@@ -210,7 +210,7 @@ mod invariants_tests {
         mint(&s, &voucher, 10_000);
         mint(&s, &borrower, 50_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
         s.client
             .request_loan(&borrower, &5_000, &5_000, &purpose(&s.env), &s.token);
 
@@ -233,7 +233,7 @@ mod invariants_tests {
         mint(&s, &voucher, 10_000);
         mint(&s, &borrower, 10_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
         s.client
             .request_loan(&borrower, &5_000, &5_000, &purpose(&s.env), &s.token);
 
@@ -254,7 +254,7 @@ mod invariants_tests {
         let voucher = Address::generate(&s.env);
         mint(&s, &voucher, 10_000);
 
-        s.client.vouch(&voucher, &borrower, &10_000, &s.token);
+        s.client.vouch(&voucher, &borrower, &10_000, &s.token, &None);
 
         // Contract balance must be >= 10_000 (the locked stake)
         let cb = balance(&s, &s.contract_id);
@@ -284,10 +284,10 @@ mod invariants_tests {
         mint(&s, &v2, 10_000);
         mint(&s, &borrower, 5_000);
 
-        s.client.vouch(&v1, &borrower, &6_000, &s.token);
+        s.client.vouch(&v1, &borrower, &6_000, &s.token, &None);
         verify_invariants(&s, &[borrower.clone()]);
 
-        s.client.vouch(&v2, &borrower, &4_000, &s.token);
+        s.client.vouch(&v2, &borrower, &4_000, &s.token, &None);
         verify_invariants(&s, &[borrower.clone()]);
 
         s.client

--- a/src/is_eligible_token_filter_test.rs
+++ b/src/is_eligible_token_filter_test.rs
@@ -42,7 +42,7 @@ mod is_eligible_token_filter_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128, token: &Address) {
         StellarAssetClient::new(&s.env, token).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, token);
+        s.client.vouch(voucher, borrower, &stake, token, &None);
     }
 
     /// Issue #368: is_eligible filters vouches by token — USDC vouches don't count for XLM loans.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Str
 
 #[cfg(test)]
 mod withdrawal_queue_test;
+#[cfg(test)]
+mod cross_chain_vouch_test;
 
 use crate::errors::ContractError;
 use crate::helpers::{config, get_active_loan_record, has_active_loan, require_allowed_token, require_not_paused};
@@ -78,8 +80,9 @@ impl QuorumCreditContract {
         borrower: Address,
         stake: i128,
         token: Address,
+        chain_id: Option<u32>,
     ) -> Result<(), ContractError> {
-        vouch::vouch(env, voucher, borrower, stake, token)
+        vouch::vouch(env, voucher, borrower, stake, token, chain_id)
     }
 
     pub fn batch_vouch(
@@ -88,8 +91,9 @@ impl QuorumCreditContract {
         borrowers: Vec<Address>,
         stakes: Vec<i128>,
         token: Address,
+        chain_id: Option<u32>,
     ) -> Result<(), ContractError> {
-        vouch::batch_vouch(env, voucher, borrowers, stakes, token)
+        vouch::batch_vouch(env, voucher, borrowers, stakes, token, chain_id)
     }
 
     // ─────────────────────────────────────────────
@@ -153,6 +157,36 @@ impl QuorumCreditContract {
     /// Get the pending withdrawal queue for a borrower.
     pub fn get_withdrawal_queue(env: Env, borrower: Address) -> Vec<QueuedWithdrawal> {
         vouch::get_withdrawal_queue(env, borrower)
+    }
+
+    // ─────────────────────────────────────────────
+    // Cross-chain Bridge Management
+    // ─────────────────────────────────────────────
+
+    /// Register a cross-chain bridge so vouchers can stake tokens from other chains.
+    /// Requires admin quorum. `chain_id` must be unique (e.g. 1 = Ethereum, 137 = Polygon).
+    pub fn register_bridge(
+        env: Env,
+        admin_signers: Vec<Address>,
+        chain_id: u32,
+        chain_name: String,
+        bridge_address: Address,
+    ) -> Result<(), ContractError> {
+        vouch::register_bridge(env, admin_signers, chain_id, chain_name, bridge_address)
+    }
+
+    /// Deactivate a registered bridge. Existing vouches are unaffected; new ones are rejected.
+    pub fn remove_bridge(
+        env: Env,
+        admin_signers: Vec<Address>,
+        chain_id: u32,
+    ) -> Result<(), ContractError> {
+        vouch::remove_bridge(env, admin_signers, chain_id)
+    }
+
+    /// Return all registered bridges (active and inactive).
+    pub fn get_bridges(env: Env) -> Vec<crate::types::BridgeRecord> {
+        vouch::get_bridges(env)
     }
 
     // ─────────────────────────────────────────────

--- a/src/loan_deadline_enforcement_test.rs
+++ b/src/loan_deadline_enforcement_test.rs
@@ -36,7 +36,7 @@ mod loan_deadline_enforcement_tests {
         client.set_config(&Vec::from_array(env, [_admin.clone()]), &config);
 
         // Have voucher vouch
-        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id, &None);
 
         // Request loan
         client.request_loan(

--- a/src/loan_overwrite_protection_test.rs
+++ b/src/loan_overwrite_protection_test.rs
@@ -45,7 +45,7 @@ mod loan_overwrite_protection_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// Verify that request_loan blocks when an active loan already exists.

--- a/src/loan_purpose_test.rs
+++ b/src/loan_purpose_test.rs
@@ -27,7 +27,7 @@ mod loan_purpose_tests {
         let voucher = Address::generate(&env);
         let borrower = Address::generate(&env);
         StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &1_000_000);
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id.address());
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id.address(), &None);
 
         (env, client, borrower, token_id.address())
     }

--- a/src/max_loan_amount_test.rs
+++ b/src/max_loan_amount_test.rs
@@ -33,7 +33,7 @@ mod max_loan_amount_tests {
         let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id, &None);
 
         let result = client.try_request_loan(
             &borrower,
@@ -54,7 +54,7 @@ mod max_loan_amount_tests {
         let (contract_id, token_id, _admin, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id, &None);
 
         let result = client.try_request_loan(
             &borrower,

--- a/src/max_loan_to_stake_ratio_test.rs
+++ b/src/max_loan_to_stake_ratio_test.rs
@@ -32,7 +32,7 @@ mod max_loan_to_stake_ratio_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Have voucher vouch with 1,000,000 stroops
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         // Attempt to request 1,100,000 stroops (exceeds 1:1 ratio)
         let result = client.try_request_loan(
@@ -55,7 +55,7 @@ mod max_loan_to_stake_ratio_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Have voucher vouch with 1,000,000 stroops
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id, &None);
 
         // Request 1,000,000 stroops (exactly 1:1 ratio)
         let result = client.try_request_loan(

--- a/src/max_vouchers_per_borrower_test.rs
+++ b/src/max_vouchers_per_borrower_test.rs
@@ -58,12 +58,12 @@ mod tests {
         token_admin.mint(&voucher4, &1_000_000);
 
         // First 3 vouches should succeed
-        client.vouch(&voucher1, &borrower, &100_000, &token);
-        client.vouch(&voucher2, &borrower, &100_000, &token);
-        client.vouch(&voucher3, &borrower, &100_000, &token);
+        client.vouch(&voucher1, &borrower, &100_000, &token, &None);
+        client.vouch(&voucher2, &borrower, &100_000, &token, &None);
+        client.vouch(&voucher3, &borrower, &100_000, &token, &None);
 
         // 4th vouch should fail with MaxVouchersPerBorrowerExceeded error
-        let result = client.try_vouch(&voucher4, &borrower, &100_000, &token);
+        let result = client.try_vouch(&voucher4, &borrower, &100_000, &token, &None);
         assert!(result.is_err());
         assert_eq!(
             result.err(),
@@ -180,18 +180,18 @@ mod tests {
         token_admin.mint(&voucher3, &1_000_000);
 
         // Add 2 vouches (at limit)
-        client.vouch(&voucher1, &borrower, &100_000, &token);
-        client.vouch(&voucher2, &borrower, &100_000, &token);
+        client.vouch(&voucher1, &borrower, &100_000, &token, &None);
+        client.vouch(&voucher2, &borrower, &100_000, &token, &None);
 
         // 3rd vouch should fail
-        let result = client.try_vouch(&voucher3, &borrower, &100_000, &token);
+        let result = client.try_vouch(&voucher3, &borrower, &100_000, &token, &None);
         assert!(result.is_err());
 
         // Withdraw one vouch
         client.withdraw_vouch(&voucher1, &borrower);
 
         // Now voucher3 should be able to vouch
-        client.vouch(&voucher3, &borrower, &100_000, &token);
+        client.vouch(&voucher3, &borrower, &100_000, &token, &None);
 
         let vouches = client.get_vouches(&borrower).unwrap();
         assert_eq!(vouches.len(), 2);

--- a/src/min_loan_amount_test.rs
+++ b/src/min_loan_amount_test.rs
@@ -30,7 +30,7 @@ mod min_loan_amount_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Vouch with sufficient stake
-        client.vouch(&voucher, &borrower, &500_000, &token_id);
+        client.vouch(&voucher, &borrower, &500_000, &token_id, &None);
 
         // Try to request loan with amount below minimum (DEFAULT_MIN_LOAN_AMOUNT = 100_000)
         let result = client.try_request_loan(
@@ -52,7 +52,7 @@ mod min_loan_amount_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Vouch with sufficient stake
-        client.vouch(&voucher, &borrower, &500_000, &token_id);
+        client.vouch(&voucher, &borrower, &500_000, &token_id, &None);
 
         // Request loan with amount exactly at minimum (DEFAULT_MIN_LOAN_AMOUNT = 100_000)
         let result = client.try_request_loan(
@@ -74,7 +74,7 @@ mod min_loan_amount_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Vouch with sufficient stake
-        client.vouch(&voucher, &borrower, &500_000, &token_id);
+        client.vouch(&voucher, &borrower, &500_000, &token_id, &None);
 
         // Try to request loan with amount just below minimum
         let result = client.try_request_loan(

--- a/src/mint_reputation_nft_test.rs
+++ b/src/mint_reputation_nft_test.rs
@@ -53,7 +53,7 @@ mod mint_reputation_nft_tests {
     fn do_full_repay(s: &Setup, borrower: &Address, voucher: &Address) {
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(voucher, &500_000);
-        s.client.vouch(voucher, borrower, &500_000, &s.token_id);
+        s.client.vouch(voucher, borrower, &500_000, &s.token_id, &None);
         s.client.request_loan(borrower, &100_000, &500_000, &String::from_str(&s.env, "test"), &s.token_id);
         // principal 100_000 + 2% yield 2_000 = 102_000
         token.mint(borrower, &102_000);
@@ -110,7 +110,7 @@ mod mint_reputation_nft_tests {
         let voucher = Address::generate(&env);
         let token = StellarAssetClient::new(&env, &token_id.address());
         token.mint(&voucher, &500_000);
-        client.vouch(&voucher, &borrower, &500_000, &token_id.address());
+        client.vouch(&voucher, &borrower, &500_000, &token_id.address(), &None);
         client.request_loan(&borrower, &100_000, &500_000, &String::from_str(&env, "t"), &token_id.address());
         token.mint(&borrower, &102_000);
         client.repay(&borrower, &102_000);

--- a/src/multi_asset_test.rs
+++ b/src/multi_asset_test.rs
@@ -56,7 +56,7 @@ mod multi_asset_tests {
         let borrower = Address::generate(&s.env);
 
         StellarAssetClient::new(&s.env, &s.usdc).mint(&voucher, &1_000_000);
-        s.client.vouch(&voucher, &borrower, &1_000_000, &s.usdc);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.usdc, &None);
         s.client
             .request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.usdc);
 
@@ -72,7 +72,7 @@ mod multi_asset_tests {
         let borrower = Address::generate(&s.env);
 
         StellarAssetClient::new(&s.env, &s.xlm).mint(&voucher, &1_000_000);
-        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm, &None);
 
         let result =
             s.client
@@ -89,7 +89,7 @@ mod multi_asset_tests {
 
         let result = s
             .client
-            .try_vouch(&voucher, &borrower, &100_000, &random_token);
+            .try_vouch(&voucher, &borrower, &100_000, &random_token, &None);
         assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
     }
 
@@ -117,7 +117,7 @@ mod multi_asset_tests {
 
         let voucher = Address::generate(&s.env);
         let borrower = Address::generate(&s.env);
-        let result = s.client.try_vouch(&voucher, &borrower, &100_000, &s.usdc);
+        let result = s.client.try_vouch(&voucher, &borrower, &100_000, &s.usdc, &None);
         assert_eq!(result, Err(Ok(ContractError::InvalidToken)));
     }
 
@@ -128,7 +128,7 @@ mod multi_asset_tests {
         let borrower = Address::generate(&s.env);
 
         StellarAssetClient::new(&s.env, &s.xlm).mint(&voucher, &1_000_000);
-        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm);
+        s.client.vouch(&voucher, &borrower, &1_000_000, &s.xlm, &None);
         s.client
             .request_loan(&borrower, &100_000, &500_000, &purpose(&s.env), &s.xlm);
 

--- a/src/multi_token_vouch_test.rs
+++ b/src/multi_token_vouch_test.rs
@@ -39,11 +39,11 @@ mod multi_token_vouch_tests {
 
         // Voucher A vouches with XLM
         StellarAssetClient::new(&env, &xlm_id.address()).mint(&voucher_a, &1_000_000);
-        client.vouch(&voucher_a, &borrower, &1_000_000, &xlm_id.address());
+        client.vouch(&voucher_a, &borrower, &1_000_000, &xlm_id.address(), &None);
 
         // Voucher B vouches with USDC
         StellarAssetClient::new(&env, &usdc_id.address()).mint(&voucher_b, &1_000_000);
-        client.vouch(&voucher_b, &borrower, &1_000_000, &usdc_id.address());
+        client.vouch(&voucher_b, &borrower, &1_000_000, &usdc_id.address(), &None);
 
         // Assert both vouches are recorded with the correct token
         let vouches = client.get_vouches(&borrower);

--- a/src/multi_voucher_stake_test.rs
+++ b/src/multi_voucher_stake_test.rs
@@ -43,7 +43,7 @@ mod multi_voucher_stake_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/oracle_credit_score_test.rs
+++ b/src/oracle_credit_score_test.rs
@@ -52,7 +52,7 @@ mod oracle_credit_score_tests {
     fn vouch_and_advance(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
         s.env.ledger().with_mut(|l| l.timestamp = 90_000);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     // ── set_oracle ────────────────────────────────────────────────────────────

--- a/src/partial_repay_test.rs
+++ b/src/partial_repay_test.rs
@@ -42,7 +42,7 @@ mod partial_repay_tests {
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/paused_state_test.rs
+++ b/src/paused_state_test.rs
@@ -63,7 +63,7 @@ fn test_vouch_blocked_when_paused() {
     assert_eq!(client.get_paused(), true);
 
     // Try to vouch - should fail
-    let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
 }
 
@@ -88,7 +88,7 @@ fn test_increase_stake_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
 
     // First vouch while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Pause the contract
     let admin_signers = Vec::from_array(&env, [admin.clone()]);
@@ -104,7 +104,7 @@ fn test_decrease_stake_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
 
     // First vouch while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Pause the contract
     let admin_signers = Vec::from_array(&env, [admin.clone()]);
@@ -120,7 +120,7 @@ fn test_withdraw_vouch_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
 
     // First vouch while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Pause the contract
     let admin_signers = Vec::from_array(&env, [admin.clone()]);
@@ -138,7 +138,7 @@ fn test_transfer_vouch_blocked_when_paused() {
     let new_voucher = Address::generate(&env);
 
     // First vouch while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Pause the contract
     let admin_signers = Vec::from_array(&env, [admin.clone()]);
@@ -154,7 +154,7 @@ fn test_request_loan_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, token_client) = setup_test_env();
 
     // Setup: vouch while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -185,7 +185,7 @@ fn test_repay_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, token_client) = setup_test_env();
 
     // Setup: vouch and request loan while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -218,7 +218,7 @@ fn test_vote_slash_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, token_client) = setup_test_env();
 
     // Setup: vouch and request loan while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -251,7 +251,7 @@ fn test_propose_slash_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, token_client) = setup_test_env();
 
     // Setup: vouch and request loan while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -284,7 +284,7 @@ fn test_execute_slash_proposal_blocked_when_paused() {
     let (env, client, admin, voucher, borrower, token_addr, token_client) = setup_test_env();
 
     // Setup: vouch and request loan while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -345,7 +345,7 @@ fn test_operations_work_after_unpause() {
     assert_eq!(client.get_paused(), true);
 
     // Try to vouch - should fail
-    let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
     assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
 
     // Unpause the contract
@@ -355,7 +355,7 @@ fn test_operations_work_after_unpause() {
     assert_eq!(client.get_paused(), false);
 
     // Now vouch should work
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Verify vouch was successful
     assert!(client.vouch_exists(&voucher, &borrower));
@@ -369,7 +369,7 @@ fn test_all_fund_moving_functions_respect_pause() {
     let new_voucher = Address::generate(&env);
 
     // Setup: create vouches and loan while unpaused
-    client.vouch(&voucher, &borrower, &1_000_000, &token_addr);
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
 
     // Fund the contract for loan disbursement
     token_client.mint(
@@ -394,7 +394,7 @@ fn test_all_fund_moving_functions_respect_pause() {
 
     // Test all fund-moving functions are blocked
     assert_eq!(
-        client.try_vouch(&voucher, &Address::generate(&env), &1_000_000, &token_addr),
+        client.try_vouch(&voucher, &Address::generate(&env), &1_000_000, &token_addr, &None),
         Err(Ok(ContractError::ContractPaused))
     );
 

--- a/src/property_inflow_outflow_test.rs
+++ b/src/property_inflow_outflow_test.rs
@@ -79,7 +79,7 @@ mod property_inflow_outflow_tests {
         let stake = 1_000_000i128;
 
         mint(&s, &voucher, stake);
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
 
         assert_invariant(&s, stake, 0, "after vouch");
     }
@@ -98,7 +98,7 @@ mod property_inflow_outflow_tests {
         let mut inflow = stake + loan;
         let mut outflow = 0i128;
 
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
         assert_invariant(&s, inflow, outflow, "after vouch");
 
         s.env.ledger().with_mut(|l| l.timestamp += 61);
@@ -123,7 +123,7 @@ mod property_inflow_outflow_tests {
         let mut inflow = stake + loan;
         let mut outflow = 0i128;
 
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
         s.env.ledger().with_mut(|l| l.timestamp += 61);
         s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
         outflow += loan;
@@ -154,7 +154,7 @@ mod property_inflow_outflow_tests {
         let mut inflow = stake + loan;
         let mut outflow = 0i128;
 
-        s.client.vouch(&voucher, &borrower, &stake, &s.token);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
         s.env.ledger().with_mut(|l| l.timestamp += 61);
         s.client.request_loan(&borrower, &loan, &stake, &purpose(&s.env), &s.token);
         outflow += loan;
@@ -192,7 +192,7 @@ mod property_inflow_outflow_tests {
             let total_owed = loan + yield_amt;
 
             mint(&s, &voucher, stake);
-            s.client.vouch(&voucher, &borrower, &stake, &s.token);
+            s.client.vouch(&voucher, &borrower, &stake, &s.token, &None);
             inflow += stake;
             assert_invariant(&s, inflow, outflow, "after vouch");
 

--- a/src/protocol_fee_collection_test.rs
+++ b/src/protocol_fee_collection_test.rs
@@ -36,7 +36,7 @@ mod protocol_fee_collection_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Have voucher vouch
-        client.vouch(&voucher, &borrower, &5_000_000, &token_id);
+        client.vouch(&voucher, &borrower, &5_000_000, &token_id, &None);
 
         // Request loan for 1,000,000 stroops
         client.request_loan(

--- a/src/referral_test.rs
+++ b/src/referral_test.rs
@@ -42,7 +42,7 @@ mod referral_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token);
+        s.client.vouch(voucher, borrower, &stake, &s.token, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address, amount: i128) {
@@ -168,7 +168,7 @@ mod referral_tests {
         let voucher = Address::generate(&env);
 
         StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &1_000_000);
-        client.vouch(&voucher, &borrower, &1_000_000, &token_id.address());
+        client.vouch(&voucher, &borrower, &1_000_000, &token_id.address(), &None);
         client.register_referral(&borrower, &referrer);
         client.request_loan(
             &borrower,

--- a/src/repay_multi_voucher_yield_test.rs
+++ b/src/repay_multi_voucher_yield_test.rs
@@ -50,7 +50,7 @@ mod repay_multi_voucher_yield_tests {
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/repay_overpayment_test.rs
+++ b/src/repay_overpayment_test.rs
@@ -39,7 +39,7 @@ mod repay_overpayment_tests {
         voucher: &Address,
         borrower: &Address,
     ) {
-        client.vouch(voucher, borrower, &5_000_000, token_id);
+        client.vouch(voucher, borrower, &5_000_000, token_id, &None);
         client.request_loan(
             borrower,
             &PRINCIPAL,

--- a/src/repay_protocol_fee_test.rs
+++ b/src/repay_protocol_fee_test.rs
@@ -42,7 +42,7 @@ mod repay_protocol_fee_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {

--- a/src/repayment_reminder_test.rs
+++ b/src/repayment_reminder_test.rs
@@ -42,7 +42,7 @@ mod repayment_reminder_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/request_loan_insufficient_stake_test.rs
+++ b/src/request_loan_insufficient_stake_test.rs
@@ -30,7 +30,7 @@ mod request_loan_insufficient_stake_tests {
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
         // Vouch with 100_000 stake but request loan with threshold of 500_000
-        client.vouch(&voucher, &borrower, &100_000, &token_id);
+        client.vouch(&voucher, &borrower, &100_000, &token_id, &None);
 
         let result = client.try_request_loan(
             &borrower,

--- a/src/request_loan_stake_threshold_test.rs
+++ b/src/request_loan_stake_threshold_test.rs
@@ -46,7 +46,7 @@ mod request_loan_stake_threshold_tests {
 
         // Step 1: Voucher A vouches with 1,000,000 stroops.
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher_a, &1_000_000);
-        s.client.vouch(&voucher_a, &borrower, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher_a, &borrower, &1_000_000, &s.token_id, &None);
 
         // Step 2: Attempt loan with threshold of 2,000,000 stroops.
         let result = s.client.try_request_loan(
@@ -74,7 +74,7 @@ mod request_loan_stake_threshold_tests {
 
         // Step 1: Voucher A vouches with 1,000,000 stroops.
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher_a, &1_000_000);
-        s.client.vouch(&voucher_a, &borrower, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher_a, &borrower, &1_000_000, &s.token_id, &None);
 
         // Step 4: Request with threshold of 1,000,000 stroops — must succeed.
         let result = s.client.try_request_loan(

--- a/src/security_fixes_test.rs
+++ b/src/security_fixes_test.rs
@@ -54,7 +54,7 @@ mod security_fixes_tests {
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(voucher, &stake);
-        s.client.vouch(&voucher, &borrower, &stake, &s.token_id);
+        s.client.vouch(&voucher, &borrower, &stake, &s.token_id, &None);
     }
 
     // ── Issue 108: Prevent Borrower from Repaying Another Borrower's Loan ──
@@ -313,7 +313,7 @@ mod security_fixes_tests {
         token.mint(&user, &stake);
 
         // Attempt to vouch for self should return SelfVouchNotAllowed
-        let result = s.client.try_vouch(&user, &user, &stake, &s.token_id);
+        let result = s.client.try_vouch(&user, &user, &stake, &s.token_id, &None);
         assert_eq!(result, Err(Ok(ContractError::SelfVouchNotAllowed)));
     }
 

--- a/src/slash_after_repay_test.rs
+++ b/src/slash_after_repay_test.rs
@@ -52,7 +52,7 @@ mod slash_after_repay_tests {
     /// Helper: mint tokens to voucher and vouch for borrower.
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// Helper: request a loan for borrower (loan amount = 100_000, threshold = stake).

--- a/src/slash_auth_test.rs
+++ b/src/slash_auth_test.rs
@@ -51,7 +51,7 @@ mod slash_auth_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address) {

--- a/src/slash_escrow_test.rs
+++ b/src/slash_escrow_test.rs
@@ -43,7 +43,7 @@ mod slash_escrow_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/slash_multi_voucher_test.rs
+++ b/src/slash_multi_voucher_test.rs
@@ -54,7 +54,7 @@ mod slash_multi_voucher_tests {
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         let token = StellarAssetClient::new(&s.env, &s.token_id);
         token.mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/slash_precision_small_stake_test.rs
+++ b/src/slash_precision_small_stake_test.rs
@@ -58,7 +58,7 @@ mod slash_precision_tests {
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         let token_client = StellarAssetClient::new(&s.env, &s.token_id);
         token_client.mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {

--- a/src/slash_vote_flow_test.rs
+++ b/src/slash_vote_flow_test.rs
@@ -51,7 +51,7 @@ mod slash_vote_flow_tests {
         // Step 1: Create loan with 3 vouchers, each staking 1_000_000
         for voucher in [&voucher_a, &voucher_b, &voucher_c] {
             StellarAssetClient::new(&env, &token_id).mint(voucher, &1_000_000);
-            client.vouch(voucher, &borrower, &1_000_000, &token_id);
+            client.vouch(voucher, &borrower, &1_000_000, &token_id, &None);
         }
         client.request_loan(
             &borrower,

--- a/src/types.rs
+++ b/src/types.rs
@@ -180,6 +180,8 @@ pub enum DataKey {
     VoucherStats(Address),
     /// Withdrawal queue: borrower → Vec<QueuedWithdrawal>
     WithdrawalQueue(Address),
+    /// Registered cross-chain bridges: Vec<BridgeRecord>
+    AllowedBridges,
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -303,6 +305,23 @@ pub struct VouchRecord {
     pub expiry_timestamp: Option<u64>,
     /// Optional delegate address; if set, this address can manage the vouch.
     pub delegate: Option<Address>,
+    /// Optional chain ID for cross-chain vouches. `None` means native Stellar.
+    /// When set, the token must originate from a registered bridge for that chain.
+    pub chain_id: Option<u32>,
+}
+
+/// Metadata for a registered cross-chain bridge.
+#[contracttype]
+#[derive(Clone)]
+pub struct BridgeRecord {
+    /// Numeric chain identifier (e.g. 1 = Ethereum mainnet, 137 = Polygon).
+    pub chain_id: u32,
+    /// Human-readable chain name (e.g. "ethereum", "polygon").
+    pub chain_name: soroban_sdk::String,
+    /// The Stellar-side bridge contract address that wraps/unwraps tokens.
+    pub bridge_address: Address,
+    /// Whether this bridge is currently active and accepted for new vouches.
+    pub active: bool,
 }
 
 #[contracttype]

--- a/src/vote_slash_auto_execute_test.rs
+++ b/src/vote_slash_auto_execute_test.rs
@@ -50,7 +50,7 @@ mod vote_slash_auto_execute_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -5,7 +5,7 @@ use crate::helpers::{
     has_active_loan, require_allowed_token, require_not_paused, require_positive_amount,
 };
 use crate::types::{
-    DataKey, QueuedWithdrawal, VouchHistoryEntry, VouchRecord,
+    BridgeRecord, DataKey, QueuedWithdrawal, VouchHistoryEntry, VouchRecord,
     PARTIAL_WITHDRAWAL_MAX_BPS, PARTIAL_WITHDRAWAL_PENALTY_BPS, BPS_DENOMINATOR,
 };
 use soroban_sdk::{symbol_short, token, Address, Env, Vec};
@@ -50,11 +50,12 @@ pub fn vouch(
     borrower: Address,
     stake: i128,
     token: Address,
+    chain_id: Option<u32>,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
     require_not_paused(&env)?;
     let cfg = VouchConfig::load(&env);
-    do_vouch(&env, &cfg, voucher, borrower, stake, token)
+    do_vouch(&env, &cfg, voucher, borrower, stake, token, chain_id)
 }
 
 fn validate_vouch<'a>(
@@ -64,6 +65,7 @@ fn validate_vouch<'a>(
     borrower: &Address,
     stake: i128,
     token: &Address,
+    chain_id: Option<u32>,
 ) -> Result<(token::Client<'a>, Vec<VouchRecord>), ContractError> {
     require_positive_amount(env, stake)?;
 
@@ -92,6 +94,12 @@ fn validate_vouch<'a>(
     }
 
     let token_client = require_allowed_token(env, token)?;
+
+    // Bridge validation: if chain_id is provided, the token must originate from
+    // a registered, active bridge for that chain.
+    if let Some(cid) = chain_id {
+        validate_bridge(env, cid, token)?;
+    }
 
     if cfg.min_stake > 0 && stake < cfg.min_stake {
         return Err(ContractError::MinStakeNotMet);
@@ -144,6 +152,7 @@ fn commit_vouch(
     stake: i128,
     token: Address,
     mut vouches: Vec<VouchRecord>,
+    chain_id: Option<u32>,
 ) -> Result<(), ContractError> {
     let contract = env.current_contract_address();
 
@@ -178,6 +187,7 @@ fn commit_vouch(
         token: token.clone(),
         expiry_timestamp: None,
         delegate: None,
+        chain_id,
     });
 
     env.storage()
@@ -226,9 +236,10 @@ fn do_vouch(
     borrower: Address,
     stake: i128,
     token: Address,
+    chain_id: Option<u32>,
 ) -> Result<(), ContractError> {
-    let (token_client, vouches) = validate_vouch(env, cfg, &voucher, &borrower, stake, &token)?;
-    commit_vouch(env, &token_client, voucher, borrower, stake, token, vouches)
+    let (token_client, vouches) = validate_vouch(env, cfg, &voucher, &borrower, stake, &token, chain_id)?;
+    commit_vouch(env, &token_client, voucher, borrower, stake, token, vouches, chain_id)
 }
 
 pub fn batch_vouch(
@@ -237,6 +248,7 @@ pub fn batch_vouch(
     borrowers: Vec<Address>,
     stakes: Vec<i128>,
     token: Address,
+    chain_id: Option<u32>,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
     require_not_paused(&env)?;
@@ -251,7 +263,7 @@ pub fn batch_vouch(
     for i in 0..borrowers.len() {
         let borrower = borrowers.get(i).unwrap();
         let stake = stakes.get(i).unwrap();
-        validate_vouch(&env, &cfg, &voucher, &borrower, stake, &token)?;
+        validate_vouch(&env, &cfg, &voucher, &borrower, stake, &token, chain_id)?;
     }
 
     // Phase 2: commit all — only reached if all validations passed
@@ -264,7 +276,7 @@ pub fn batch_vouch(
             .persistent()
             .get(&DataKey::Vouches(borrower.clone()))
             .unwrap_or(Vec::new(&env));
-        commit_vouch(&env, &token_client, voucher.clone(), borrower, stake, token.clone(), vouches)?;
+        commit_vouch(&env, &token_client, voucher.clone(), borrower, stake, token.clone(), vouches, chain_id)?;
     }
 
     Ok(())
@@ -739,4 +751,125 @@ fn distribute_penalty(
             token_client.transfer(&contract, &vr.voucher, &share);
         }
     }
+}
+
+// ── Bridge validation ─────────────────────────────────────────────────────────
+
+/// Validate that `chain_id` is registered, active, and that `token` is the
+/// bridge contract address for that chain.
+fn validate_bridge(env: &Env, chain_id: u32, token: &Address) -> Result<(), ContractError> {
+    let bridges: Vec<BridgeRecord> = env
+        .storage()
+        .instance()
+        .get(&DataKey::AllowedBridges)
+        .unwrap_or(Vec::new(env));
+
+    for bridge in bridges.iter() {
+        if bridge.chain_id == chain_id {
+            if !bridge.active {
+                return Err(ContractError::InvalidChain);
+            }
+            if bridge.bridge_address != *token {
+                return Err(ContractError::InvalidChain);
+            }
+            return Ok(());
+        }
+    }
+
+    Err(ContractError::InvalidChain)
+}
+
+/// Register a new cross-chain bridge. Admin-only.
+pub fn register_bridge(
+    env: Env,
+    admin_signers: Vec<Address>,
+    chain_id: u32,
+    chain_name: soroban_sdk::String,
+    bridge_address: Address,
+) -> Result<(), ContractError> {
+    require_bridge_admin(&env, &admin_signers)?;
+
+    let mut bridges: Vec<BridgeRecord> = env
+        .storage()
+        .instance()
+        .get(&DataKey::AllowedBridges)
+        .unwrap_or(Vec::new(&env));
+
+    for b in bridges.iter() {
+        if b.chain_id == chain_id {
+            return Err(ContractError::BridgeAlreadyRegistered);
+        }
+    }
+
+    bridges.push_back(BridgeRecord {
+        chain_id,
+        chain_name,
+        bridge_address,
+        active: true,
+    });
+
+    env.storage()
+        .instance()
+        .set(&DataKey::AllowedBridges, &bridges);
+
+    Ok(())
+}
+
+/// Deactivate a registered bridge. Admin-only.
+pub fn remove_bridge(
+    env: Env,
+    admin_signers: Vec<Address>,
+    chain_id: u32,
+) -> Result<(), ContractError> {
+    require_bridge_admin(&env, &admin_signers)?;
+
+    let mut bridges: Vec<BridgeRecord> = env
+        .storage()
+        .instance()
+        .get(&DataKey::AllowedBridges)
+        .unwrap_or(Vec::new(&env));
+
+    let idx = bridges
+        .iter()
+        .position(|b| b.chain_id == chain_id)
+        .ok_or(ContractError::InvalidChain)? as u32;
+
+    let mut record = bridges.get(idx).unwrap();
+    record.active = false;
+    bridges.set(idx, record);
+
+    env.storage()
+        .instance()
+        .set(&DataKey::AllowedBridges, &bridges);
+
+    Ok(())
+}
+
+/// Return all registered bridges.
+pub fn get_bridges(env: Env) -> Vec<BridgeRecord> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AllowedBridges)
+        .unwrap_or(Vec::new(&env))
+}
+
+/// Verify that enough admin signers have authorised the call.
+fn require_bridge_admin(env: &Env, signers: &Vec<Address>) -> Result<(), ContractError> {
+    let cfg: crate::types::Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .expect("not initialized");
+
+    let mut valid: u32 = 0;
+    for signer in signers.iter() {
+        if cfg.admins.iter().any(|a| a == signer) {
+            signer.require_auth();
+            valid += 1;
+        }
+    }
+    if valid < cfg.admin_threshold {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+    Ok(())
 }

--- a/src/vouch_active_loan_test.rs
+++ b/src/vouch_active_loan_test.rs
@@ -40,7 +40,7 @@ mod vouch_active_loan_tests {
 
     fn mint_and_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// vouch() must return ActiveLoanExists when the borrower already has an active loan.
@@ -63,7 +63,7 @@ mod vouch_active_loan_tests {
 
         // Step 2: Attempt to add a new vouch while loan is active.
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher2, &500_000);
-        let result = s.client.try_vouch(&voucher2, &borrower, &500_000, &s.token_id);
+        let result = s.client.try_vouch(&voucher2, &borrower, &500_000, &s.token_id, &None);
 
         // Step 3: Assert ActiveLoanExists is returned.
         assert_eq!(
@@ -101,7 +101,7 @@ mod vouch_active_loan_tests {
 
         // Step 5: Attempt to add a new vouch — must succeed.
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher2, &500_000);
-        let result = s.client.try_vouch(&voucher2, &borrower, &500_000, &s.token_id);
+        let result = s.client.try_vouch(&voucher2, &borrower, &500_000, &s.token_id, &None);
         assert!(result.is_ok(), "vouch() must succeed after loan is repaid");
     }
 }

--- a/src/vouch_cooldown_test.rs
+++ b/src/vouch_cooldown_test.rs
@@ -52,10 +52,10 @@ mod vouch_cooldown_tests {
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher, &2_000_000);
 
         // First vouch succeeds
-        s.client.vouch(&voucher, &borrower1, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher, &borrower1, &1_000_000, &s.token_id, &None);
 
         // Attempt second vouch immediately (within 24-hour cooldown) should fail
-        let result = s.client.try_vouch(&voucher, &borrower2, &1_000_000, &s.token_id);
+        let result = s.client.try_vouch(&voucher, &borrower2, &1_000_000, &s.token_id, &None);
         assert_eq!(result, Err(Ok(ContractError::VouchCooldownActive)));
     }
 
@@ -71,14 +71,14 @@ mod vouch_cooldown_tests {
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher, &2_000_000);
 
         // First vouch at timestamp 120
-        s.client.vouch(&voucher, &borrower1, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher, &borrower1, &1_000_000, &s.token_id, &None);
 
         // Advance time by 24 hours + 1 second (default cooldown is 24 hours)
         let cooldown_secs = 24 * 60 * 60;
         s.env.ledger().with_mut(|l| l.timestamp = 120 + cooldown_secs + 1);
 
         // Second vouch should now succeed
-        s.client.vouch(&voucher, &borrower2, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher, &borrower2, &1_000_000, &s.token_id, &None);
 
         // Verify both vouches exist
         let vouches1 = s.client.get_vouches(&borrower1).unwrap();
@@ -100,10 +100,10 @@ mod vouch_cooldown_tests {
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher2, &1_000_000);
 
         // voucher1 vouches
-        s.client.vouch(&voucher1, &borrower, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher1, &borrower, &1_000_000, &s.token_id, &None);
 
         // voucher2 can vouch immediately (different voucher, no cooldown)
-        s.client.vouch(&voucher2, &borrower, &1_000_000, &s.token_id);
+        s.client.vouch(&voucher2, &borrower, &1_000_000, &s.token_id, &None);
 
         // Verify both vouches exist
         let vouches = s.client.get_vouches(&borrower).unwrap();

--- a/src/vouch_min_stake_test.rs
+++ b/src/vouch_min_stake_test.rs
@@ -32,7 +32,7 @@ mod vouch_min_stake_tests {
         let (contract_id, token_id, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        let result = client.try_vouch(&voucher, &borrower, &(DEFAULT_MIN_YIELD_STAKE - 1), &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &(DEFAULT_MIN_YIELD_STAKE - 1), &token_id, &None);
         assert_eq!(result, Err(Ok(ContractError::MinStakeNotMet)));
     }
 
@@ -44,7 +44,7 @@ mod vouch_min_stake_tests {
         let (contract_id, token_id, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        let result = client.try_vouch(&voucher, &borrower, &DEFAULT_MIN_YIELD_STAKE, &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &DEFAULT_MIN_YIELD_STAKE, &token_id, &None);
         assert!(result.is_ok());
     }
 }

--- a/src/vouch_zero_stake_test.rs
+++ b/src/vouch_zero_stake_test.rs
@@ -25,7 +25,7 @@ mod vouch_zero_stake_tests {
         let (contract_id, token_id, voucher, borrower) = setup(&env);
         let client = QuorumCreditContractClient::new(&env, &contract_id);
 
-        let result = client.try_vouch(&voucher, &borrower, &0, &token_id);
+        let result = client.try_vouch(&voucher, &borrower, &0, &token_id, &None);
         assert_eq!(result, Err(Ok(ContractError::InsufficientFunds)));
     }
 }

--- a/src/voucher_balance_check_test.rs
+++ b/src/voucher_balance_check_test.rs
@@ -52,7 +52,7 @@ mod voucher_balance_check_tests {
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher, &500);
 
         // Attempt to vouch with 1000 tokens (more than balance)
-        let result = s.client.try_vouch(&voucher, &borrower, &1_000, &s.token_id);
+        let result = s.client.try_vouch(&voucher, &borrower, &1_000, &s.token_id, &None);
         
         // Should return InsufficientVoucherBalance error
         assert_eq!(result, Err(Ok(ContractError::InsufficientVoucherBalance)));
@@ -69,7 +69,7 @@ mod voucher_balance_check_tests {
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher, &1_000);
 
         // Vouch with 1000 tokens should succeed
-        let result = s.client.try_vouch(&voucher, &borrower, &1_000, &s.token_id);
+        let result = s.client.try_vouch(&voucher, &borrower, &1_000, &s.token_id, &None);
         assert!(result.is_ok(), "vouch should succeed with sufficient balance");
 
         // Verify vouch was recorded
@@ -86,7 +86,7 @@ mod voucher_balance_check_tests {
         // Don't mint any tokens to voucher (balance = 0)
 
         // Attempt to vouch with any amount
-        let result = s.client.try_vouch(&voucher, &borrower, &100, &s.token_id);
+        let result = s.client.try_vouch(&voucher, &borrower, &100, &s.token_id, &None);
         
         // Should return InsufficientVoucherBalance error
         assert_eq!(result, Err(Ok(ContractError::InsufficientVoucherBalance)));

--- a/src/voucher_stats_test.rs
+++ b/src/voucher_stats_test.rs
@@ -44,7 +44,7 @@ mod voucher_stats_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {

--- a/src/withdraw_slash_treasury_test.rs
+++ b/src/withdraw_slash_treasury_test.rs
@@ -44,8 +44,8 @@ mod withdraw_slash_treasury_tests {
 
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher_a, &600_000);
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher_b, &400_000);
-        s.client.vouch(&voucher_a, &borrower, &600_000, &s.token_id);
-        s.client.vouch(&voucher_b, &borrower, &400_000, &s.token_id);
+        s.client.vouch(&voucher_a, &borrower, &600_000, &s.token_id, &None);
+        s.client.vouch(&voucher_b, &borrower, &400_000, &s.token_id, &None);
         s.client.request_loan(
             &borrower,
             &200_000,

--- a/src/withdrawal_queue_test.rs
+++ b/src/withdrawal_queue_test.rs
@@ -53,7 +53,7 @@ mod withdrawal_queue_tests {
 
         // Mint and vouch
         StellarAssetClient::new(&env, &token_id.address()).mint(&voucher, &10_000_000);
-        client.vouch(&voucher, &borrower, &10_000_000, &token_id.address());
+        client.vouch(&voucher, &borrower, &10_000_000, &token_id.address(), &None);
 
         Setup {
             env,
@@ -263,7 +263,7 @@ mod withdrawal_queue_tests {
         let voucher2 = Address::generate(&s.env);
         StellarAssetClient::new(&s.env, &s.token_id).mint(&voucher2, &5_000_000);
         s.env.ledger().with_mut(|l| l.timestamp += 120);
-        s.client.vouch(&voucher2, &s.borrower, &5_000_000, &s.token_id);
+        s.client.vouch(&voucher2, &s.borrower, &5_000_000, &s.token_id, &None);
 
         disburse_loan(&s);
 

--- a/src/yield_precision_small_stake_test.rs
+++ b/src/yield_precision_small_stake_test.rs
@@ -48,7 +48,7 @@ mod yield_precision_small_stake_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     /// Test core issue: stake=49 stroops (<50) produces 0 yield due to truncation.

--- a/src/yield_reserve_solvency_test.rs
+++ b/src/yield_reserve_solvency_test.rs
@@ -43,7 +43,7 @@ mod yield_reserve_solvency_tests {
 
     fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
         StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
-        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id, &None);
     }
 
     fn purpose(env: &Env) -> String {


### PR DESCRIPTION
closes #632

- Add chain_id: Option<u32> field to VouchRecord to track the originating chain
- Add BridgeRecord type with chain_id, chain_name, bridge_address, and active flag
- Add AllowedBridges storage key to DataKey enum
- Add InvalidChain (49) and BridgeAlreadyRegistered (50) error variants
- Update vouch() and batch_vouch() to accept chain_id: Option<u32>
- Implement validate_bridge() to verify chain_id is registered and active
- Add register_bridge(), remove_bridge(), get_bridges() admin functions
- Expose bridge management functions on the contract interface
- Update all existing test call sites to pass &None for chain_id
- Add cross_chain_vouch_test.rs with 5 tests covering the full bridge lifecycle

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
