### PR TITLE
Feat/vouch global cooldown

### DIFF
--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -106,6 +106,8 @@ mod admin_delegation_test;
 mod governance_veto_test;
 #[cfg(test)]
 mod loan_health_test;
+#[cfg(test)]
+mod vouch_global_cooldown_test;
 
 pub use errors::ContractError;
 pub use types::*;

--- a/QuorumCredit/src/vouch.rs
+++ b/QuorumCredit/src/vouch.rs
@@ -94,6 +94,7 @@ pub fn vouch(
     }
 
     let sector = soroban_sdk::String::from_str(&env, "");
+    check_and_update_cooldown(&env, &voucher)?;
     do_vouch(&env, voucher, borrower, stake, token, sector)
 }
 
@@ -126,7 +127,28 @@ pub fn vouch_with_sector(
         }
     }
 
+    check_and_update_cooldown(&env, &voucher)?;
     do_vouch(&env, voucher, borrower, stake, token, sector)
+}
+
+/// Check and enforce the per-voucher global cooldown.
+/// Returns `VouchCooldownActive` if the cooldown has not elapsed.
+/// Call this once per transaction (not per borrower in a batch).
+fn check_and_update_cooldown(env: &Env, voucher: &Address) -> Result<(), ContractError> {
+    let now = env.ledger().timestamp();
+    let last: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::LastVouchTimestamp(voucher.clone()))
+        .unwrap_or(0);
+    if last > 0 && now < last + crate::types::DEFAULT_VOUCH_COOLDOWN_SECS {
+        return Err(ContractError::VouchCooldownActive);
+    }
+    env.storage()
+        .persistent()
+        .set(&DataKey::LastVouchTimestamp(voucher.clone()), &now);
+    extend_ttl(env, &DataKey::LastVouchTimestamp(voucher.clone()));
+    Ok(())
 }
 
 fn do_vouch(
@@ -167,16 +189,9 @@ fn do_vouch(
         }
     }
 
-    // Rate limiting: enforce cooldown between vouch calls from the same address.
-    let now = env.ledger().timestamp();
-    let last: u64 = env
-        .storage()
-        .persistent()
-        .get(&DataKey::LastVouchTimestamp(voucher.clone()))
-        .unwrap_or(0);
-    if last > 0 && now < last + crate::types::DEFAULT_VOUCH_COOLDOWN_SECS {
-        return Err(ContractError::VouchCooldownActive);
-    }
+    // NOTE: cooldown is enforced by the caller (vouch / batch_vouch) once per
+    // transaction, not here, so that batch_vouch cannot bypass it by resetting
+    // the timestamp on every iteration within the same ledger.
 
     let mut vouches: Vec<VouchRecord> = env
         .storage()
