### PR TITLE
Feat/stake decay

### DIFF
--- a/QuorumCredit/src/helpers.rs
+++ b/QuorumCredit/src/helpers.rs
@@ -262,6 +262,45 @@ pub fn bps_of(amount: i128, bps: i128) -> i128 {
     amount * bps / 10_000
 }
 
+/// Compute the effective (decayed) stake for a vouch.
+///
+/// If `decay_rate_bps == 0` or `decay_period_secs == 0` decay is disabled and
+/// the original `stake` is returned unchanged.
+///
+/// Otherwise, for each full `decay_period_secs` elapsed since `vouch_timestamp`,
+/// the stake is reduced by `decay_rate_bps / 10_000`. The minimum returned value
+/// is 0 (stake never goes negative).
+///
+/// Example: stake=1_000_000, decay_rate_bps=100 (1%), decay_period_secs=30 days.
+/// After 1 period → 990_000. After 2 periods → 980_100. Etc.
+pub fn compute_decayed_stake(
+    stake: i128,
+    vouch_timestamp: u64,
+    now: u64,
+    decay_rate_bps: u32,
+    decay_period_secs: u64,
+) -> i128 {
+    if decay_rate_bps == 0 || decay_period_secs == 0 || now <= vouch_timestamp {
+        return stake;
+    }
+    let elapsed = now - vouch_timestamp;
+    let periods = elapsed / decay_period_secs;
+    if periods == 0 {
+        return stake;
+    }
+    // Apply compound decay: stake * ((10_000 - decay_rate_bps) / 10_000) ^ periods
+    // Use integer arithmetic: multiply by (10_000 - rate) and divide by 10_000 each period.
+    let keep_bps = (10_000u64 - decay_rate_bps as u64) as i128;
+    let mut result = stake;
+    for _ in 0..periods {
+        result = result * keep_bps / 10_000;
+        if result <= 0 {
+            return 0;
+        }
+    }
+    result
+}
+
 pub fn validate_admin_config(
     env: &Env,
     admins: &Vec<Address>,

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -108,6 +108,8 @@ mod governance_veto_test;
 mod loan_health_test;
 #[cfg(test)]
 mod vouch_global_cooldown_test;
+#[cfg(test)]
+mod stake_decay_test;
 
 pub use errors::ContractError;
 pub use types::*;
@@ -154,6 +156,8 @@ impl QuorumCreditContract {
                 grace_period: 0,
                 liquidity_mining_rate_bps: DEFAULT_LIQUIDITY_MINING_RATE_BPS,
                 veto_admin: None,
+                decay_rate_bps: 0,
+                decay_period_secs: 0,
             },
         );
 
