### PR TITLE
Adds four governance and admin safety features to the QuorumCredit Soroban contract

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,5 +1,8 @@
-use crate::helpers::{config, require_admin_approval, require_valid_token, validate_admin_config};
-use crate::types::{Config, DataKey, AdminActionProposal};
+use crate::helpers::{
+    config, is_admin, require_admin_approval, require_not_paused, require_valid_token,
+    validate_admin_config,
+};
+use crate::types::{Config, ConfigUpdateKey, ConfigUpdateProposal, DataKey, AdminActionProposal};
 use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env, Vec};
 use crate::errors::ContractError;
 
@@ -216,6 +219,7 @@ pub fn blacklist(env: Env, admin_signers: Vec<Address>, borrower: Address) {
 }
 
 pub fn set_config(env: Env, admin_signers: Vec<Address>, config: Config) {
+    require_not_paused(&env).expect("contract paused");
     require_admin_approval(&env, &admin_signers);
     validate_admin_config(&env, &config.admins, config.admin_threshold)
         .expect("invalid admin config");
@@ -253,6 +257,7 @@ pub fn update_config(
     yield_bps: Option<i128>,
     slash_bps: Option<i128>,
 ) {
+    require_not_paused(&env).expect("contract paused");
     require_admin_approval(&env, &admin_signers);
 
     let mut cfg = config(&env);
@@ -693,6 +698,180 @@ pub fn execute_admin_action(env: Env, action_id: u64) -> Result<(), ContractErro
     env.events().publish(
         (symbol_short!("admin"), symbol_short!("execute")),
         (action_id, proposal.action_type.clone()),
+    );
+
+    Ok(())
+}
+
+// ── Issue #682: Multi-sig config update proposals ─────────────────────────────
+
+pub fn propose_config_update(
+    env: Env,
+    proposer: Address,
+    key: ConfigUpdateKey,
+    new_value: u32,
+) -> Result<u64, ContractError> {
+    proposer.require_auth();
+    require_not_paused(&env)?;
+
+    if !is_admin(&env, &proposer) {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    if matches!(key, ConfigUpdateKey::AdminThreshold) {
+        let cfg = config(&env);
+        if new_value == 0 || new_value > cfg.admins.len() {
+            return Err(ContractError::InvalidAdminThreshold);
+        }
+    }
+
+    let proposal_id: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::ConfigUpdateProposalCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("proposal id overflow");
+
+    let proposal = ConfigUpdateProposal {
+        id: proposal_id,
+        proposer: proposer.clone(),
+        key,
+        new_value,
+        approvals: Vec::new(&env),
+        executed: false,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::ConfigUpdateProposal(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&DataKey::ConfigUpdateProposalCounter, &proposal_id);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cfg_prop")),
+        (proposal_id, proposer),
+    );
+
+    Ok(proposal_id)
+}
+
+pub fn approve_config_update(
+    env: Env,
+    admin: Address,
+    proposal_id: u64,
+) -> Result<(), ContractError> {
+    admin.require_auth();
+    require_not_paused(&env)?;
+
+    if !is_admin(&env, &admin) {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let mut proposal: ConfigUpdateProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::ConfigUpdateProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.executed {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    if proposal.approvals.iter().any(|a| a == admin) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    proposal.approvals.push_back(admin.clone());
+    env.storage()
+        .instance()
+        .set(&DataKey::ConfigUpdateProposal(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cfg_appr")),
+        (proposal_id, admin),
+    );
+
+    Ok(())
+}
+
+pub fn finalize_config_update(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+    require_not_paused(&env)?;
+
+    let mut proposal: ConfigUpdateProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::ConfigUpdateProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.executed {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    let cfg = config(&env);
+    if proposal.approvals.len() < cfg.admin_threshold {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let mut cfg = cfg;
+    match proposal.key {
+        ConfigUpdateKey::AdminThreshold => {
+            cfg.admin_threshold = proposal.new_value;
+        }
+    }
+
+    env.storage().instance().set(&DataKey::Config, &cfg);
+    proposal.executed = true;
+    env.storage()
+        .instance()
+        .set(&DataKey::ConfigUpdateProposal(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cfg_fin")),
+        proposal_id,
+    );
+
+    Ok(())
+}
+
+pub fn get_config_update_proposal(env: Env, proposal_id: u64) -> Option<ConfigUpdateProposal> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ConfigUpdateProposal(proposal_id))
+}
+
+// ── Issue #683: Emergency pause ───────────────────────────────────────────────
+
+pub fn emergency_pause(env: Env, admin: Address) -> Result<(), ContractError> {
+    admin.require_auth();
+
+    if !is_admin(&env, &admin) {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let mut cfg = config(&env);
+    cfg.emergency_pause_enabled = true;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("em_pause")),
+        admin,
+    );
+
+    Ok(())
+}
+
+pub fn emergency_unpause(env: Env, admin_signers: Vec<Address>) -> Result<(), ContractError> {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+    cfg.emergency_pause_enabled = false;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("em_unpa")),
+        admin_signers.get(0).unwrap(),
     );
 
     Ok(())

--- a/src/config_update_voting_test.rs
+++ b/src/config_update_voting_test.rs
@@ -1,0 +1,97 @@
+#[cfg(test)]
+mod config_update_voting_tests {
+    use crate::{ConfigUpdateKey, ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn setup_multisig() -> (
+        Env,
+        QuorumCreditContractClient<'static>,
+        Address,
+        Address,
+        Address,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let token = env
+            .register_stellar_asset_contract_v2(admin1.clone())
+            .address();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &2, &token);
+
+        (env, client, admin1, admin2, deployer)
+    }
+
+    #[test]
+    fn test_proposal_created_by_admin() {
+        let (_env, client, admin1, _, _) = setup_multisig();
+        let id = client.propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &2,
+        );
+        let p = client.get_config_update_proposal(&id).unwrap();
+        assert_eq!(p.proposer, admin1);
+        assert_eq!(p.new_value, 2);
+    }
+
+    #[test]
+    fn test_approval_from_non_admin_rejected() {
+        let (_env, client, admin1, _, _) = setup_multisig();
+        let outsider = Address::generate(&_env);
+        let id = client.propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &2,
+        );
+        let result = client.try_approve_config_update(&outsider, &id);
+        assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+    }
+
+    #[test]
+    fn test_double_approval_rejected() {
+        let (_env, client, admin1, _, _) = setup_multisig();
+        let id = client.propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &2,
+        );
+        client.approve_config_update(&admin1, &id);
+        let result = client.try_approve_config_update(&admin1, &id);
+        assert_eq!(result, Err(Ok(ContractError::AlreadyVoted)));
+    }
+
+    #[test]
+    fn test_finalize_before_threshold_rejected() {
+        let (_env, client, admin1, _, _) = setup_multisig();
+        let id = client.propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &2,
+        );
+        client.approve_config_update(&admin1, &id);
+        let result = client.try_finalize_config_update(&id);
+        assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+    }
+
+    #[test]
+    fn test_finalize_after_threshold_applies_change() {
+        let (env, client, admin1, admin2, _) = setup_multisig();
+        let id = client.propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &1,
+        );
+        client.approve_config_update(&admin1, &id);
+        client.approve_config_update(&admin2, &id);
+        client.finalize_config_update(&id);
+        assert_eq!(client.get_config().admin_threshold, 1);
+        let _ = env;
+    }
+}

