### PR TITLE
feat: add secure_delete, key_manager, secure_random, and commitment_validator modules (#702–#705)

### DIFF
--- a/QuorumCredit/src/commitment_validator.rs
+++ b/QuorumCredit/src/commitment_validator.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn create_commitment(env: &Env, value: Bytes, nonce: BytesN<32>) -> BytesN<32> {
+    let mut data = value;
+    let nonce_bytes: Bytes = nonce.into();
+    data.append(&nonce_bytes);
+    env.crypto().sha256(&data)
+}
+
+pub fn verify_commitment(env: &Env, commitment: BytesN<32>, value: Bytes, nonce: BytesN<32>) -> bool {
+    let computed = create_commitment(env, value, nonce);
+    commitment == computed
+}

--- a/QuorumCredit/src/key_manager.rs
+++ b/QuorumCredit/src/key_manager.rs
@@ -1,0 +1,32 @@
+use crate::types::DataKey;
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn derive_key(env: &Env, seed: Bytes, context: Bytes) -> BytesN<32> {
+    let mut data = seed;
+    data.append(&context);
+    env.crypto().sha256(&data)
+}
+
+pub fn store_key(env: &Env, key_id: BytesN<32>, key: BytesN<32>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ManagedKey(key_id), &key);
+}
+
+pub fn get_key(env: &Env, key_id: BytesN<32>) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ManagedKey(key_id))
+}
+
+pub fn rotate_key(env: &Env, key_id: BytesN<32>, new_seed: Bytes, context: Bytes) -> BytesN<32> {
+    let new_key = derive_key(env, new_seed, context);
+    store_key(env, key_id, new_key.clone());
+    new_key
+}
+
+pub fn delete_key(env: &Env, key_id: BytesN<32>) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ManagedKey(key_id));
+}

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -16,6 +16,7 @@ pub mod liquidity_mining;
 pub mod loan;
 pub mod reputation;
 pub mod secure_delete;
+pub mod secure_random;
 pub mod staking_derivatives;
 pub mod types;
 pub mod upgrade;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -14,6 +14,7 @@ pub mod helpers;
 pub mod liquidity_mining;
 pub mod loan;
 pub mod reputation;
+pub mod secure_delete;
 pub mod staking_derivatives;
 pub mod types;
 pub mod upgrade;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -11,6 +11,7 @@ pub mod fraud_detection;
 pub mod governance;
 pub mod health;
 pub mod helpers;
+pub mod key_manager;
 pub mod liquidity_mining;
 pub mod loan;
 pub mod reputation;

--- a/QuorumCredit/src/lib.rs
+++ b/QuorumCredit/src/lib.rs
@@ -6,6 +6,7 @@ use soroban_sdk::{
 
 pub mod admin;
 pub mod benchmarks;
+pub mod commitment_validator;
 pub mod errors;
 pub mod fraud_detection;
 pub mod governance;

--- a/QuorumCredit/src/secure_delete.rs
+++ b/QuorumCredit/src/secure_delete.rs
@@ -1,0 +1,14 @@
+use crate::types::DataKey;
+use soroban_sdk::Env;
+
+pub fn secure_delete_persistent(env: &Env, key: &DataKey) {
+    env.storage().persistent().remove(key);
+}
+
+pub fn secure_delete_instance(env: &Env, key: &DataKey) {
+    env.storage().instance().remove(key);
+}
+
+pub fn secure_delete_temporary(env: &Env, key: &DataKey) {
+    env.storage().temporary().remove(key);
+}

--- a/QuorumCredit/src/secure_random.rs
+++ b/QuorumCredit/src/secure_random.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn generate_nonce(env: &Env) -> BytesN<32> {
+    env.prng().gen::<BytesN<32>>()
+}
+
+pub fn generate_id(env: &Env) -> u64 {
+    env.prng().gen::<u64>()
+}
+
+pub fn generate_bytes(env: &Env, len: u32) -> Bytes {
+    env.prng().gen_len(len)
+}

--- a/QuorumCredit/src/types.rs
+++ b/QuorumCredit/src/types.rs
@@ -187,6 +187,8 @@ pub enum DataKey {
     PartialDefaultCount(Address),
     // #664: Slash record with forgiveness info per loan
     SlashRecord(u64),
+    // #704: Managed derived key storage
+    ManagedKey(soroban_sdk::BytesN<32>),
 }
 
 // ── Audit Log ─────────────────────────────────────────────────────────────────

--- a/src/commitment_validator.rs
+++ b/src/commitment_validator.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn create_commitment(env: &Env, value: Bytes, nonce: BytesN<32>) -> BytesN<32> {
+    let mut data = value;
+    let nonce_bytes: Bytes = nonce.into();
+    data.append(&nonce_bytes);
+    env.crypto().sha256(&data)
+}
+
+pub fn verify_commitment(env: &Env, commitment: BytesN<32>, value: Bytes, nonce: BytesN<32>) -> bool {
+    let computed = create_commitment(env, value, nonce);
+    commitment == computed
+}

--- a/src/key_manager.rs
+++ b/src/key_manager.rs
@@ -1,0 +1,32 @@
+use crate::types::DataKey;
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn derive_key(env: &Env, seed: Bytes, context: Bytes) -> BytesN<32> {
+    let mut data = seed;
+    data.append(&context);
+    env.crypto().sha256(&data)
+}
+
+pub fn store_key(env: &Env, key_id: BytesN<32>, key: BytesN<32>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ManagedKey(key_id), &key);
+}
+
+pub fn get_key(env: &Env, key_id: BytesN<32>) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ManagedKey(key_id))
+}
+
+pub fn rotate_key(env: &Env, key_id: BytesN<32>, new_seed: Bytes, context: Bytes) -> BytesN<32> {
+    let new_key = derive_key(env, new_seed, context);
+    store_key(env, key_id, new_key.clone());
+    new_key
+}
+
+pub fn delete_key(env: &Env, key_id: BytesN<32>) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::ManagedKey(key_id));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod governance;
 mod helpers;
 mod key_manager;
 mod secure_delete;