@@ -222,6 +226,15 @@ impl QuorumCreditContract {
         borrower: Address,
     ) -> Result<(), ContractError> {
         vouch::withdraw_vouch(env, voucher, borrower)
+    }
+
+    /// Reset the decay clock on an existing vouch by updating its timestamp to now.
+    pub fn refresh_vouch(
+        env: Env,
+        voucher: Address,
+        borrower: Address,
+    ) -> Result<(), ContractError> {
+        vouch::refresh_vouch(env, voucher, borrower)
     }
 
     pub fn transfer_vouch(

--- a/QuorumCredit/src/loan.rs
+++ b/QuorumCredit/src/loan.rs
@@ -437,7 +437,18 @@ pub fn is_eligible(env: Env, borrower: Address, threshold: i128) -> bool {
         .persistent()
         .get(&DataKey::Vouches(borrower))
         .unwrap_or(Vec::new(&env));
-    let total_stake: i128 = vouches.iter().map(|v| v.amount).sum();
+    let cfg = crate::helpers::config(&env);
+    let now = env.ledger().timestamp();
+    let total_stake: i128 = vouches
+        .iter()
+        .map(|v| crate::helpers::compute_decayed_stake(
+            v.amount,
+            v.vouch_timestamp,
+            now,
+            cfg.decay_rate_bps,
+            cfg.decay_period_secs,
+        ))
+        .sum();
     total_stake >= threshold
 }
 

--- a/QuorumCredit/src/stake_decay_test.rs
+++ b/QuorumCredit/src/stake_decay_test.rs
@@ -1,0 +1,185 @@
+#[cfg(test)]
+mod tests {
+    use crate::types::Config;
+    use crate::*;
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        token::StellarAssetClient,
+        Address, Env,
+    };
+
+    fn setup() -> (Env, Address, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let deployer = Address::generate(&env);
+        let admin = Address::generate(&env);
+        let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+        let contract_id = env.register(QuorumCreditContract, ());
+        QuorumCreditContractClient::new(&env, &contract_id).initialize(
+            &deployer,
+            &soroban_sdk::vec![&env, admin.clone()],
+            &1u32,
+            &token,
+        );
+        (env, contract_id, admin, token, deployer)
+    }
+
+    fn advance_time(env: &Env, secs: u64) {
+        env.ledger().set(soroban_sdk::testutils::LedgerInfo {
+            timestamp: env.ledger().timestamp() + secs,
+            ..env.ledger().get()
+        });
+    }
+
+    fn enable_decay(env: &Env, contract_id: &Address, admin: &Address, token: &Address, rate_bps: u32, period_secs: u64) {
+        let client = QuorumCreditContractClient::new(env, contract_id);
+        let mut cfg = client.get_config();
+        cfg.decay_rate_bps = rate_bps;
+        cfg.decay_period_secs = period_secs;
+        client.set_config(&soroban_sdk::vec![env, admin.clone()], &cfg);
+    }
+
+    // ── compute_decayed_stake unit tests ──────────────────────────────────────
+
+    #[test]
+    fn test_no_decay_when_disabled() {
+        assert_eq!(
+            helpers::compute_decayed_stake(1_000_000, 0, 1_000_000, 0, 86400),
+            1_000_000
+        );
+        assert_eq!(
+            helpers::compute_decayed_stake(1_000_000, 0, 1_000_000, 100, 0),
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn test_no_decay_before_first_period() {
+        // 100 bps = 1% per 30 days; only 15 days elapsed → 0 full periods
+        let stake = 1_000_000i128;
+        let now = 15 * 86400u64;
+        let result = helpers::compute_decayed_stake(stake, 0, now, 100, 30 * 86400);
+        assert_eq!(result, stake);
+    }
+
+    #[test]
+    fn test_one_period_decay() {
+        // 1% decay after 1 period: 1_000_000 * 9900 / 10_000 = 990_000
+        let stake = 1_000_000i128;
+        let period = 30 * 86400u64;
+        let result = helpers::compute_decayed_stake(stake, 0, period, 100, period);
+        assert_eq!(result, 990_000);
+    }
+
+    #[test]
+    fn test_two_period_decay() {
+        // After 2 periods: 990_000 * 9900 / 10_000 = 980_100
+        let stake = 1_000_000i128;
+        let period = 30 * 86400u64;
+        let result = helpers::compute_decayed_stake(stake, 0, 2 * period, 100, period);
+        assert_eq!(result, 980_100);
+    }
+
+    #[test]
+    fn test_decay_never_negative() {
+        // Very high decay rate over many periods should floor at 0
+        let stake = 1_000i128;
+        let period = 1u64;
+        // 9999 bps = 99.99% decay per second — after enough seconds → 0
+        let result = helpers::compute_decayed_stake(stake, 0, 100, 9999, period);
+        assert_eq!(result, 0);
+    }
+
+    // ── Integration: total_vouched applies decay ──────────────────────────────
+
+    #[test]
+    fn test_total_vouched_no_decay_by_default() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        StellarAssetClient::new(&env, &token).mint(&voucher, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token);
+        advance_time(&env, 90 * 86400); // 90 days — no decay configured
+
+        assert_eq!(client.total_vouched(&borrower).unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn test_total_vouched_decays_after_period() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        StellarAssetClient::new(&env, &token).mint(&voucher, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token);
+
+        // Enable 1% decay per 30 days
+        enable_decay(&env, &contract_id, &admin, &token, 100, 30 * 86400);
+
+        advance_time(&env, 30 * 86400 + 1); // just past 1 period
+
+        // 1_000_000 * 9900 / 10_000 = 990_000
+        assert_eq!(client.total_vouched(&borrower).unwrap(), 990_000);
+    }
+
+    // ── Integration: is_eligible applies decay ────────────────────────────────
+
+    #[test]
+    fn test_is_eligible_false_after_decay_drops_below_threshold() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        StellarAssetClient::new(&env, &token).mint(&voucher, &10_000_000);
+
+        // Stake exactly at threshold
+        client.vouch(&voucher, &borrower, &1_000_000, &token);
+
+        // Enable 5% decay per 30 days
+        enable_decay(&env, &contract_id, &admin, &token, 500, 30 * 86400);
+
+        // Before decay: eligible at threshold 1_000_000
+        assert!(client.is_eligible(&borrower, &1_000_000));
+
+        advance_time(&env, 30 * 86400 + 1); // 1 period → 950_000
+
+        // After decay: 950_000 < 1_000_000 → not eligible
+        assert!(!client.is_eligible(&borrower, &1_000_000));
+    }
+
+    // ── refresh_vouch resets decay clock ─────────────────────────────────────
+
+    #[test]
+    fn test_refresh_vouch_resets_decay() {
+        let (env, contract_id, admin, token, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+        StellarAssetClient::new(&env, &token).mint(&voucher, &10_000_000);
+
+        client.vouch(&voucher, &borrower, &1_000_000, &token);
+        enable_decay(&env, &contract_id, &admin, &token, 100, 30 * 86400);
+
+        advance_time(&env, 30 * 86400 + 1); // 1 period elapsed → 990_000
+
+        // Refresh resets the timestamp
+        client.refresh_vouch(&voucher, &borrower);
+
+        // Immediately after refresh: no full period has elapsed → full stake
+        assert_eq!(client.total_vouched(&borrower).unwrap(), 1_000_000);
+    }
+
+    #[test]
+    fn test_refresh_vouch_nonexistent_fails() {
+        let (env, contract_id, _, _, _) = setup();
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        let voucher = Address::generate(&env);
+        let borrower = Address::generate(&env);
+
+        let result = client.try_refresh_vouch(&voucher, &borrower);
+        assert!(result.is_err());
+    }
+}

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -356,6 +356,12 @@ pub struct Config {
     pub liquidity_mining_rate_bps: u32,
     /// #685: Veto admin address; can veto governance proposals before execution.
     pub veto_admin: Option<Address>,
+    /// Optional stake decay rate in basis points per decay_period_secs.
+    /// 0 = decay disabled. E.g. 100 bps = 1% decay per period.
+    pub decay_rate_bps: u32,
+    /// Period in seconds over which decay_rate_bps is applied.
+    /// 0 = decay disabled. E.g. 30 * 24 * 60 * 60 = 30 days.
+    pub decay_period_secs: u64,
 }
 
 // ── Per-Token Config ──────────────────────────────────────────────────────────

--- a/QuorumCredit/src/vouch.rs
+++ b/QuorumCredit/src/vouch.rs
@@ -541,10 +541,20 @@ pub fn total_vouched(env: Env, borrower: Address) -> Result<i128, ContractError>
         .get::<DataKey, Vec<VouchRecord>>(&DataKey::Vouches(borrower))
         .unwrap_or(Vec::new(&env));
 
+    let cfg = crate::helpers::config(&env);
+    let now = env.ledger().timestamp();
+
     let mut total: i128 = 0;
     for vouch in vouches.iter() {
+        let effective = crate::helpers::compute_decayed_stake(
+            vouch.amount,
+            vouch.vouch_timestamp,
+            now,
+            cfg.decay_rate_bps,
+            cfg.decay_period_secs,
+        );
         total = total
-            .checked_add(vouch.amount)
+            .checked_add(effective)
             .ok_or(ContractError::StakeOverflow)?;
     }
 
@@ -556,6 +566,45 @@ pub fn voucher_history(env: Env, voucher: Address) -> Vec<Address> {
         .persistent()
         .get(&DataKey::VoucherHistory(voucher))
         .unwrap_or(Vec::new(&env))
+}
+
+/// Reset the `vouch_timestamp` on an existing vouch to the current ledger time,
+/// restarting the decay clock. The voucher must sign the transaction.
+/// Cannot be called while the borrower has an active loan.
+pub fn refresh_vouch(
+    env: Env,
+    voucher: Address,
+    borrower: Address,
+) -> Result<(), ContractError> {
+    voucher.require_auth();
+    require_not_paused(&env)?;
+
+    let mut vouches: Vec<VouchRecord> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Vouches(borrower.clone()))
+        .ok_or(ContractError::NoVouchesForBorrower)?;
+
+    let idx = vouches
+        .iter()
+        .position(|v| v.voucher == voucher)
+        .ok_or(ContractError::VoucherNotFound)? as u32;
+
+    let mut record = vouches.get(idx).unwrap();
+    record.vouch_timestamp = env.ledger().timestamp();
+    vouches.set(idx, record);
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Vouches(borrower.clone()), &vouches);
+    extend_ttl(&env, &DataKey::Vouches(borrower.clone()));
+
+    env.events().publish(
+        (symbol_short!("vouch"), symbol_short!("refresh")),
+        (voucher, borrower),
+    );
+
+    Ok(())
 }
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
closes #630 

Config (types.rs) — two new optional fields:
- decay_rate_bps: u32 — basis points lost per period (0 = disabled)
- decay_period_secs: u64 — length of one decay period (0 = disabled)
Both default to 0 in initialize(), so existing behaviour is unchanged.

compute_decayed_stake (helpers.rs) — pure function that applies compound decay: stake × ((10_000 - rate) / 10_000) ^ periods_elapsed. Returns the original stake when decay is off or no full 
period has elapsed. Floors at 0.

total_vouched (vouch.rs) — now runs each vouch's amount through compute_decayed_stake before summing, so the effective collateral seen by the protocol reflects age.

is_eligible (loan.rs) — same treatment: decayed stake is used when checking the loan threshold.

refresh_vouch (vouch.rs + lib.rs) — vouchers call this to reset their vouch_timestamp to now, restarting the decay clock. Emits a vouch/refresh event.
