### PR TITLE
feat: add loan health monitoring and dashboard query functions

### DIFF
--- a/QuorumCredit/src/health.rs
+++ b/QuorumCredit/src/health.rs
@@ -1,7 +1,10 @@
-use crate::errors::ContractError;
-use crate::types::{Config, DataKey};
-use soroban_sdk::{contracttype, Address, Env, String, Vec};
-use crate::helpers::is_zero_address;
+use crate::types::{
+    Config, DataKey, ExposureReport, HealthAlertThresholds, LoanHealthScore, LoanRecord,
+    LoanStatus, ProtocolHealthReport, RiskLevel, VouchRecord,
+};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Vec};
+
+// ── Protocol-level health check (existing) ────────────────────────────────────
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -17,34 +20,26 @@ pub fn health_check(env: &Env) -> HealthStatus {
     let mut issues = Vec::new(env);
     let mut is_healthy = true;
 
-    // Check if initialized
     let initialized = env.storage().instance().has(&DataKey::Config);
     if !initialized {
         issues.push_back(String::from_str(env, "Contract not initialized"));
         is_healthy = false;
     }
 
-    // Check if paused
     let paused: bool = env
         .storage()
         .instance()
         .get(&DataKey::Paused)
         .unwrap_or(false);
 
-    // Check yield reserve solvency (contract must hold enough XLM for yield payouts)
     let yield_reserve_solvent = if initialized {
         let config: Config = env
             .storage()
             .instance()
             .get(&DataKey::Config)
-            .unwrap_or_else(|| {
-                panic!("Config not found despite initialized check");
-            });
-
+            .unwrap_or_else(|| panic!("Config not found despite initialized check"));
         let token_client = soroban_sdk::token::Client::new(env, &config.token);
         let contract_balance = token_client.balance(&env.current_contract_address());
-        
-        // Reserve must be at least 1 XLM (10_000_000 stroops) to be considered solvent
         contract_balance >= 10_000_000
     } else {
         false
@@ -61,5 +56,340 @@ pub fn health_check(env: &Env) -> HealthStatus {
         paused,
         yield_reserve_solvent,
         issues,
+    }
+}
+
+// ── Alert threshold helpers ───────────────────────────────────────────────────
+
+const HEALTH_THRESHOLDS_KEY: &str = "hlth_thr";
+
+pub fn get_alert_thresholds(env: &Env) -> HealthAlertThresholds {
+    env.storage()
+        .instance()
+        .get(&soroban_sdk::Symbol::new(env, HEALTH_THRESHOLDS_KEY))
+        .unwrap_or_else(HealthAlertThresholds::default)
+}
+
+pub fn set_alert_thresholds(env: &Env, thresholds: HealthAlertThresholds) {
+    env.storage()
+        .instance()
+        .set(&soroban_sdk::Symbol::new(env, HEALTH_THRESHOLDS_KEY), &thresholds);
+}
+
+// ── Individual loan health ────────────────────────────────────────────────────
+
+/// Compute a health score for a single active loan.
+///
+/// Score components (each 0–100, averaged):
+/// 1. Time component: full marks if > at_risk_deadline, zero if past deadline.
+/// 2. Repayment component: proportional to repayment progress.
+/// 3. History component: inverted borrower risk score.
+/// 4. Concentration component: penalises single-voucher dominance.
+pub fn get_loan_health(env: Env, borrower: Address) -> Option<LoanHealthScore> {
+    let loan_record: LoanRecord = env
+        .storage()
+        .persistent()
+        .get(&DataKey::ActiveLoan(borrower.clone()))
+        .and_then(|loan_id: u64| {
+            env.storage()
+                .persistent()
+                .get(&DataKey::Loan(loan_id))
+        })?;
+
+    if loan_record.status != LoanStatus::Active {
+        return None;
+    }
+
+    let thresholds = get_alert_thresholds(&env);
+    let now = env.ledger().timestamp();
+
+    // 1. Time component
+    let seconds_until_deadline = if now >= loan_record.deadline {
+        0u64
+    } else {
+        loan_record.deadline - now
+    };
+    let time_score: u32 = if loan_record.deadline <= now {
+        0
+    } else {
+        let duration = loan_record.deadline.saturating_sub(loan_record.disbursement_timestamp);
+        if duration == 0 {
+            100
+        } else {
+            let remaining_ratio = seconds_until_deadline * 100 / duration;
+            remaining_ratio.min(100) as u32
+        }
+    };
+
+    // 2. Repayment component
+    let total_owed = loan_record.amount + loan_record.total_yield;
+    let repayment_progress_bps: u32 = if total_owed > 0 {
+        (loan_record.amount_repaid * 10_000 / total_owed).min(10_000) as u32
+    } else {
+        10_000
+    };
+    let repayment_score: u32 = repayment_progress_bps / 100;
+
+    // 3. History component (inverted risk score)
+    let default_count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DefaultCount(borrower.clone()))
+        .unwrap_or(0);
+    let loan_count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LoanCount(borrower.clone()))
+        .unwrap_or(0);
+    let repayment_count: u32 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::RepaymentCount(borrower.clone()))
+        .unwrap_or(0);
+    let numerator = (default_count as i128) * 10_000;
+    let denominator = (loan_count as i128) + (repayment_count as i128) + 1;
+    let borrower_risk_score = (numerator / denominator).min(10_000);
+    let history_score: u32 = (100 - (borrower_risk_score / 100).min(100)) as u32;
+
+    // 4. Concentration component
+    let vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .unwrap_or_else(|| Vec::new(&env));
+    let total_stake: i128 = vouches
+        .iter()
+        .filter(|v| v.token == loan_record.token_address)
+        .map(|v| v.amount)
+        .sum();
+    let max_stake: i128 = vouches
+        .iter()
+        .filter(|v| v.token == loan_record.token_address)
+        .map(|v| v.amount)
+        .fold(0i128, |acc, s| if s > acc { s } else { acc });
+    let top_voucher_concentration_bps: u32 = if total_stake > 0 {
+        (max_stake * 10_000 / total_stake).min(10_000) as u32
+    } else {
+        10_000
+    };
+    let concentration_score: u32 = if top_voucher_concentration_bps >= thresholds.concentration_risk_bps {
+        0
+    } else {
+        100 - (top_voucher_concentration_bps / 100).min(100)
+    };
+
+    let score = (time_score + repayment_score + history_score + concentration_score) / 4;
+
+    let risk_level = if seconds_until_deadline <= thresholds.critical_deadline_secs
+        || repayment_progress_bps < thresholds.at_risk_repayment_bps / 4
+    {
+        RiskLevel::Critical
+    } else if seconds_until_deadline <= thresholds.at_risk_deadline_secs
+        || repayment_progress_bps < thresholds.at_risk_repayment_bps
+    {
+        RiskLevel::AtRisk
+    } else {
+        RiskLevel::Healthy
+    };
+
+    // Emit warning event when at-risk or critical
+    if risk_level != RiskLevel::Healthy {
+        env.events().publish(
+            (symbol_short!("health"), symbol_short!("at_risk")),
+            (borrower.clone(), loan_record.id, score),
+        );
+    }
+
+    Some(LoanHealthScore {
+        borrower,
+        loan_id: loan_record.id,
+        score,
+        risk_level,
+        seconds_until_deadline,
+        repayment_progress_bps,
+        borrower_risk_score,
+        top_voucher_concentration_bps,
+    })
+}
+
+// ── Dashboard query functions ─────────────────────────────────────────────────
+
+/// Return health scores for all active loans that are at-risk or critical.
+pub fn get_at_risk_loans(env: Env) -> Vec<LoanHealthScore> {
+    let borrower_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::BorrowerList)
+        .unwrap_or_else(|| Vec::new(&env));
+
+    let mut results: Vec<LoanHealthScore> = Vec::new(&env);
+    for borrower in borrower_list.iter() {
+        if let Some(health) = get_loan_health(env.clone(), borrower) {
+            if health.risk_level != RiskLevel::Healthy {
+                results.push_back(health);
+            }
+        }
+    }
+    results
+}
+
+/// Return the total active stake exposure for a voucher across all active loans.
+pub fn get_voucher_exposure(env: Env, voucher: Address) -> ExposureReport {
+    let backed_borrowers: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::VoucherHistory(voucher.clone()))
+        .unwrap_or_else(|| Vec::new(&env));
+
+    let thresholds = get_alert_thresholds(&env);
+    let now = env.ledger().timestamp();
+    let mut total_active_stake: i128 = 0;
+    let mut active_loan_count: u32 = 0;
+    let mut at_risk_count: u32 = 0;
+
+    for borrower in backed_borrowers.iter() {
+        let loan_id_opt: Option<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()));
+        let loan_id = match loan_id_opt {
+            Some(id) => id,
+            None => continue,
+        };
+        let loan_record: LoanRecord = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+        {
+            Some(r) => r,
+            None => continue,
+        };
+        if loan_record.status != LoanStatus::Active {
+            continue;
+        }
+
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for v in vouches.iter() {
+            if v.voucher == voucher {
+                total_active_stake += v.amount;
+                active_loan_count += 1;
+
+                let seconds_until_deadline = if now >= loan_record.deadline {
+                    0u64
+                } else {
+                    loan_record.deadline - now
+                };
+                let total_owed = loan_record.amount + loan_record.total_yield;
+                let repayment_bps: u32 = if total_owed > 0 {
+                    (loan_record.amount_repaid * 10_000 / total_owed).min(10_000) as u32
+                } else {
+                    10_000
+                };
+                if seconds_until_deadline <= thresholds.at_risk_deadline_secs
+                    || repayment_bps < thresholds.at_risk_repayment_bps
+                {
+                    at_risk_count += 1;
+                }
+                break;
+            }
+        }
+    }
+
+    ExposureReport {
+        voucher,
+        total_active_stake,
+        active_loan_count,
+        at_risk_count,
+    }
+}
+
+/// Return a protocol-wide health summary.
+pub fn get_protocol_health(env: Env) -> ProtocolHealthReport {
+    let borrower_list: Vec<Address> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::BorrowerList)
+        .unwrap_or_else(|| Vec::new(&env));
+
+    let thresholds = get_alert_thresholds(&env);
+    let now = env.ledger().timestamp();
+    let mut active_loan_count: u32 = 0;
+    let mut at_risk_loan_count: u32 = 0;
+    let mut total_outstanding: i128 = 0;
+    let mut total_locked_stake: i128 = 0;
+
+    for borrower in borrower_list.iter() {
+        let loan_id_opt: Option<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ActiveLoan(borrower.clone()));
+        let loan_id = match loan_id_opt {
+            Some(id) => id,
+            None => continue,
+        };
+        let loan_record: LoanRecord = match env
+            .storage()
+            .persistent()
+            .get(&DataKey::Loan(loan_id))
+        {
+            Some(r) => r,
+            None => continue,
+        };
+        if loan_record.status != LoanStatus::Active {
+            continue;
+        }
+
+        active_loan_count += 1;
+        total_outstanding += loan_record.amount - loan_record.amount_repaid.min(loan_record.amount);
+
+        let vouches: Vec<VouchRecord> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Vouches(borrower.clone()))
+            .unwrap_or_else(|| Vec::new(&env));
+        let stake: i128 = vouches
+            .iter()
+            .filter(|v| v.token == loan_record.token_address)
+            .map(|v| v.amount)
+            .sum();
+        total_locked_stake += stake;
+
+        let seconds_until_deadline = if now >= loan_record.deadline {
+            0u64
+        } else {
+            loan_record.deadline - now
+        };
+        let total_owed = loan_record.amount + loan_record.total_yield;
+        let repayment_bps: u32 = if total_owed > 0 {
+            (loan_record.amount_repaid * 10_000 / total_owed).min(10_000) as u32
+        } else {
+            10_000
+        };
+        if seconds_until_deadline <= thresholds.at_risk_deadline_secs
+            || repayment_bps < thresholds.at_risk_repayment_bps
+        {
+            at_risk_loan_count += 1;
+        }
+    }
+
+    let config: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .unwrap_or_else(|| panic!("not initialized"));
+    let token_client = soroban_sdk::token::Client::new(&env, &config.token);
+    let contract_balance = token_client.balance(&env.current_contract_address());
+
+    ProtocolHealthReport {
+        active_loan_count,
+        at_risk_loan_count,
+        total_outstanding,
+        total_locked_stake,
+        contract_balance,
     }
 }

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -104,6 +104,8 @@ mod default_prediction_test;
 mod admin_delegation_test;
 #[cfg(test)]
 mod governance_veto_test;
