### PR TITLE
feat: repayment escrow, oracle verification, early discount, retry (#666-669)

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,4 +57,14 @@ pub enum ContractError {
     WithdrawalNotQueued = 47,
     /// Partial withdrawal amount exceeds the 50% cap.
     PartialWithdrawalExceedsCap = 48,
+    /// #667: Caller is not the registered oracle.
+    OracleUnauthorized = 49,
+    /// #667: Credit score value is out of the valid range (0–1000).
+    InvalidCreditScore = 50,
+    /// #666: Repayment is pending oracle verification; cannot release yet.
+    EscrowPending = 51,
+    /// #666: No repayment is currently held in escrow for this borrower.
+    NoEscrowFound = 52,
+    /// #669: Maximum retry attempts exceeded.
+    MaxRetriesExceeded = 53,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod withdrawal_queue_test;
 use crate::errors::ContractError;
 use crate::helpers::{config, get_active_loan_record, has_active_loan, require_allowed_token, require_not_paused};
 use crate::types::{
-    Config, DataKey, LoanRecord, LoanStatus, QueuedWithdrawal, VouchRecord,
+    Config, DataKey, EscrowStatus, LoanRecord, LoanStatus, QueuedWithdrawal, VouchRecord,
     DEFAULT_LIQUIDITY_MINING_RATE_BPS, DEFAULT_LOAN_DURATION, DEFAULT_MAX_LOAN_TO_STAKE_RATIO,
     DEFAULT_MAX_VOUCHERS, DEFAULT_MIN_LOAN_AMOUNT, DEFAULT_MIN_VOUCH_AGE_SECS, DEFAULT_SLASH_BPS,
     DEFAULT_YIELD_BPS,
@@ -68,6 +68,8 @@ impl QuorumCreditContract {
                 min_vouch_age_secs: DEFAULT_MIN_VOUCH_AGE_SECS,
                 prepayment_penalty_bps: 0,
                 liquidity_mining_rate_bps: DEFAULT_LIQUIDITY_MINING_RATE_BPS,
+                oracle_address: None,
+                early_repayment_discount_bps: 0,
             },
         );
 
@@ -233,6 +235,8 @@ impl QuorumCreditContract {
             amortization_schedule: Vec::new(&env),
             reminder_sent: false,
             risk_score: 0,
+            escrow_status: EscrowStatus::None,
+            retry_count: 0,
         };
 
         env.storage()
@@ -262,8 +266,17 @@ impl QuorumCreditContract {
             return Err(ContractError::InvalidAmount);
         }
 
-        let total_owed = loan.amount + loan.total_yield;
-        let outstanding = total_owed - loan.amount_repaid;
+        let cfg = config(&env);
+        let now = env.ledger().timestamp();
+
+        // #668: Apply early repayment discount if repaying before deadline
+        let discount = if now < loan.deadline && cfg.early_repayment_discount_bps > 0 {
+            loan.total_yield * cfg.early_repayment_discount_bps as i128 / 10_000
+        } else {
+            0
+        };
+        let effective_total_owed = loan.amount + loan.total_yield - discount;
+        let outstanding = effective_total_owed - loan.amount_repaid;
 
         if payment > outstanding {
             return Err(ContractError::InvalidAmount);
@@ -274,9 +287,129 @@ impl QuorumCreditContract {
 
         loan.amount_repaid += payment;
 
-        if loan.amount_repaid >= total_owed {
+        if loan.amount_repaid >= effective_total_owed {
+            // #666/#667: If oracle is configured, hold in escrow pending verification.
+            // Otherwise release immediately.
+            if cfg.oracle_address.is_some() {
+                loan.escrow_status = EscrowStatus::Pending;
+                loan.status = LoanStatus::Active; // stays active until oracle releases
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::EscrowAmount(borrower.clone()), &payment);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Loan(loan.id), &loan);
+                env.events().publish(
+                    (symbol_short!("loan"), symbol_short!("escrow")),
+                    (borrower, payment),
+                );
+            } else {
+                // No oracle — release immediately
+                loan.status = LoanStatus::Repaid;
+                loan.repayment_timestamp = Some(now);
+                loan.escrow_status = EscrowStatus::Released;
+
+                let vouches: Vec<VouchRecord> = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Vouches(borrower.clone()))
+                    .unwrap_or(Vec::new(&env));
+
+                let total_stake: i128 = vouches
+                    .iter()
+                    .filter(|v| v.token == loan.token_address)
+                    .map(|v| v.stake)
+                    .sum();
+
+                for v in vouches.iter() {
+                    if v.token != loan.token_address {
+                        continue;
+                    }
+                    let yield_share = if total_stake > 0 {
+                        loan.total_yield * v.stake / total_stake
+                    } else {
+                        0
+                    };
+                    token_client.transfer(
+                        &env.current_contract_address(),
+                        &v.voucher,
+                        &(v.stake + yield_share),
+                    );
+                }
+
+                vouch::process_withdrawal_queue(&env, &borrower);
+
+                env.storage()
+                    .persistent()
+                    .remove(&DataKey::ActiveLoan(borrower.clone()));
+                env.storage()
+                    .persistent()
+                    .remove(&DataKey::Vouches(borrower.clone()));
+
+                env.events().publish(
+                    (symbol_short!("loan"), symbol_short!("repaid")),
+                    (borrower.clone(), loan.amount),
+                );
+
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Loan(loan.id), &loan);
+            }
+        } else {
+            env.storage()
+                .persistent()
+                .set(&DataKey::Loan(loan.id), &loan);
+        }
+
+        Ok(())
+    }
+
+    /// #667: Called by the registered oracle to verify a repayment held in escrow.
+    /// If `approved` is true, releases funds to vouchers. If false, returns funds to borrower.
+    pub fn verify_repayment(
+        env: Env,
+        oracle: Address,
+        borrower: Address,
+        approved: bool,
+    ) -> Result<(), ContractError> {
+        oracle.require_auth();
+        require_not_paused(&env)?;
+
+        // Verify caller is the registered oracle
+        let cfg = config(&env);
+        let registered = cfg.oracle_address.ok_or(ContractError::OracleUnauthorized)?;
+        if oracle != registered {
+            return Err(ContractError::OracleUnauthorized);
+        }
+
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()))
+            .ok_or(ContractError::NoActiveLoan)?;
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(ContractError::NoActiveLoan)?;
+
+        if loan.escrow_status != EscrowStatus::Pending {
+            return Err(ContractError::NoEscrowFound);
+        }
+
+        let escrowed: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EscrowAmount(borrower.clone()))
+            .unwrap_or(0);
+
+        let token_client = require_allowed_token(&env, &loan.token_address)?;
+        let now = env.ledger().timestamp();
+
+        if approved {
+            loan.escrow_status = EscrowStatus::Released;
             loan.status = LoanStatus::Repaid;
-            loan.repayment_timestamp = Some(env.ledger().timestamp());
+            loan.repayment_timestamp = Some(now);
 
             let vouches: Vec<VouchRecord> = env
                 .storage()
@@ -306,7 +439,6 @@ impl QuorumCreditContract {
                 );
             }
 
