### PR TITLE
Implement admin whitelist and blacklist (#688, #689)

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,15 +1,32 @@
+use crate::errors::ContractError;
 use crate::helpers::{
     config, is_admin, require_admin_approval, require_not_paused, require_valid_token,
     validate_admin_config,
 };
-use crate::types::{Config, ConfigUpdateKey, ConfigUpdateProposal, DataKey, AdminActionProposal};
+use crate::types::{AdminActionProposal, Config, ConfigUpdateKey, ConfigUpdateProposal, DataKey};
 use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env, Vec};
-use crate::errors::ContractError;
+
+fn validate_admin_member(env: &Env, admin: &Address, config: &Config) {
+    if !config.admin_whitelist.is_empty()
+        && !config.admin_whitelist.iter().any(|allowed| allowed == *admin)
+    {
+        panic_with_error!(&env, ContractError::AdminNotWhitelisted);
+    }
+    if config
+        .admin_blacklist
+        .iter()
+        .any(|blocked| blocked == *admin)
+    {
+        panic_with_error!(&env, ContractError::AdminBlacklisted);
+    }
+}
 
 pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
     require_admin_approval(&env, &admin_signers);
 
     let mut cfg = config(&env);
+
+    validate_admin_member(&env, &new_admin, &cfg);
 
     if cfg.admins.iter().any(|a| a == new_admin) {
         panic_with_error!(&env, ContractError::AlreadyInitialized);
@@ -66,6 +83,8 @@ pub fn rotate_admin(env: Env, admin_signers: Vec<Address>, old_admin: Address, n
 
     let mut cfg = config(&env);
 
+    validate_admin_member(&env, &new_admin, &cfg);
+
     if cfg.admins.iter().any(|a| a == new_admin) {
         panic_with_error!(&env, ContractError::AlreadyInitialized);
     }
@@ -103,6 +122,92 @@ pub fn set_admin_threshold(env: Env, admin_signers: Vec<Address>, new_threshold:
     env.events().publish(
         (symbol_short!("admin"), symbol_short!("thresh")),
         new_threshold,
+    );
+}
+
+/// Issue #688: Add an address to the admin whitelist.
+pub fn add_to_admin_whitelist(env: Env, admin_signers: Vec<Address>, address: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    if cfg.admin_whitelist.iter().any(|a| a == address) {
+        panic_with_error!(&env, ContractError::AlreadyInitialized);
+    }
+    if cfg.admin_blacklist.iter().any(|a| a == address) {
+        panic_with_error!(&env, ContractError::AdminBlacklisted);
+    }
+
+    cfg.admin_whitelist.push_back(address.clone());
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("wl_add")),
+        address,
+    );
+}
+
+/// Issue #688: Remove an address from the admin whitelist.
+pub fn remove_from_admin_whitelist(env: Env, admin_signers: Vec<Address>, address: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    let idx = cfg
+        .admin_whitelist
+        .iter()
+        .position(|a| a == address)
+        .expect("address not in whitelist") as u32;
+
+    cfg.admin_whitelist.remove(idx);
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("wl_rm")),
+        address,
+    );
+}
+
+/// Issue #689: Add an address to the admin blacklist.
+pub fn add_to_admin_blacklist(env: Env, admin_signers: Vec<Address>, address: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    if cfg.admin_blacklist.iter().any(|a| a == address) {
+        panic_with_error!(&env, ContractError::AlreadyInitialized);
+    }
+    if cfg.admin_whitelist.iter().any(|a| a == address) {
+        panic_with_error!(&env, ContractError::AdminNotWhitelisted);
+    }
+
+    cfg.admin_blacklist.push_back(address.clone());
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("bl_add")),
+        address,
+    );
+}
+
+/// Issue #689: Remove an address from the admin blacklist.
+pub fn remove_from_admin_blacklist(env: Env, admin_signers: Vec<Address>, address: Address) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+
+    let idx = cfg
+        .admin_blacklist
+        .iter()
+        .position(|a| a == address)
+        .expect("address not in blacklist") as u32;
+
+    cfg.admin_blacklist.remove(idx);
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("bl_rm")),
+        address,
     );
 }
 