+#[cfg(test)]
+mod loan_health_test;
 
 pub use errors::ContractError;
 pub use types::*;
@@ -908,6 +910,41 @@ impl QuorumCreditContract {
 
     pub fn health_check(env: Env) -> health::HealthStatus {
         health::health_check(&env)
+    }
+
+    /// Get the health score for a single active loan.
+    pub fn get_loan_health(env: Env, borrower: Address) -> Option<LoanHealthScore> {
+        health::get_loan_health(env, borrower)
+    }
+
+    /// Get health scores for all active loans that are at-risk or critical.
+    pub fn get_at_risk_loans(env: Env) -> Vec<LoanHealthScore> {
+        health::get_at_risk_loans(env)
+    }
+
+    /// Get the total active stake exposure for a voucher.
+    pub fn get_voucher_exposure(env: Env, voucher: Address) -> ExposureReport {
+        health::get_voucher_exposure(env, voucher)
+    }
+
+    /// Get a protocol-wide health summary.
+    pub fn get_protocol_health(env: Env) -> ProtocolHealthReport {
+        health::get_protocol_health(env)
+    }
+
+    /// Set configurable alert thresholds (admin only).
+    pub fn set_health_alert_thresholds(
+        env: Env,
+        admin_signers: Vec<Address>,
+        thresholds: HealthAlertThresholds,
+    ) {
+        helpers::require_admin_approval(&env, &admin_signers);
+        health::set_alert_thresholds(&env, thresholds);
+    }
+
+    /// Get the current alert thresholds.
+    pub fn get_health_alert_thresholds(env: Env) -> HealthAlertThresholds {
+        health::get_alert_thresholds(&env)
     }
 
     // ── Upgrade Safety ────────────────────────────────────────────────────────

--- a/QuorumCredit/src/loan_health_test.rs
+++ b/QuorumCredit/src/loan_health_test.rs
@@ -1,0 +1,161 @@
+#[cfg(test)]
+mod tests {
+    use crate::types::{HealthAlertThresholds, LoanCategory, RiskLevel};
+    use crate::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger, LedgerInfo},
+        Address, Env,
+    };
+
+    fn setup_env() -> (Env, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        (env, deployer, admin, token)
+    }
+
+    fn init_contract(env: &Env, deployer: &Address, admin: &Address, token: &Address) -> Address {
+        let contract_id = env.register(QuorumCreditContract, ());
+        let client = QuorumCreditContractClient::new(env, &contract_id);
+        client.initialize(
+            deployer,
+            &soroban_sdk::vec![env, admin.clone()],
+            &1u32,
+            token,
+        );
+        contract_id
+    }
+
+    #[test]
+    fn test_get_loan_health_no_active_loan() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let borrower = Address::generate(&env);
+        let result = client.get_loan_health(&borrower);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_at_risk_loans_empty() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let at_risk = client.get_at_risk_loans();
+        assert_eq!(at_risk.len(), 0);
+    }
+
+    #[test]
+    fn test_get_voucher_exposure_no_loans() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let voucher = Address::generate(&env);
+        let report = client.get_voucher_exposure(&voucher);
+        assert_eq!(report.total_active_stake, 0);
+        assert_eq!(report.active_loan_count, 0);
+        assert_eq!(report.at_risk_count, 0);
+    }
+
+    #[test]
+    fn test_get_protocol_health_no_loans() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let report = client.get_protocol_health();
+        assert_eq!(report.active_loan_count, 0);
+        assert_eq!(report.at_risk_loan_count, 0);
+        assert_eq!(report.total_outstanding, 0);
+    }
+
+    #[test]
+    fn test_set_and_get_health_alert_thresholds() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let thresholds = HealthAlertThresholds {
+            at_risk_deadline_secs: 3 * 24 * 60 * 60,
+            critical_deadline_secs: 12 * 60 * 60,
+            at_risk_repayment_bps: 3000,
+            concentration_risk_bps: 7000,
+        };
+        client.set_health_alert_thresholds(&soroban_sdk::vec![&env, admin.clone()], &thresholds);
+
+        let stored = client.get_health_alert_thresholds();
+        assert_eq!(stored.at_risk_deadline_secs, 3 * 24 * 60 * 60);
+        assert_eq!(stored.critical_deadline_secs, 12 * 60 * 60);
+        assert_eq!(stored.at_risk_repayment_bps, 3000);
+        assert_eq!(stored.concentration_risk_bps, 7000);
+    }
+
+    #[test]
+    fn test_default_health_alert_thresholds() {
+        let (env, deployer, admin, token) = setup_env();
+        let contract_id = init_contract(&env, &deployer, &admin, &token);
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+
+        let defaults = client.get_health_alert_thresholds();
+        assert_eq!(defaults.at_risk_deadline_secs, 7 * 24 * 60 * 60);
+        assert_eq!(defaults.critical_deadline_secs, 24 * 60 * 60);
+        assert_eq!(defaults.at_risk_repayment_bps, 2500);
+        assert_eq!(defaults.concentration_risk_bps, 8000);
+    }
+
+    #[test]
+    fn test_get_loan_health_active_loan() {
+        use soroban_sdk::testutils::MockAuth;
+        use soroban_sdk::token::StellarAssetClient;
+
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let token_admin = StellarAssetClient::new(&env, &token);
+
+        let contract_id = env.register(QuorumCreditContract, ());
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(
+            &deployer,
+            &soroban_sdk::vec![&env, admin.clone()],
+            &1u32,
+            &token,
+        );
+
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        // Fund voucher and contract
+        token_admin.mint(&voucher, &10_000_000_000);
+        token_admin.mint(&contract_id, &10_000_000_000);
+
+        let stake = 5_000_000_000i128;
+        client.vouch(&voucher, &borrower, &stake, &token);
+
+        let loan_amount = 1_000_000_000i128;
+        client.request_loan(
+            &borrower,
+            &loan_amount,
+            &stake,
+            &soroban_sdk::String::from_str(&env, "test"),
+            &token,
+            &crate::types::LoanCategory::Personal,
+        );
+
+        let health = client.get_loan_health(&borrower);
+        assert!(health.is_some());
+        let h = health.unwrap();
+        assert_eq!(h.borrower, borrower);
+        assert!(h.score <= 100);
+        // New loan with no repayment and far deadline should be healthy
+        assert_eq!(h.risk_level, RiskLevel::Healthy);
+    }
+}

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -189,6 +189,90 @@ pub enum DataKey {
     SlashRecord(u64),
 }
 