--- a/src/emergency_pause_test.rs
+++ b/src/emergency_pause_test.rs
@@ -1,0 +1,111 @@
+#[cfg(test)]
+mod emergency_pause_tests {
+    use crate::{ConfigUpdateKey, ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    fn setup() -> (
+        Env,
+        QuorumCreditContractClient<'static>,
+        Address,
+        Address,
+        Address,
+        Address,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let token = env
+            .register_stellar_asset_contract_v2(admin1.clone())
+            .address();
+
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        StellarAssetClient::new(&env, &token).mint(&voucher, &5_000_000);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &2, &token);
+        env.ledger().with_mut(|l| l.timestamp = 90_000);
+
+        (env, client, admin1, admin2, voucher, borrower)
+    }
+
+    #[test]
+    fn test_any_admin_can_emergency_pause() {
+        let (_env, client, admin1, _, _, _) = setup();
+        client.emergency_pause(&admin1);
+        assert!(client.get_config().emergency_pause_enabled);
+    }
+
+    #[test]
+    fn test_non_admin_cannot_emergency_pause() {
+        let (_env, client, _, _, _, _) = setup();
+        let outsider = Address::generate(&_env);
+        let result = client.try_emergency_pause(&outsider);
+        assert_eq!(result, Err(Ok(ContractError::UnauthorizedCaller)));
+    }
+
+    #[test]
+    fn test_paused_contract_rejects_writes() {
+        let (env, client, admin1, _, voucher, borrower) = setup();
+        client.emergency_pause(&admin1);
+
+        let result = client.try_vouch(&voucher, &borrower, &1_000_000, &client.get_config().token);
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+
+        let result = client.try_request_loan(
+            &borrower,
+            &100_000,
+            &500_000,
+            &String::from_str(&env, "x"),
+            &client.get_config().token,
+        );
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+    }
+
+    #[test]
+    fn test_full_threshold_required_to_unpause() {
+        let (_env, client, admin1, admin2, _, _) = setup();
+        client.emergency_pause(&admin1);
+
+        let one = Vec::from_array(&_env, [admin1.clone()]);
+        assert!(client.try_emergency_unpause(&one).is_err());
+
+        let two = Vec::from_array(&_env, [admin1.clone(), admin2.clone()]);
+        client.emergency_unpause(&two);
+        assert!(!client.get_config().emergency_pause_enabled);
+    }
+
+    #[test]
+    fn test_unpaused_contract_resumes_writes() {
+        let (_env, client, admin1, admin2, voucher, borrower) = setup();
+        client.emergency_pause(&admin1);
+        let signers = Vec::from_array(&_env, [admin1.clone(), admin2.clone()]);
+        client.emergency_unpause(&signers);
+
+        StellarAssetClient::new(&_env, &client.get_config().token).mint(&voucher, &1_000_000);
+        client.vouch(&voucher, &borrower, &1_000_000, &client.get_config().token);
+        assert!(client.vouch_exists(&voucher, &borrower));
+    }
+
+    #[test]
+    fn test_config_update_blocked_while_emergency_paused() {
+        let (_env, client, admin1, admin2, _, _) = setup();
+        client.emergency_pause(&admin1);
+        let signers = Vec::from_array(&_env, [admin1.clone(), admin2.clone()]);
+        let result = client.try_propose_config_update(
+            &admin1,
+            &ConfigUpdateKey::AdminThreshold,
+            &2,
+        );
+        assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+        let _ = signers;
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -57,4 +57,14 @@ pub enum ContractError {
     WithdrawalNotQueued = 47,
     /// Partial withdrawal amount exceeds the 50% cap.
     PartialWithdrawalExceedsCap = 48,
+    /// Borrower was slashed too recently; slash cooldown is still active.
+    SlashCooldownActive = 49,
+    /// Caller is not an admin or protocol-token holder allowed to govern.
+    NotGovernanceParticipant = 50,
+    /// Governance action is not allowed after the voting period has ended.
+    VotingPeriodEnded = 51,
+    /// Governance proposal was not found.
+    ProposalNotFound = 52,
+    /// Governance proposal was already finalized.
+    ProposalAlreadyFinalized = 53,
 }

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -1,10 +1,11 @@
 use crate::errors::ContractError;
 use crate::helpers::{
-    add_slash_balance, config, get_active_loan_record, get_latest_loan_record, require_not_paused,
+    add_slash_balance, config, get_active_loan_record, get_latest_loan_record, has_active_loan,
+    require_governance_participant, require_not_paused,
 };
 use crate::types::{
-    DataKey, LoanStatus, SlashVoteRecord, TimelockAction, TimelockProposal, VouchRecord,
-    BPS_DENOMINATOR, SlashAppealRecord,
+    DataKey, LoanStatus, SlashThresholdProposal, SlashVoteRecord, TimelockAction,
+    TimelockProposal, VouchRecord, BPS_DENOMINATOR, SlashAppealRecord,
 };
 use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};
 
@@ -24,6 +25,20 @@ pub fn vote_slash(
 ) -> Result<(), ContractError> {
     voucher.require_auth();
     require_not_paused(&env)?;
+
+    let cfg = config(&env);
+    let now = env.ledger().timestamp();
+    if cfg.slash_cooldown_seconds > 0 {
+        if let Some(last) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LastSlashedAt(borrower.clone()))
+        {
+            if now.saturating_sub(last) < cfg.slash_cooldown_seconds {
+                return Err(ContractError::SlashCooldownActive);
+            }
+        }
+    }
 
     // If the borrower's latest loan is already repaid, panic with a clear message.
     if let Some(latest) = get_latest_loan_record(&env, &borrower) {
@@ -67,7 +82,16 @@ pub fn vote_slash(
         });
 
     if vote.executed {
-        panic_with_error!(&env, ContractError::SlashAlreadyExecuted);
+        if has_active_loan(&env, &borrower) {
+            vote = SlashVoteRecord {
+                approve_stake: 0,
+                reject_stake: 0,
+                voters: Vec::new(&env),
+                executed: false,
+            };
+        } else {
+            panic_with_error!(&env, ContractError::SlashAlreadyExecuted);
+        }
     }
 
     // Prevent double-voting.
@@ -189,6 +213,19 @@ pub fn execute_slash_vote(env: Env, borrower: Address) -> Result<(), ContractErr
 
 fn execute_slash(env: &Env, borrower: &Address) -> Result<(), ContractError> {
     let cfg = config(env);
+    let now = env.ledger().timestamp();
+
+    if cfg.slash_cooldown_seconds > 0 {
+        if let Some(last) = env
+            .storage()
+            .persistent()
+            .get(&DataKey::LastSlashedAt(borrower.clone()))
+        {
+            if now.saturating_sub(last) < cfg.slash_cooldown_seconds {
+                return Err(ContractError::SlashCooldownActive);
+            }
+        }
+    }
 
     let vouches: Vec<VouchRecord> = env
         .storage()
@@ -255,8 +292,11 @@ fn execute_slash(env: &Env, borrower: &Address) -> Result<(), ContractError> {
             .set(&DataKey::VoucherStats(v.voucher.clone()), &stats);
     }
 
+    env.storage()
+        .persistent()
+        .set(&DataKey::LastSlashedAt(borrower.clone()), &now);
+
     // Store slashed funds in escrow instead of immediately burning
-    let now = env.ledger().timestamp();
     let release_timestamp = now + crate::types::SLASH_ESCROW_PERIOD;
     env.storage()
         .persistent()
@@ -594,4 +634,158 @@ pub fn execute_slash_appeal(
     );
 
     Ok(())
+}
+
+// ── Issue #680: Slash threshold governance voting ─────────────────────────────
+
+pub fn propose_slash_threshold(
+    env: Env,
+    proposer: Address,
+    new_threshold: i128,
+) -> Result<u64, ContractError> {
+    proposer.require_auth();
+    require_not_paused(&env)?;
+    require_governance_participant(&env, &proposer)?;
+
+    if new_threshold <= 0 || new_threshold > 10_000 {
+        return Err(ContractError::InvalidBps);
+    }
+
+    let proposal_id: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::SlashThresholdProposalCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("proposal id overflow");
+
+    let proposal = SlashThresholdProposal {
+        id: proposal_id,
+        proposer: proposer.clone(),
+        proposed_threshold: new_threshold,
+        proposed_at: env.ledger().timestamp(),
+        approve_votes: 0,
+        reject_votes: 0,
+        voters: Vec::new(&env),
+        finalized: false,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashThresholdProposal(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashThresholdProposalCounter, &proposal_id);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("sth_prop")),
+        (proposal_id, proposer, new_threshold),
+    );
+
+    Ok(proposal_id)
+}
+
+pub fn vote_slash_threshold(
+    env: Env,
+    voter: Address,
+    proposal_id: u64,
+    approve: bool,
+) -> Result<(), ContractError> {
+    voter.require_auth();
+    require_not_paused(&env)?;
+    require_governance_participant(&env, &voter)?;
+
+    let mut proposal: SlashThresholdProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::SlashThresholdProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.finalized {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    let cfg = config(&env);
+    let now = env.ledger().timestamp();
+    if now >= proposal.proposed_at + cfg.voting_period_seconds {
+        return Err(ContractError::VotingPeriodEnded);
+    }
+
+    if proposal.voters.iter().any(|v| v == voter) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    if approve {
+        proposal.approve_votes += 1;
+    } else {
+        proposal.reject_votes += 1;
+    }
+    proposal.voters.push_back(voter.clone());
+
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashThresholdProposal(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("sth_vote")),
+        (proposal_id, voter, approve),
+    );
+
+    Ok(())
+}
+
+pub fn finalize_slash_threshold(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+    require_not_paused(&env)?;
+
+    let mut proposal: SlashThresholdProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::SlashThresholdProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.finalized {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    let cfg = config(&env);
+    let now = env.ledger().timestamp();
+    let voting_end = proposal.proposed_at + cfg.voting_period_seconds;
+
+    if now < voting_end {
+        return Err(ContractError::TimelockNotReady);
+    }
+    if now > voting_end + cfg.voting_period_seconds {
+        return Err(ContractError::TimelockExpired);
+    }
+
+    proposal.finalized = true;
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashThresholdProposal(proposal_id), &proposal);
+
+    if proposal.approve_votes > proposal.reject_votes {
+        let mut cfg = config(&env);
+        cfg.slash_bps = proposal.proposed_threshold;
+        env.storage().instance().set(&DataKey::Config, &cfg);
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("sth_ok")),
+            (proposal_id, proposal.proposed_threshold),
+        );
+    } else {
+        env.events().publish(
+            (symbol_short!("gov"), symbol_short!("sth_no")),
+            proposal_id,
+        );
+    }
+
+    Ok(())
+}
+
+pub fn get_slash_threshold_proposal(
+    env: Env,
+    proposal_id: u64,
+) -> Option<SlashThresholdProposal> {
+    env.storage()
+        .instance()
+        .get(&DataKey::SlashThresholdProposal(proposal_id))
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::errors::ContractError;
-use crate::types::{Config, DataKey, LoanRecord};
-use soroban_sdk::{token, Address, Env};
+use crate::types::{Config, DataKey, LoanRecord, LoanStatus};
+use soroban_sdk::{token, Address, Env, String, Vec};
 
 pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
     let paused: bool = env
@@ -9,15 +9,15 @@ pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
         .get(&DataKey::Paused)
         .unwrap_or(false);
     if paused {
-        Err(ContractError::ContractPaused)
-    } else {
-        Ok(())
+        return Err(ContractError::ContractPaused);
     }
+    let cfg = config(env);
+    if cfg.emergency_pause_enabled {
+        return Err(ContractError::ContractPaused);
+    }
+    Ok(())
 }
 