@@ -221,8 +326,14 @@ pub fn blacklist(env: Env, admin_signers: Vec<Address>, borrower: Address) {
 pub fn set_config(env: Env, admin_signers: Vec<Address>, config: Config) {
     require_not_paused(&env).expect("contract paused");
     require_admin_approval(&env, &admin_signers);
-    validate_admin_config(&env, &config.admins, config.admin_threshold)
-        .expect("invalid admin config");
+    validate_admin_config(
+        &env,
+        &config.admins,
+        config.admin_threshold,
+        &config.admin_whitelist,
+        &config.admin_blacklist,
+    )
+    .expect("invalid admin config");
     if config.yield_bps < 0 || config.yield_bps > 10_000 {
         panic_with_error!(&env, ContractError::InvalidBps);
     }

--- a/src/admin_whitelist_blacklist_test.rs
+++ b/src/admin_whitelist_blacklist_test.rs
@@ -1,0 +1,148 @@
+#[cfg(test)]
+mod admin_whitelist_blacklist_tests {
+    use crate::{QuorumCreditContract, QuorumCreditContractClient};
+    use soroban_sdk::{testutils::Address as _, Address, Env, Vec};
+
+    fn setup() -> (
+        Env,
+        QuorumCreditContractClient<'static>,
+        Address,
+        Address,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let deployer = Address::generate(&env);
+        let admin1 = Address::generate(&env);
+        let admin2 = Address::generate(&env);
+        let admins = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let token = env
+            .register_stellar_asset_contract_v2(admin1.clone())
+            .address();
+
+        let contract_id = env.register(QuorumCreditContract, ());
+        let client = QuorumCreditContractClient::new(&env, &contract_id);
+        client.initialize(&deployer, &admins, &2, &token);
+
+        (env, client, admin1, admin2)
+    }
+
+    // ── Issue #688: admin whitelist ───────────────────────────────────────────
+
+    #[test]
+    fn test_add_and_remove_admin_whitelist() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let candidate = Address::generate(&env);
+
+        client.add_to_admin_whitelist(&signers, &candidate);
+        let cfg = client.get_config();
+        assert!(cfg.admin_whitelist.iter().any(|a| a == candidate));
+
+        client.remove_from_admin_whitelist(&signers, &candidate);
+        let cfg = client.get_config();
+        assert!(!cfg.admin_whitelist.iter().any(|a| a == candidate));
+    }
+
+    #[test]
+    fn test_whitelist_prevents_non_whitelisted_admin() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let allowed = Address::generate(&env);
+        let blocked = Address::generate(&env);
+
+        client.add_to_admin_whitelist(&signers, &allowed);
+
+        let result = client.try_add_admin(&signers, &blocked);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_whitelisted_admin_can_be_added() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let candidate = Address::generate(&env);
+
+        client.add_to_admin_whitelist(&signers, &candidate);
+        client.add_admin(&signers, &candidate);
+
+        let cfg = client.get_config();
+        assert!(cfg.admins.iter().any(|a| a == candidate));
+    }
+
+    #[test]
+    fn test_duplicate_whitelist_entry_rejected() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let candidate = Address::generate(&env);
+
+        client.add_to_admin_whitelist(&signers, &candidate);
+        let result = client.try_add_to_admin_whitelist(&signers, &candidate);
+        assert!(result.is_err());
+    }
+
+    // ── Issue #689: admin blacklist ───────────────────────────────────────────
+
+    #[test]
+    fn test_add_and_remove_admin_blacklist() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let bad_actor = Address::generate(&env);
+
+        client.add_to_admin_blacklist(&signers, &bad_actor);
+        let cfg = client.get_config();
+        assert!(cfg.admin_blacklist.iter().any(|a| a == bad_actor));
+
+        client.remove_from_admin_blacklist(&signers, &bad_actor);
+        let cfg = client.get_config();
+        assert!(!cfg.admin_blacklist.iter().any(|a| a == bad_actor));
+    }
+
+    #[test]
+    fn test_blacklisted_address_cannot_be_added_as_admin() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let bad_actor = Address::generate(&env);
+
+        client.add_to_admin_blacklist(&signers, &bad_actor);
+
+        let result = client.try_add_admin(&signers, &bad_actor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cannot_blacklist_whitelisted_address() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let candidate = Address::generate(&env);
+
+        client.add_to_admin_whitelist(&signers, &candidate);
+        let result = client.try_add_to_admin_blacklist(&signers, &candidate);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_duplicate_blacklist_entry_rejected() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let bad_actor = Address::generate(&env);
+
+        client.add_to_admin_blacklist(&signers, &bad_actor);
+        let result = client.try_add_to_admin_blacklist(&signers, &bad_actor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_removed_from_blacklist_can_be_added_as_admin() {
+        let (env, client, admin1, admin2) = setup();
+        let signers = Vec::from_array(&env, [admin1.clone(), admin2.clone()]);
+        let candidate = Address::generate(&env);
+
+        client.add_to_admin_blacklist(&signers, &candidate);
+        client.remove_from_admin_blacklist(&signers, &candidate);
+        client.add_admin(&signers, &candidate);
+
+        let cfg = client.get_config();
+        assert!(cfg.admins.iter().any(|a| a == candidate));
+    }
+}

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -4,7 +4,7 @@ use crate::helpers::{
     require_admin_approval, require_governance_participant, require_not_paused,
 };
 use crate::types::{
-    DataKey, LoanStatus, PendingSlashRecord, SlashAppealRecord, SlashThresholdProposal,
+    DataKey, LoanStatus, PendingSlashRecord, SlashAppealRecord, SlashRecord, SlashThresholdProposal,
     SlashVoteRecord, TimelockAction, TimelockProposal, VouchRecord, BPS_DENOMINATOR,
 };
 use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -62,12 +62,6 @@ pub fn validate_timestamp(_env: &Env, timestamp: u64, now: u64) -> Result<(), Co
     Ok(())
 }
 