-            // Process any queued withdrawals now that the loan is closed
             vouch::process_withdrawal_queue(&env, &borrower);
 
             env.storage()
@@ -320,13 +452,68 @@ impl QuorumCreditContract {
                 (symbol_short!("loan"), symbol_short!("repaid")),
                 (borrower.clone(), loan.amount),
             );
+        } else {
+            // Oracle rejected — return escrowed funds to borrower
+            loan.escrow_status = EscrowStatus::Rejected;
+            loan.amount_repaid -= escrowed;
+
+            if escrowed > 0 {
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &borrower,
+                    &escrowed,
+                );
+            }
+
+            env.events().publish(
+                (symbol_short!("loan"), symbol_short!("escrow_rej")),
+                (borrower.clone(), escrowed),
+            );
         }
 
+        env.storage()
+            .persistent()
+            .remove(&DataKey::EscrowAmount(borrower.clone()));
         env.storage()
             .persistent()
             .set(&DataKey::Loan(loan.id), &loan);
 
         Ok(())
+    }
+
+    /// #669: Retry a failed repayment. Increments retry_count and re-attempts the transfer.
+    /// Returns `MaxRetriesExceeded` if retry_count >= MAX_REPAYMENT_RETRIES.
+    pub fn retry_repayment(
+        env: Env,
+        borrower: Address,
+        payment: i128,
+    ) -> Result<(), ContractError> {
+        borrower.require_auth();
+        require_not_paused(&env)?;
+
+        let loan_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()))
+            .ok_or(ContractError::NoActiveLoan)?;
+        let mut loan: LoanRecord = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+            .ok_or(ContractError::NoActiveLoan)?;
+
+        const MAX_REPAYMENT_RETRIES: u32 = 3;
+        if loan.retry_count >= MAX_REPAYMENT_RETRIES {
+            return Err(ContractError::MaxRetriesExceeded);
+        }
+
+        loan.retry_count += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Loan(loan.id), &loan);
+
+        // Delegate to the standard repay logic
+        Self::repay(env, borrower, payment)
     }
 
     pub fn get_loan(env: Env, borrower: Address) -> Option<LoanRecord> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -110,6 +110,23 @@ pub enum LoanStatus {
     Defaulted,
 }
 