@@ -233,13 +248,6 @@ fn do_vouch(
     // Task 3: Record vouch in the graph for circular detection
     record_vouch_graph(env, voucher.clone(), borrower.clone());
 
-    // Record the timestamp of this vouch for rate limiting.
-    env.storage().persistent().set(
-        &DataKey::LastVouchTimestamp(voucher.clone()),
-        &env.ledger().timestamp(),
-    );
-    extend_ttl(env, &DataKey::LastVouchTimestamp(voucher.clone()));
-
     env.events().publish(
         (symbol_short!("vouch"), symbol_short!("added")),
         (voucher, borrower, stake, token),
@@ -261,6 +269,10 @@ pub fn batch_vouch(
 
     assert!(borrowers.len() == stakes.len(), "borrowers and stakes length mismatch");
     assert!(!borrowers.is_empty(), "batch cannot be empty");
+
+    // Enforce global cooldown once for the entire batch — prevents bypass by
+    // spreading vouches across multiple borrowers in a single transaction.
+    check_and_update_cooldown(&env, &voucher)?;
 
     for i in 0..borrowers.len() {
         let borrower = borrowers.get(i).unwrap();

--- a/QuorumCredit/src/vouch_global_cooldown_test.rs
+++ b/QuorumCredit/src/vouch_global_cooldown_test.rs
@@ -1,0 +1,128 @@
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env,
+    };
+
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let contract_id = env.register(QuorumCreditContract, ());
+        QuorumCreditContractClient::new(&env, &contract_id).initialize(
+            &deployer,
+            &soroban_sdk::vec![&env, admin.clone()],
+            &1u32,
+            &token,
+        );
+        (env, contract_id, admin, token, deployer)
+    }
+
+    fn fund(env: &Env, token: &Address, admin: &Address, to: &Address, amount: i128) {
+        StellarAssetClient::new(env, token).mint(to, &amount);
+        // also fund contract for loan disbursement
+        StellarAssetClient::new(env, token).mint(admin, &amount);
+    }
+
+    #[test]
+    fn test_single_vouch_sets_cooldown() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        fund(&env, &token, &admin, &voucher, 10_000_000_000);
+
+        // First vouch succeeds
+        client.vouch(&voucher, &borrower, &1_000_000, &token);
+
+        // Immediate second vouch for a different borrower must fail with cooldown
+        let borrower2 = Address::generate(&env);
+        let result = client.try_vouch(&voucher, &borrower2, &1_000_000, &token);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_vouch_cooldown_enforced_once() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        fund(&env, &token, &admin, &voucher, 10_000_000_000);
+
+        let b1 = Address::generate(&env);
+        let b2 = Address::generate(&env);
+        let b3 = Address::generate(&env);
+
+        // batch_vouch with 3 borrowers should succeed (cooldown checked once)
+        client.batch_vouch(
+            &voucher,
+            &soroban_sdk::vec![&env, b1.clone(), b2.clone(), b3.clone()],
+            &soroban_sdk::vec![&env, 1_000_000i128, 1_000_000i128, 1_000_000i128],
+            &token,
+        );
+
+        // Immediately after, another batch_vouch must fail — cooldown is active
+        let b4 = Address::generate(&env);
+        let result = client.try_batch_vouch(
+            &voucher,
+            &soroban_sdk::vec![&env, b4.clone()],
+            &soroban_sdk::vec![&env, 1_000_000i128],
+            &token,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_batch_vouch_allowed_after_cooldown_elapses() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        fund(&env, &token, &admin, &voucher, 10_000_000_000);
+
+        let b1 = Address::generate(&env);
+        client.batch_vouch(
+            &voucher,
+            &soroban_sdk::vec![&env, b1.clone()],
+            &soroban_sdk::vec![&env, 1_000_000i128],
+            &token,
+        );
+
+        // Advance time past the cooldown (24 hours + 1 second)
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: env.ledger().timestamp() + crate::types::DEFAULT_VOUCH_COOLDOWN_SECS + 1,
+            ..env.ledger().get()
+        });
+
+        let b2 = Address::generate(&env);
+        // Should succeed now
+        client.batch_vouch(
+            &voucher,
+            &soroban_sdk::vec![&env, b2.clone()],
+            &soroban_sdk::vec![&env, 1_000_000i128],
+            &token,
+        );
+    }
+
+    #[test]
+    fn test_single_vouch_allowed_after_cooldown_elapses() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        fund(&env, &token, &admin, &voucher, 10_000_000_000);
+
+        let b1 = Address::generate(&env);
+        client.vouch(&voucher, &b1, &1_000_000, &token);
+
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: env.ledger().timestamp() + crate::types::DEFAULT_VOUCH_COOLDOWN_SECS + 1,
+            ..env.ledger().get()
+        });
+
+        let b2 = Address::generate(&env);
+        client.vouch(&voucher, &b2, &1_000_000, &token); // must not panic
+    }
+}


### PR DESCRIPTION
closes #629 
Root cause: do_vouch() was responsible for both checking and updating LastVouchTimestamp. In batch_vouch, this was called per borrower. Within a single ledger, all iterations share the same 
env.ledger().timestamp(), so the cooldown check on iteration 1 would see now == last and fire VouchCooldownActive — breaking legitimate batches. More critically, a voucher could exploit this
by crafting a batch where the first entry passes (last=0) and all subsequent entries also pass if the timestamp hadn't been written yet in the same execution context.

Fix in vouch.rs:
- Removed cooldown check+update from do_vouch() entirely
- Added check_and_update_cooldown(env, voucher) — checks once, writes once
- vouch() and vouch_with_sector() call it before do_vouch()
- batch_vouch() calls it once before the loop — the whole batch counts as one cooldown event, so a voucher cannot bypass the 24-hour wait by spreading vouches across N borrowers in a single 
transaction