-/// Returns `Err(InsufficientFunds)` if `amount` is not strictly positive (≤ 0).
-/// Kept for backward compatibility; prefer `validate_amount` in new code.
-pub fn require_positive_amount(env: &Env, amount: i128) -> Result<(), ContractError> {
-    validate_amount(env, amount).map_err(|_| ContractError::InsufficientFunds)
-}
-
 // ── Config & Loan Helpers ─────────────────────────────────────────────────────
 
 pub fn config(env: &Env) -> Config {
@@ -171,12 +165,37 @@ pub fn validate_admin_config(
     env: &Env,
     admins: &Vec<Address>,
     admin_threshold: u32,
+    admin_whitelist: &Vec<Address>,
+    admin_blacklist: &Vec<Address>,
 ) -> Result<(), ContractError> {
     if admins.is_empty() {
         return Err(ContractError::InvalidAdminThreshold);
     }
     if admin_threshold == 0 || admin_threshold > admins.len() {
         return Err(ContractError::InvalidAdminThreshold);
+    }
+    for i in 0..admin_whitelist.len() {
+        let allowed = admin_whitelist.get(i).unwrap();
+        require_valid_address(env, &allowed)?;
+        for j in 0..i {
+            let prior = admin_whitelist.get(j).unwrap();
+            if allowed == prior {
+                return Err(ContractError::InvalidAdminThreshold);
+            }
+        }
+    }
+    for i in 0..admin_blacklist.len() {
+        let blocked = admin_blacklist.get(i).unwrap();
+        require_valid_address(env, &blocked)?;
+        for j in 0..i {
+            let prior = admin_blacklist.get(j).unwrap();
+            if blocked == prior {
+                return Err(ContractError::InvalidAdminThreshold);
+            }
+        }
+        if admin_whitelist.iter().any(|a| a == blocked) {
+            return Err(ContractError::InvalidAdminThreshold);
+        }
     }
     let admin_count = admins.len();
     for i in 0..admin_count {
@@ -187,6 +206,14 @@ pub fn validate_admin_config(
             if admin == prior_admin {
                 return Err(ContractError::InvalidAdminThreshold);
             }
+        }
+        if !admin_whitelist.is_empty()
+            && !admin_whitelist.iter().any(|allowed| allowed == admin)
+        {
+            return Err(ContractError::AdminNotWhitelisted);
+        }
+        if admin_blacklist.iter().any(|blocked| blocked == admin) {
+            return Err(ContractError::AdminBlacklisted);
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ mod withdrawal_queue_test;
 mod cross_chain_vouch_test;
 #[cfg(test)]
 mod property_stake_loan_invariants_test;
+#[cfg(test)]
+mod admin_whitelist_blacklist_test;
 
 use crate::helpers::{
     config, get_active_loan_record, has_active_loan, loan_status as helper_loan_status,
@@ -55,7 +57,13 @@ impl QuorumCreditContract {
             return Err(ContractError::AlreadyInitialized);
         }
 
-        helpers::validate_admin_config(&env, &admins, admin_threshold)?;
+        helpers::validate_admin_config(
+            &env,
+            &admins,
+            admin_threshold,
+            &Vec::new(&env),
+            &Vec::new(&env),
+        )?;
         helpers::require_valid_token(&env, &token)?;
 
         env.storage().instance().set(&DataKey::Deployer, &deployer);
@@ -64,6 +72,8 @@ impl QuorumCreditContract {
             &Config {
                 admins,
                 admin_threshold,
+                admin_whitelist: Vec::new(&env),
+                admin_blacklist: Vec::new(&env),
                 token,
                 allowed_tokens: Vec::new(&env),
                 yield_bps: DEFAULT_YIELD_BPS,
@@ -726,6 +736,20 @@ impl QuorumCreditContract {
         governance::get_slash_threshold_proposal(env, proposal_id)
     }
 
+    // ── Admin management ─────────────────────────────────────────────────────
+
+    pub fn add_admin(env: Env, admin_signers: Vec<Address>, new_admin: Address) {
+        admin::add_admin(env, admin_signers, new_admin)
+    }
+
+    pub fn remove_admin(env: Env, admin_signers: Vec<Address>, admin_to_remove: Address) {
+        admin::remove_admin(env, admin_signers, admin_to_remove)
+    }
+
+    pub fn set_admin_threshold(env: Env, admin_signers: Vec<Address>, new_threshold: u32) {
+        admin::set_admin_threshold(env, admin_signers, new_threshold)
+    }
+
     // ── Admin ─────────────────────────────────────────────────────────────────
 
     pub fn pause(env: Env, admin_signers: Vec<Address>) {
@@ -745,6 +769,26 @@ impl QuorumCreditContract {
 
     pub fn set_config(env: Env, admin_signers: Vec<Address>, cfg: Config) {
         admin::set_config(env, admin_signers, cfg)
+    }
+
+    // ── Issue #688: Admin whitelist management ────────────────────────────────
+
+    pub fn add_to_admin_whitelist(env: Env, admin_signers: Vec<Address>, address: Address) {
+        admin::add_to_admin_whitelist(env, admin_signers, address)
+    }
+
+    pub fn remove_from_admin_whitelist(env: Env, admin_signers: Vec<Address>, address: Address) {
+        admin::remove_from_admin_whitelist(env, admin_signers, address)
+    }
+
+    // ── Issue #689: Admin blacklist management ────────────────────────────────
+
+    pub fn add_to_admin_blacklist(env: Env, admin_signers: Vec<Address>, address: Address) {
+        admin::add_to_admin_blacklist(env, admin_signers, address)
+    }
+
+    pub fn remove_from_admin_blacklist(env: Env, admin_signers: Vec<Address>, address: Address) {
+        admin::remove_from_admin_blacklist(env, admin_signers, address)
     }
 
     pub fn update_config(

--- a/src/types.rs
+++ b/src/types.rs
@@ -351,6 +351,11 @@ pub struct ConfigUpdateProposal {
 pub struct Config {
     pub admins: Vec<Address>,
     pub admin_threshold: u32,
+    /// Admin addresses that are permitted to be configured as admins.
+    /// If empty, any valid admin address may be used.
+    pub admin_whitelist: Vec<Address>,
+    /// Admin addresses that are explicitly forbidden from being configured as admins.
+    pub admin_blacklist: Vec<Address>,
     /// Primary token contract address used for loans and vouches.
     pub token: Address,
     /// Additional token contract addresses accepted for loans/vouches.
@@ -540,22 +545,8 @@ pub enum TimelockAction {
     SetConfig(Config),
 }
 
-/// Escrow state for a repayment pending oracle verification.
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum EscrowStatus {
-    /// No escrow in flight (default).
-    None,
-    /// Repayment held pending oracle approval.
-    Pending,
-    /// Oracle approved — funds released to vouchers.
-    Released,
-    /// Oracle rejected — funds returned to borrower.
-    Rejected,
-}
-
-/// A slash execution that has been approved by governance but is waiting for
-/// its `executable_at` delay to elapse before it can be carried out.
+/// A pending slash awaiting execution after the mandatory delay period.
+/// Created when a slash vote reaches quorum; executed via `execute_pending_slash`.
 #[contracttype]
 #[derive(Clone)]
 pub struct PendingSlashRecord {
@@ -615,21 +606,6 @@ pub struct WithdrawalRequest {
     pub borrower: Address,
     pub token: Address,
     pub requested_at: u64,
-}
-
-/// A pending slash awaiting execution after the mandatory delay period.
-/// Created when a slash vote reaches quorum; executed via `execute_pending_slash`.
-#[contracttype]
-#[derive(Clone)]
-pub struct PendingSlashRecord {
-    /// Borrower subject to the pending slash.
-    pub borrower: soroban_sdk::Address,
-    /// Ledger timestamp when the slash vote was approved.
-    pub approved_at: u64,
-    /// Earliest ledger timestamp at which the slash may be executed.
-    pub executable_at: u64,
-    /// True once the slash has been executed.
-    pub executed: bool,
 }
 
 /// A queued withdrawal request submitted during an active loan.


### PR DESCRIPTION
## Summary

- ** closes #688 Add Admin Whitelist**: Adds `add_to_admin_whitelist` and `remove_from_admin_whitelist` functions to restrict which addresses can be configured as admins. When the whitelist is non-empty, only listed addresses may be added as admins.
- ** closes #689 Implement Admin Blacklist**: Adds `add_to_admin_blacklist` and `remove_from_admin_blacklist` functions to permanently block specific addresses from ever being configured as admins.
- Both functions are multi-sig gated (`require_admin_approval`) and exposed through the contract's public interface in `lib.rs`.
- Also exposes `add_admin`, `remove_admin`, and `set_admin_threshold` through `lib.rs` (were in `admin.rs` but not wired up to the contract interface).
- Fixes several pre-existing compile errors: duplicate `EscrowStatus` and `PendingSlashRecord` definitions in `types.rs`, duplicate `require_positive_amount` in `helpers.rs`, misplaced `use` imports in `admin.rs`, and missing `SlashRecord` import in `governance.rs`.

## New contract functions

| Function | Description |
|---|---|
| `add_to_admin_whitelist(admin_signers, address)` | Adds address to the admin whitelist |
| `remove_from_admin_whitelist(admin_signers, address)` | Removes address from the admin whitelist |
| `add_to_admin_blacklist(admin_signers, address)` | Adds address to the admin blacklist |
| `remove_from_admin_blacklist(admin_signers, address)` | Removes address from the admin blacklist |
| `add_admin(admin_signers, new_admin)` | Now exposed in contract interface |
| `remove_admin(admin_signers, admin_to_remove)` | Now exposed in contract interface |
| `set_admin_threshold(admin_signers, new_threshold)` | Now exposed in contract interface |

## Test plan

- [x] `test_add_and_remove_admin_whitelist` — round-trip add/remove from whitelist
- [x] `test_whitelist_prevents_non_whitelisted_admin` — non-whitelisted address cannot be added as admin
- [x] `test_whitelisted_admin_can_be_added` — whitelisted address can be added as admin
- [x] `test_duplicate_whitelist_entry_rejected` — duplicate whitelist entries are rejected
- [x] `test_add_and_remove_admin_blacklist` — round-trip add/remove from blacklist
- [x] `test_blacklisted_address_cannot_be_added_as_admin` — blacklisted address cannot be added as admin
- [x] `test_cannot_blacklist_whitelisted_address` — cannot add a whitelisted address to the blacklist
- [x] `test_duplicate_blacklist_entry_rejected` — duplicate blacklist entries are rejected
- [x] `test_removed_from_blacklist_can_be_added_as_admin` — removing from blacklist re-enables adding as admin