+// ── Escrow Status (#666) ──────────────────────────────────────────────────────
+
+/// Tracks the escrow state of a repayment.
+/// Repayments are held in escrow until oracle verification releases them.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    /// No repayment is currently held in escrow.
+    None,
+    /// A repayment has been received and is pending oracle verification.
+    Pending,
+    /// Oracle has verified the repayment; funds have been released to vouchers.
+    Released,
+    /// Oracle rejected the repayment; funds were returned to the borrower.
+    Rejected,
+}
+
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -188,6 +205,12 @@ pub enum DataKey {
     StakingDerivative(Address, Address),
     // #637: Fraud Detection
     VoucherFraudScore(Address),
+    // #667: Oracle address for repayment verification
+    OracleAddress,
+    // #667: External credit score per borrower
+    ExternalCreditScore(Address),
+    // #666: Escrowed repayment amount per borrower (held pending oracle verification)
+    EscrowAmount(Address),
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -241,6 +264,12 @@ pub struct Config {
     pub prepayment_penalty_bps: u32,
     /// #634: Liquidity mining reward rate in basis points per epoch (e.g. 50 = 0.5% per 7 days).
     pub liquidity_mining_rate_bps: u32,
+    /// #667: Optional oracle contract address for repayment verification.
+    /// When set, repayments are held in escrow until the oracle calls `verify_repayment`.
+    pub oracle_address: Option<Address>,
+    /// #668: Discount applied to the total owed when repaying before the deadline,
+    /// in basis points (e.g. 50 = 0.5%). 0 means no discount.
+    pub early_repayment_discount_bps: u32,
 }
 
 // ── Data Types ────────────────────────────────────────────────────────────────
@@ -285,6 +314,11 @@ pub struct LoanRecord {
     pub reminder_sent: bool,
     /// Risk score for the borrower (0-100), used for dynamic yield calculation.
     pub risk_score: u32,
+    /// #666: Current escrow state of the repayment.
+    /// Repayments are held in escrow (Pending) until oracle verification.
+    pub escrow_status: EscrowStatus,
+    /// #669: Number of times a failed repayment has been retried.
+    pub retry_count: u32,
 }
 
 /// A single payment event recorded against a loan.
@@ -531,3 +565,17 @@ pub const FRAUD_SCORE_HIGH_THRESHOLD: u32 = 70;
 pub const FRAUD_SCORE_MAX: u32 = 100;
 pub const FRAUD_SCORE_DEFAULT_WEIGHT: u32 = 20;
 pub const FRAUD_SCORE_CONCENTRATION_WEIGHT: u32 = 10;
+
+// ── #667: External Credit Score ───────────────────────────────────────────────
+
+/// Credit score record pushed by a trusted oracle.
+#[contracttype]
+#[derive(Clone)]
+pub struct ExternalCreditScore {
+    /// Score in range 0–1000.
+    pub score: u32,
+    /// Ledger timestamp when this score was last updated.
+    pub updated_at: u64,
+    /// Oracle address that submitted this score.
+    pub oracle: Address,
+}


### PR DESCRIPTION
## Summary

closes #666 
closes #667 
closes #668 
closes #669 

### #666 — Repayment Escrow
- Added `EscrowStatus` enum (`None`, `Pending`, `Released`, `Rejected`) to `types.rs`
- Added `escrow_status` field to `LoanRecord`
- Added `DataKey::EscrowAmount(Address)` to track the held amount
- `repay()` now holds the full payment in escrow when an oracle is configured, emitting a `loan/escrow` event

### #667 — Oracle Verification
- Added `oracle_address: Option<Address>` to `Config`
- Added `DataKey::OracleAddress`, `DataKey::ExternalCreditScore(Address)`
- Added `ExternalCreditScore` struct to `types.rs`
- Added `verify_repayment(oracle, borrower, approved)`: oracle approves → releases funds to vouchers; rejects → returns funds to borrower
- New errors: `OracleUnauthorized = 49`, `InvalidCreditScore = 50`, `NoEscrowFound = 52`

### #668 — Early Repayment Discount
- Added `early_repayment_discount_bps: u32` to `Config` (default 0)
- `repay()` reduces `total_yield` by the discount fraction when payment arrives before the deadline

### #669 — Repayment Failure Retry
- Added `retry_count: u32` to `LoanRecord`
- Added `retry_repayment(borrower, payment)`: increments `retry_count` (max 3) then delegates to `repay()`
- New error: `MaxRetriesExceeded = 53`

### Files changed
- `src/types.rs` — new types, updated `Config`, `LoanRecord`, `DataKey`
- `src/errors.rs` — five new error variants (49–53)
- `src/lib.rs` — updated `repay()`, new `verify_repayment()` and `retry_repayment()`