+mod secure_random;
 mod types;
 mod vouch;
 mod vouch_snapshot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod admin;
 mod errors;
 mod governance;
 mod helpers;
+mod secure_delete;
 mod types;
 mod vouch;
 mod vouch_snapshot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod admin;
 mod errors;
 mod governance;
 mod helpers;
+mod key_manager;
 mod secure_delete;
 mod types;
 mod vouch;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 mod admin;
+mod commitment_validator;
 mod errors;
 mod governance;
 mod helpers;

--- a/src/secure_delete.rs
+++ b/src/secure_delete.rs
@@ -1,0 +1,14 @@
+use crate::types::DataKey;
+use soroban_sdk::Env;
+
+pub fn secure_delete_persistent(env: &Env, key: &DataKey) {
+    env.storage().persistent().remove(key);
+}
+
+pub fn secure_delete_instance(env: &Env, key: &DataKey) {
+    env.storage().instance().remove(key);
+}
+
+pub fn secure_delete_temporary(env: &Env, key: &DataKey) {
+    env.storage().temporary().remove(key);
+}

--- a/src/secure_random.rs
+++ b/src/secure_random.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::{Bytes, BytesN, Env};
+
+pub fn generate_nonce(env: &Env) -> BytesN<32> {
+    env.prng().gen::<BytesN<32>>()
+}
+
+pub fn generate_id(env: &Env) -> u64 {
+    env.prng().gen::<u64>()
+}
+
+pub fn generate_bytes(env: &Env, len: u32) -> Bytes {
+    env.prng().gen_len(len)
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -253,6 +253,8 @@ pub enum DataKey {
     ExternalCreditScore(Address),
     // #666: Escrowed repayment amount per borrower (held pending oracle verification)
     EscrowAmount(Address),
+    // #704: Managed derived key storage
+    ManagedKey(soroban_sdk::BytesN<32>),
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR implements four security utility modules across both contract crates (`src/` and `QuorumCredit/src/`), covering secure data deletion, key management, secure randomness generation, and cryptographic commitment validation. Each module is self-contained and follows the existing Soroban SDK patterns used throughout the codebase.

---

### #705 — Implement Secure Deletion (`secure_delete`)

**Files:** `src/secure_delete.rs`, `QuorumCredit/src/secure_delete.rs`

Added `secure_delete` module exposing three helpers that remove sensitive `DataKey` entries from the appropriate Soroban storage tier, ensuring sensitive data is properly purged rather than left to expire:

- `secure_delete_persistent(env, key)` — removes a key from persistent storage
- `secure_delete_instance(env, key)` — removes a key from instance storage
- `secure_delete_temporary(env, key)` — removes a key from temporary storage

---

### #704 — Add Secure Key Management (`key_manager`)

**Files:** `src/key_manager.rs`, `QuorumCredit/src/key_manager.rs`, `src/types.rs`, `QuorumCredit/src/types.rs`

Added `key_manager` module providing secure key derivation via `env.crypto().sha256()` and persistent storage/retrieval. Added `ManagedKey(BytesN<32>)` variant to the `DataKey` enum in both crates to back key storage.

- `derive_key(env, seed, context)` — derives a `BytesN<32>` key via SHA-256 of `seed || context`
- `store_key(env, key_id, key)` — persists a derived key indexed by its `BytesN<32>` ID
- `get_key(env, key_id)` — retrieves a stored key by ID
- `rotate_key(env, key_id, new_seed, context)` — atomically derives and stores a replacement key
- `delete_key(env, key_id)` — removes a key from persistent storage

---

### #703 — Implement Secure Random Generation (`secure_random`)

**Files:** `src/secure_random.rs`, `QuorumCredit/src/secure_random.rs`

Added `secure_random` module using the Soroban runtime PRNG (`env.prng()`), which is seeded by the ledger's randomness beacon, ensuring all generated values are unpredictable and safe for use as IDs and nonces:

- `generate_nonce(env)` — returns a cryptographically random `BytesN<32>` nonce
- `generate_id(env)` — returns a random `u64` identifier
- `generate_bytes(env, len)` — returns random `Bytes` of a caller-specified length

---

### #702 — Add Cryptographic Commitment Validation (`commitment_validator`)

**Files:** `src/commitment_validator.rs`, `QuorumCredit/src/commitment_validator.rs`

Added `commitment_validator` module implementing a standard hash-based commit-reveal scheme. Commitments are computed as `SHA-256(value || nonce)` using `env.crypto().sha256()`:

- `create_commitment(env, value, nonce)` — returns `SHA-256(value || nonce)` as `BytesN<32>`
- `verify_commitment(env, commitment, value, nonce)` — returns `true` if the commitment matches the revealed value and nonce

---

## Closes

Closes #705
Closes #704
Closes #703
Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)