+// ── Loan Health Monitoring ────────────────────────────────────────────────────
+
+/// Risk level of a loan.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RiskLevel {
+    Healthy,
+    AtRisk,
+    Critical,
+}
+
+/// Health score for an individual active loan.
+#[contracttype]
+#[derive(Clone)]
+pub struct LoanHealthScore {
+    pub borrower: Address,
+    pub loan_id: u64,
+    /// 0–100: higher is healthier.
+    pub score: u32,
+    pub risk_level: RiskLevel,
+    /// Seconds remaining until deadline (0 if past deadline).
+    pub seconds_until_deadline: u64,
+    /// Repayment progress in basis points (0–10_000).
+    pub repayment_progress_bps: u32,
+    /// Borrower historical risk score (0–10_000; higher = riskier).
+    pub borrower_risk_score: i128,
+    /// Voucher concentration: stake held by the single largest voucher in bps.
+    pub top_voucher_concentration_bps: u32,
+}
+
+/// Exposure summary for a single voucher across all active loans.
+#[contracttype]
+#[derive(Clone)]
+pub struct ExposureReport {
+    pub voucher: Address,
+    /// Total stake currently locked in active loans (stroops).
+    pub total_active_stake: i128,
+    /// Number of active loans this voucher is backing.
+    pub active_loan_count: u32,
+    /// Number of those loans that are at-risk or critical.
+    pub at_risk_count: u32,
+}
+
+/// Protocol-wide health summary.
+#[contracttype]
+#[derive(Clone)]
+pub struct ProtocolHealthReport {
+    /// Total number of active loans.
+    pub active_loan_count: u32,
+    /// Number of active loans classified as at-risk or critical.
+    pub at_risk_loan_count: u32,
+    /// Total principal outstanding across all active loans (stroops).
+    pub total_outstanding: i128,
+    /// Total stake locked across all active loans (stroops).
+    pub total_locked_stake: i128,
+    /// Contract token balance (stroops).
+    pub contract_balance: i128,
+}
+
+/// Configurable thresholds for health alert classification.
+#[contracttype]
+#[derive(Clone)]
+pub struct HealthAlertThresholds {
+    /// Seconds before deadline at which a loan is considered at-risk (default: 7 days).
+    pub at_risk_deadline_secs: u64,
+    /// Seconds before deadline at which a loan is considered critical (default: 1 day).
+    pub critical_deadline_secs: u64,
+    /// Repayment progress bps below which a loan is at-risk (default: 2500 = 25%).
+    pub at_risk_repayment_bps: u32,
+    /// Top-voucher concentration bps above which concentration risk is flagged (default: 8000 = 80%).
+    pub concentration_risk_bps: u32,
+}
+
+impl HealthAlertThresholds {
+    pub fn default() -> Self {
+        HealthAlertThresholds {
+            at_risk_deadline_secs: 7 * 24 * 60 * 60,
+            critical_deadline_secs: 24 * 60 * 60,
+            at_risk_repayment_bps: 2500,
+            concentration_risk_bps: 8000,
+        }
+    }
+}
+
 // ── Audit Log ─────────────────────────────────────────────────────────────────
 
 #[contracttype]


### PR DESCRIPTION
closes #617
- Add LoanHealthScore, ExposureReport, ProtocolHealthReport, RiskLevel, and HealthAlertThresholds types to types.rs
- Implement get_loan_health(borrower) -> Option<LoanHealthScore> with 4-component score: time-to-deadline, repayment progress, borrower history, and voucher concentration risk
- Emit health/at_risk event when a loan is AtRisk or Critical
- Add get_at_risk_loans() -> Vec<LoanHealthScore> dashboard query
- Add get_voucher_exposure(voucher) -> ExposureReport
- Add get_protocol_health() -> ProtocolHealthReport
- Add set_health_alert_thresholds / get_health_alert_thresholds (admin) with configurable at_risk_deadline_secs, critical_deadline_secs, at_risk_repayment_bps, and concentration_risk_bps
- Add loan_health_test.rs with tests for all new query functions

Closes #loan-health-monitoring

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