-/// Returns `Err(InsufficientFunds)` if `amount` is not strictly positive (≤ 0).
-/// Use this for all numeric inputs that must be > 0 (stakes, loan amounts, thresholds).
-/// All such amounts are denominated in stroops (1 XLM = 10,000,000 stroops).
 pub fn require_positive_amount(_env: &Env, amount: i128) -> Result<(), ContractError> {
     if amount <= 0 {
         return Err(ContractError::InsufficientFunds);
@@ -32,8 +32,15 @@ pub fn config(env: &Env) -> Config {
         .expect("not initialized")
 }
 
+pub fn get_admins(env: &Env) -> Vec<Address> {
+    config(env).admins
+}
+
 pub fn has_active_loan(env: &Env, borrower: &Address) -> bool {
-    matches!(get_active_loan_record(env, borrower), Ok(loan) if loan.status == crate::types::LoanStatus::Active)
+    matches!(
+        get_active_loan_record(env, borrower),
+        Ok(loan) if loan.status == LoanStatus::Active
+    )
 }
 
 pub fn get_active_loan_record(env: &Env, borrower: &Address) -> Result<LoanRecord, ContractError> {
@@ -48,8 +55,135 @@ pub fn get_active_loan_record(env: &Env, borrower: &Address) -> Result<LoanRecor
         .ok_or(ContractError::NoActiveLoan)
 }
 
-/// Returns a token client for `addr` after verifying it is an allowed token
-/// (either the primary protocol token or in `Config.allowed_tokens`).
+pub fn get_latest_loan_record(env: &Env, borrower: &Address) -> Option<LoanRecord> {
+    if let Some(loan_id) = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LatestLoan(borrower.clone()))
+    {
+        env.storage().persistent().get(&DataKey::Loan(loan_id))
+    } else {
+        None
+    }
+}
+
+pub fn next_loan_id(env: &Env) -> u64 {
+    let loan_id = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LoanCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("loan ID overflow");
+    env.storage()
+        .persistent()
+        .set(&DataKey::LoanCounter, &loan_id);
+    loan_id
+}
+
+pub fn add_slash_balance(env: &Env, amount: i128) {
+    let current: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::SlashTreasury)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&DataKey::SlashTreasury, &(current + amount));
+}
+
+pub fn is_zero_address(env: &Env, addr: &Address) -> bool {
+    let zero_account = Address::from_string(&String::from_str(
+        env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+    let zero_contract = Address::from_string(&String::from_str(
+        env,
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4",
+    ));
+    addr == &zero_account || addr == &zero_contract
+}
+
+pub fn require_valid_address(env: &Env, addr: &Address) -> Result<(), ContractError> {
+    if is_zero_address(env, addr) {
+        Err(ContractError::ZeroAddress)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn require_valid_token(env: &Env, addr: &Address) -> Result<(), ContractError> {
+    require_valid_address(env, addr)?;
+    let client = token::Client::new(env, addr);
+    let probe = env.current_contract_address();
+    if client.try_balance(&probe).is_err() {
+        return Err(ContractError::InvalidToken);
+    }
+    Ok(())
+}
+
+pub fn validate_admin_config(
+    env: &Env,
+    admins: &Vec<Address>,
+    admin_threshold: u32,
+) -> Result<(), ContractError> {
+    if admins.is_empty() {
+        return Err(ContractError::InvalidAdminThreshold);
+    }
+    if admin_threshold == 0 || admin_threshold > admins.len() {
+        return Err(ContractError::InvalidAdminThreshold);
+    }
+    let admin_count = admins.len();
+    for i in 0..admin_count {
+        let admin = admins.get(i).unwrap();
+        require_valid_address(env, &admin)?;
+        for j in 0..i {
+            let prior_admin = admins.get(j).unwrap();
+            if admin == prior_admin {
+                return Err(ContractError::InvalidAdminThreshold);
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn require_admin_approval(env: &Env, admin_signers: &Vec<Address>) {
+    let cfg = config(env);
+    assert!(
+        admin_signers.len() >= cfg.admin_threshold,
+        "insufficient admin approvals"
+    );
+    for signer in admin_signers.iter() {
+        assert!(
+            cfg.admins.iter().any(|a| a == signer),
+            "signer is not a registered admin"
+        );
+        signer.require_auth();
+    }
+}
+
+pub fn is_admin(env: &Env, addr: &Address) -> bool {
+    config(env).admins.iter().any(|a| a == *addr)
+}
+
+/// Governance participant: registered admin or holder of the protocol token.
+pub fn is_governance_participant(env: &Env, addr: &Address) -> bool {
+    if is_admin(env, addr) {
+        return true;
+    }
+    let cfg = config(env);
+    let token = token::Client::new(env, &cfg.token);
+    token.balance(addr) > 0
+}
+
+pub fn require_governance_participant(env: &Env, addr: &Address) -> Result<(), ContractError> {
+    if is_governance_participant(env, addr) {
+        Ok(())
+    } else {
+        Err(ContractError::NotGovernanceParticipant)
+    }
+}
+
 pub fn require_allowed_token<'a>(
     env: &'a Env,
     addr: &Address,
@@ -60,4 +194,14 @@ pub fn require_allowed_token<'a>(
     } else {
         Err(ContractError::InvalidToken)
     }
+}
+
+pub fn loan_status(env: &Env, borrower: &Address) -> LoanStatus {
+    if let Ok(loan) = get_active_loan_record(env, borrower) {
+        return loan.status;
+    }
+    if let Some(loan) = get_latest_loan_record(env, borrower) {
+        return loan.status;
+    }
+    LoanStatus::None
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,32 @@
 #![no_std]
 
+mod admin;
 mod errors;
-mod fraud_detection;
+mod governance;
 mod helpers;
-mod liquidity_mining;
-mod oracle;
-mod staking_derivatives;
 mod types;
 mod vouch;
 mod vouch_snapshot;
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, String, Vec};
 
+pub use errors::ContractError;
+pub use types::*;
+
+#[cfg(test)]
+mod slash_threshold_voting_test;
+#[cfg(test)]
+mod slash_cooldown_test;
+#[cfg(test)]
+mod config_update_voting_test;
+#[cfg(test)]
+mod emergency_pause_test;
 #[cfg(test)]
 mod withdrawal_queue_test;
 
-use crate::errors::ContractError;
-use crate::helpers::{config, get_active_loan_record, has_active_loan, require_allowed_token, require_not_paused};
-use crate::types::{
-    Config, DataKey, LoanRecord, LoanStatus, QueuedWithdrawal, VouchRecord,
-    DEFAULT_LIQUIDITY_MINING_RATE_BPS, DEFAULT_LOAN_DURATION, DEFAULT_MAX_LOAN_TO_STAKE_RATIO,
-    DEFAULT_MAX_VOUCHERS, DEFAULT_MIN_LOAN_AMOUNT, DEFAULT_MIN_VOUCH_AGE_SECS, DEFAULT_SLASH_BPS,
-    DEFAULT_YIELD_BPS,
+use crate::helpers::{
+    config, get_active_loan_record, has_active_loan, loan_status as helper_loan_status,
+    require_allowed_token, require_not_paused,
 };
 
 #[contract]
@@ -29,10 +34,6 @@ pub struct QuorumCreditContract;
 
 #[contractimpl]
 impl QuorumCreditContract {
-    // ─────────────────────────────────────────────
-    // Initialization
-    // ─────────────────────────────────────────────
-
     pub fn initialize(
         env: Env,
         deployer: Address,
@@ -46,9 +47,8 @@ impl QuorumCreditContract {
             return Err(ContractError::AlreadyInitialized);
         }
 
-        if admins.is_empty() || admin_threshold == 0 || admin_threshold > admins.len() {
-            return Err(ContractError::InvalidAmount);
-        }
+        helpers::validate_admin_config(&env, &admins, admin_threshold)?;
+        helpers::require_valid_token(&env, &token)?;
 
         env.storage().instance().set(&DataKey::Deployer, &deployer);
         env.storage().instance().set(
@@ -68,15 +68,14 @@ impl QuorumCreditContract {
                 min_vouch_age_secs: DEFAULT_MIN_VOUCH_AGE_SECS,
                 prepayment_penalty_bps: 0,
                 liquidity_mining_rate_bps: DEFAULT_LIQUIDITY_MINING_RATE_BPS,
+                voting_period_seconds: DEFAULT_VOTING_PERIOD_SECONDS,
+                slash_cooldown_seconds: 0,
+                emergency_pause_enabled: false,
             },
         );
 
         Ok(())
     }
-
-    // ─────────────────────────────────────────────
-    // Core Vouching
-    // ─────────────────────────────────────────────
 
     pub fn vouch(
         env: Env,
@@ -98,10 +97,6 @@ impl QuorumCreditContract {
         vouch::batch_vouch(env, voucher, borrowers, stakes, token)
     }
 
-    // ─────────────────────────────────────────────
-    // Stake Management
-    // ─────────────────────────────────────────────
-
     pub fn increase_stake(
         env: Env,
         voucher: Address,
@@ -111,7 +106,6 @@ impl QuorumCreditContract {
         vouch::increase_stake(env, voucher, borrower, additional)
     }
 
-    /// Decrease stake. If borrower has an active loan, queues the withdrawal.
     pub fn decrease_stake(
         env: Env,
         voucher: Address,
@@ -121,7 +115,6 @@ impl QuorumCreditContract {
         vouch::decrease_stake(env, voucher, borrower, amount)
     }
 
-    /// Fully withdraw a vouch. If borrower has an active loan, queues the withdrawal.
     pub fn withdraw_vouch(
         env: Env,
         voucher: Address,
@@ -130,13 +123,6 @@ impl QuorumCreditContract {
         vouch::withdraw_vouch(env, voucher, borrower)
     }
 
-    // ─────────────────────────────────────────────
-    // Withdrawal Queue
-    // ─────────────────────────────────────────────
-
-    /// Queue a withdrawal during an active loan.
-    /// Optionally pay a priority fee (stroops) to be processed before others.
-    /// Queue is processed automatically when the loan is repaid or slashed.
     pub fn request_withdrawal(
         env: Env,
         voucher: Address,
@@ -146,8 +132,6 @@ impl QuorumCreditContract {
         vouch::request_withdrawal(env, voucher, borrower, priority_fee)
     }
 
-    /// Partial withdrawal: withdraw up to 50% of stake during an active loan.
-    /// A 10% penalty is applied to the withdrawn amount and distributed to remaining vouchers.
     pub fn partial_withdraw(
         env: Env,
         voucher: Address,
@@ -156,14 +140,9 @@ impl QuorumCreditContract {
         vouch::partial_withdraw(env, voucher, borrower)
     }
 
-    /// Get the pending withdrawal queue for a borrower.
     pub fn get_withdrawal_queue(env: Env, borrower: Address) -> Vec<QueuedWithdrawal> {
         vouch::get_withdrawal_queue(env, borrower)
     }
-
-    // ─────────────────────────────────────────────
-    // Loans (minimal — for test support)
-    // ─────────────────────────────────────────────
 
     pub fn request_loan(
         env: Env,
@@ -204,16 +183,7 @@ impl QuorumCreditContract {
         }
 
         let now = env.ledger().timestamp();
-        let loan_id: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::LoanCounter)
-            .unwrap_or(0u64)
-            + 1;
-        env.storage()
-            .persistent()
-            .set(&DataKey::LoanCounter, &loan_id);
-
+        let loan_id = helpers::next_loan_id(&env);
         let total_yield = amount * cfg.yield_bps / 10_000;
 
         let loan = LoanRecord {
@@ -241,6 +211,9 @@ impl QuorumCreditContract {
         env.storage()
             .persistent()
             .set(&DataKey::ActiveLoan(borrower.clone()), &loan_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::LatestLoan(borrower.clone()), &loan_id);
 
         token_client.transfer(&env.current_contract_address(), &borrower, &amount);
 
@@ -306,7 +279,6 @@ impl QuorumCreditContract {
                 );
             }
 
-            // Process any queued withdrawals now that the loan is closed
             vouch::process_withdrawal_queue(&env, &borrower);
 
             env.storage()
@@ -351,5 +323,141 @@ impl QuorumCreditContract {
             .get(&DataKey::Vouches(borrower))
             .unwrap_or(Vec::new(&env));
         vouches.iter().any(|v| v.voucher == voucher)
+    }
+
+    pub fn get_config(env: Env) -> Config {
+        config(&env)
+    }
+
+    pub fn loan_status(env: Env, borrower: Address) -> LoanStatus {
+        helper_loan_status(&env, &borrower)
+    }
+
+    // ── Governance: slash voting ──────────────────────────────────────────────
+
+    pub fn vote_slash(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        governance::vote_slash(env, voucher, borrower, approve)
+    }
+
+    pub fn get_slash_vote(env: Env, borrower: Address) -> Option<SlashVoteRecord> {
+        governance::get_slash_vote(env, borrower)
+    }
+
+    pub fn set_slash_vote_quorum(env: Env, admin_signers: Vec<Address>, quorum_bps: u32) {
+        helpers::require_admin_approval(&env, &admin_signers);
+        governance::set_slash_vote_quorum(&env, quorum_bps);
+    }
+
+    pub fn get_slash_vote_quorum(env: Env) -> u32 {
+        governance::get_slash_vote_quorum(env)
+    }
+
+    pub fn execute_slash_vote(env: Env, borrower: Address) -> Result<(), ContractError> {
+        governance::execute_slash_vote(env, borrower)
+    }
+
+    // ── Issue #680: slash threshold governance ────────────────────────────────
+
+    pub fn propose_slash_threshold(
+        env: Env,
+        proposer: Address,
+        new_threshold: i128,
+    ) -> Result<u64, ContractError> {
+        governance::propose_slash_threshold(env, proposer, new_threshold)
+    }
+
+    pub fn vote_slash_threshold(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        governance::vote_slash_threshold(env, voter, proposal_id, approve)
+    }
+
+    pub fn finalize_slash_threshold(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+        governance::finalize_slash_threshold(env, proposal_id)
+    }
+
+    pub fn get_slash_threshold_proposal(
+        env: Env,
+        proposal_id: u64,
+    ) -> Option<SlashThresholdProposal> {
+        governance::get_slash_threshold_proposal(env, proposal_id)
+    }
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    pub fn pause(env: Env, admin_signers: Vec<Address>) {
+        admin::pause(env, admin_signers)
+    }
+
+    pub fn unpause(env: Env, admin_signers: Vec<Address>) {
+        admin::unpause(env, admin_signers)
+    }
+
+    pub fn get_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+    }
+
+    pub fn set_config(env: Env, admin_signers: Vec<Address>, cfg: Config) {
+        admin::set_config(env, admin_signers, cfg)
+    }
+
+    pub fn update_config(
+        env: Env,
+        admin_signers: Vec<Address>,
+        yield_bps: Option<i128>,
+        slash_bps: Option<i128>,
+    ) {
+        admin::update_config(env, admin_signers, yield_bps, slash_bps)
+    }
+
+    // ── Issue #682: multi-sig config updates ──────────────────────────────────
+
+    pub fn propose_config_update(
+        env: Env,
+        proposer: Address,
+        key: ConfigUpdateKey,
+        new_value: u32,
+    ) -> Result<u64, ContractError> {
+        admin::propose_config_update(env, proposer, key, new_value)
+    }
+
+    pub fn approve_config_update(
+        env: Env,
+        admin: Address,
+        proposal_id: u64,
+    ) -> Result<(), ContractError> {
+        admin::approve_config_update(env, admin, proposal_id)
+    }
+
+    pub fn finalize_config_update(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+        admin::finalize_config_update(env, proposal_id)
+    }
+
+    pub fn get_config_update_proposal(
+        env: Env,
+        proposal_id: u64,
+    ) -> Option<ConfigUpdateProposal> {
+        admin::get_config_update_proposal(env, proposal_id)
+    }
+
+    // ── Issue #683: emergency pause ───────────────────────────────────────────
+
+    pub fn emergency_pause(env: Env, admin: Address) -> Result<(), ContractError> {
+        admin::emergency_pause(env, admin)
+    }
+
+    pub fn emergency_unpause(env: Env, admin_signers: Vec<Address>) -> Result<(), ContractError> {
+        admin::emergency_unpause(env, admin_signers)
     }
 }

--- a/src/slash_cooldown_test.rs
+++ b/src/slash_cooldown_test.rs
@@ -1,0 +1,127 @@
+#[cfg(test)]
+mod slash_cooldown_tests {
+    use crate::{ContractError, LoanStatus, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, String, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        admin: Address,
+        token_id: Address,
+    }
+
+    fn setup_with_cooldown(cooldown_secs: u64) -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        StellarAssetClient::new(&env, &token_id.address()).mint(&contract_id, &10_000_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+
+        let mut cfg = client.get_config();
+        cfg.slash_cooldown_seconds = cooldown_secs;
+        client.set_config(&Vec::from_array(&env, [admin.clone()]), &cfg);
+
+        env.ledger().with_mut(|l| l.timestamp = 90_000);
+
+        Setup {
+            env,
+            client,
+            admin,
+            token_id: token_id.address(),
+        }
+    }
+
+    fn advance_time(s: &Setup, secs: u64) {
+        let t = s.env.ledger().timestamp();
+        s.env.ledger().with_mut(|l| l.timestamp = t + secs);
+    }
+
+    fn do_vouch(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+        advance_time(s, crate::types::DEFAULT_VOUCH_COOLDOWN_SECS + 1);
+    }
+
+    fn do_vouch_no_advance(s: &Setup, voucher: &Address, borrower: &Address, stake: i128) {
+        StellarAssetClient::new(&s.env, &s.token_id).mint(voucher, &stake);
+        s.client.vouch(voucher, borrower, &stake, &s.token_id);
+    }
+
+    fn do_loan(s: &Setup, borrower: &Address, amount: i128, threshold: i128) {
+        s.client.request_loan(
+            borrower,
+            &amount,
+            &threshold,
+            &String::from_str(&s.env, "test"),
+            &s.token_id,
+        );
+    }
+
+    fn slash_borrower(s: &Setup, borrower: &Address, voucher: &Address) {
+        s.client.vote_slash(voucher, borrower, &true);
+    }
+
+    #[test]
+    fn test_slash_within_cooldown_rejected() {
+        let s = setup_with_cooldown(3600);
+        let borrower = Address::generate(&s.env);
+        let voucher1 = Address::generate(&s.env);
+        let voucher2 = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher1, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+        slash_borrower(&s, &borrower, &voucher1);
+
+        do_vouch_no_advance(&s, &voucher2, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+
+        let result = s.client.try_vote_slash(&voucher2, &borrower, &true);
+        assert_eq!(result, Err(Ok(ContractError::SlashCooldownActive)));
+    }
+
+    #[test]
+    fn test_slash_after_cooldown_succeeds() {
+        let s = setup_with_cooldown(3600);
+        let borrower = Address::generate(&s.env);
+        let voucher1 = Address::generate(&s.env);
+        let voucher2 = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher1, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+        slash_borrower(&s, &borrower, &voucher1);
+
+        advance_time(&s, 3601);
+        do_vouch_no_advance(&s, &voucher2, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+        slash_borrower(&s, &borrower, &voucher2);
+        assert_eq!(s.client.loan_status(&borrower), LoanStatus::Defaulted);
+    }
+
+    #[test]
+    fn test_zero_cooldown_allows_immediate_reslash() {
+        let s = setup_with_cooldown(0);
+        let borrower = Address::generate(&s.env);
+        let voucher1 = Address::generate(&s.env);
+        let voucher2 = Address::generate(&s.env);
+
+        do_vouch(&s, &voucher1, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+        slash_borrower(&s, &borrower, &voucher1);
+
+        do_vouch_no_advance(&s, &voucher2, &borrower, 1_000_000);
+        do_loan(&s, &borrower, 100_000, 500_000);
+        slash_borrower(&s, &borrower, &voucher2);
+        assert_eq!(s.client.loan_status(&borrower), LoanStatus::Defaulted);
+    }
+}

--- a/src/slash_threshold_voting_test.rs
+++ b/src/slash_threshold_voting_test.rs
@@ -1,0 +1,102 @@
+#[cfg(test)]
+mod slash_threshold_voting_tests {
+    use crate::{ContractError, QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env, Vec,
+    };
+
+    struct Setup {
+        env: Env,
+        client: QuorumCreditContractClient<'static>,
+        admin: Address,
+        token_holder: Address,
+        token_id: Address,
+    }
+
+    fn setup() -> Setup {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token_holder = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin.clone()]);
+
+        let token_id = env.register_stellar_asset_contract_v2(admin.clone());
+        let contract_id = env.register_contract(None, QuorumCreditContract);
+        StellarAssetClient::new(&env, &token_id.address()).mint(&token_holder, &1_000);
+
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &1, &token_id.address());
+        env.ledger().with_mut(|l| l.timestamp = 90_000);
+
+        Setup {
+            env,
+            client,
+            admin,
+            token_holder,
+            token_id: token_id.address(),
+        }
+    }
+
+    #[test]
+    fn test_proposal_created_correctly() {
+        let s = setup();
+        let id = s.client.propose_slash_threshold(&s.admin, &3_000);
+        let p = s.client.get_slash_threshold_proposal(&id).unwrap();
+        assert_eq!(p.proposed_threshold, 3_000);
+        assert_eq!(p.proposer, s.admin);
+        assert!(!p.finalized);
+    }
+
+    #[test]
+    fn test_votes_tallied_and_approved_updates_threshold() {
+        let s = setup();
+        let voter = s.token_holder.clone();
+        let id = s.client.propose_slash_threshold(&s.admin, &4_000);
+        s.client.vote_slash_threshold(&voter, &id, &true);
+        s.client.vote_slash_threshold(&s.admin, &id, &true);
+
+        let period = s.client.get_config().voting_period_seconds;
+        s.env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+        s.client.finalize_slash_threshold(&id);
+        assert_eq!(s.client.get_config().slash_bps, 4_000);
+    }
+
+    #[test]
+    fn test_rejected_proposal_discards_without_change() {
+        let s = setup();
+        let original = s.client.get_config().slash_bps;
+        let id = s.client.propose_slash_threshold(&s.admin, &2_000);
+        s.client.vote_slash_threshold(&s.admin, &id, &false);
+        s.client.vote_slash_threshold(&s.token_holder, &id, &false);
+
+        let period = s.client.get_config().voting_period_seconds;
+        s.env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+        s.client.finalize_slash_threshold(&id);
+        assert_eq!(s.client.get_config().slash_bps, original);
+    }
+
+    #[test]
+    fn test_vote_after_period_rejected() {
+        let s = setup();
+        let id = s.client.propose_slash_threshold(&s.admin, &3_500);
+        let period = s.client.get_config().voting_period_seconds;
+        s.env.ledger().with_mut(|l| l.timestamp += period + 1);
+
+        let result = s.client.try_vote_slash_threshold(&s.admin, &id, &true);
+        assert_eq!(result, Err(Ok(ContractError::VotingPeriodEnded)));
+    }
+
+    #[test]
+    fn test_finalize_before_period_rejected() {
+        let s = setup();
+        let id = s.client.propose_slash_threshold(&s.admin, &3_500);
+        let result = s.client.try_finalize_slash_threshold(&id);
+        assert_eq!(result, Err(Ok(ContractError::TimelockNotReady)));
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,6 +48,8 @@ pub const DEFAULT_MAX_LOAN_TO_STAKE_RATIO: u32 = 150;
 pub const DEFAULT_VOUCH_COOLDOWN_SECS: u64 = 24 * 60 * 60; // 24 hours
 /// Default maximum number of vouchers that may back a single borrower.
 pub const DEFAULT_MAX_VOUCHERS_PER_BORROWER: u32 = 50;
+/// Default governance voting period for slash-threshold proposals, in seconds (7 days).
+pub const DEFAULT_VOTING_PERIOD_SECONDS: u64 = 7 * 24 * 60 * 60;
 /// Minimum delay before a timelocked governance action may be executed, in seconds (24 hours).
 pub const TIMELOCK_DELAY: u64 = 24 * 60 * 60;
 /// Maximum window after `eta` within which a timelocked action must be executed, in seconds (72 hours).
@@ -170,6 +172,14 @@ pub enum DataKey {
     AdminAction(u64),        // action_id → AdminActionProposal
     AdminActionCounter,      // u64: monotonically increasing admin action ID
     SlashAppeal(Address, Address), // (borrower, voucher) → SlashAppealRecord
+    /// Slash-threshold governance proposal id → proposal record.
+    SlashThresholdProposal(u64),
+    SlashThresholdProposalCounter,
+    /// Per-borrower timestamp of the last successful slash.
+    LastSlashedAt(Address),
+    /// Admin config-update proposal id → proposal record.
+    ConfigUpdateProposal(u64),
+    ConfigUpdateProposalCounter,
     /// Issue #599/#600: (voucher, borrower) → WithdrawalRequest (pending timelock withdrawal)
     PendingWithdrawal(Address, Address),
     /// Issue #601: borrower → LoanExtensionRequest
@@ -207,6 +217,39 @@ pub struct SlashVoteRecord {
     pub executed: bool,
 }
 
+/// Governance proposal to change the protocol slash threshold (`Config.slash_bps`).
+#[contracttype]
+#[derive(Clone)]
+pub struct SlashThresholdProposal {
+    pub id: u64,
+    pub proposer: Address,
+    pub proposed_threshold: i128,
+    pub proposed_at: u64,
+    pub approve_votes: u32,
+    pub reject_votes: u32,
+    pub voters: Vec<Address>,
+    pub finalized: bool,
+}
+
+/// Config field targeted by an admin config-update proposal.
+#[contracttype]
+#[derive(Clone)]
+pub enum ConfigUpdateKey {
+    AdminThreshold,
+}
+
+/// Multi-sig admin proposal to update a config field.
+#[contracttype]
+#[derive(Clone)]
+pub struct ConfigUpdateProposal {
+    pub id: u64,
+    pub proposer: Address,
+    pub key: ConfigUpdateKey,
+    pub new_value: u32,
+    pub approvals: Vec<Address>,
+    pub executed: bool,
+}
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 #[contracttype]
@@ -241,6 +284,12 @@ pub struct Config {
     pub prepayment_penalty_bps: u32,
     /// #634: Liquidity mining reward rate in basis points per epoch (e.g. 50 = 0.5% per 7 days).
     pub liquidity_mining_rate_bps: u32,
+    /// Voting period for slash-threshold governance proposals, in seconds.
+    pub voting_period_seconds: u64,
+    /// Minimum seconds between slashes for the same borrower (0 = disabled).
+    pub slash_cooldown_seconds: u64,
+    /// When true, critical write paths are blocked until multi-sig emergency unpause.
+    pub emergency_pause_enabled: bool,
 }
 
 // ── Data Types ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds four governance and admin safety features to the QuorumCredit Soroban contract:

- **#680** — Slash threshold governance voting (`propose_slash_threshold`, `vote_slash_threshold`, `finalize_slash_threshold`) with `voting_period_seconds` on `Config`
- **#681** — Per-borrower slashing cooldown (`slash_cooldown_seconds`, `last_slashed_at`, `SlashCooldownActive`)
- **#682** — Multi-sig admin config updates (`propose_config_update`, `approve_config_update`, `finalize_config_update`) for fields like `admin_threshold`
- **#683** — Emergency pause (`emergency_pause` / `emergency_unpause`) with single-admin pause and threshold-gated unpause

Also wires the contract through `lib.rs` with expanded `helpers.rs` and targeted tests for each issue.

## Changes

| Issue | Scope |
|-------|--------|
| #680 | `Config.voting_period_seconds`, `SlashThresholdProposal` storage, governance voting + finalization |
| #681 | `Config.slash_cooldown_seconds`, `LastSlashedAt(borrower)`, cooldown checks in `vote_slash` / `execute_slash` |
| #682 | `ConfigUpdateProposal`, admin-only propose/approve, finalize at `admin_threshold` |
| #683 | `Config.emergency_pause_enabled`, `emergency_pause()` / `emergency_unpause()`, `require_not_paused` blocks writes |

## Commits

1. `feat(contracts): add slashing threshold governance voting (#680)`
2. `feat(contracts): add slashing cooldown period per borrower (#681)`
3. `feat(contracts): add multi-sig voting for admin Config threshold changes (#682)`
4. `feat(contracts): add admin emergency pause with single-admin trigger (#683)`

## Test plan

- [x] `cargo test` — 31 tests passing
- [x] Slash threshold: proposal, vote tally, approve/reject paths, period boundaries
- [x] Slash cooldown: reject within window, allow after window, `slash_cooldown_seconds = 0`
- [x] Config update: admin-only, no double-approve, threshold before finalize
- [x] Emergency pause: single admin pause, multi-sig unpause, write ops blocked while paused

## Closes

 Closes #680
 Closes #681
 Closes #682
 Closes #683