### PR TITLE
feat: implement admin compensation (#686) and governance admin removal (#687)

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -972,3 +972,161 @@ pub fn set_confirmation_required(
         (admin_signers.get(0).unwrap(), enabled, env.ledger().timestamp()),
     );
 }
+
+// ── Issue #686: Admin compensation ───────────────────────────────────────────
+
+/// Set the admin compensation rate.
+///
+/// `compensation_bps` is the fraction of the admin compensation pool that is
+/// distributed across all admins each time `claim_admin_compensation` is called.
+/// Must be in range [0, 10000]. 0 disables compensation.
+pub fn set_admin_compensation_bps(
+    env: Env,
+    admin_signers: Vec<Address>,
+    compensation_bps: u32,
+) {
+    require_admin_approval(&env, &admin_signers);
+    if compensation_bps > 10_000 {
+        panic_with_error!(&env, ContractError::InvalidBps);
+    }
+
+    let mut cfg = config(&env);
+    cfg.admin_compensation_bps = compensation_bps;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cmp_bps")),
+        (admin_signers.get(0).unwrap(), compensation_bps, env.ledger().timestamp()),
+    );
+}
+
+/// Add funds to the admin compensation pool.
+///
+/// Anyone may call this to top up the pool (e.g. from protocol revenues).
+/// The caller must hold at least `amount` tokens and authorize the transfer.
+pub fn fund_admin_compensation(
+    env: Env,
+    funder: Address,
+    amount: i128,
+) -> Result<(), ContractError> {
+    funder.require_auth();
+    if amount <= 0 {
+        panic_with_error!(&env, ContractError::InvalidAmount);
+    }
+
+    let cfg = config(&env);
+    soroban_sdk::token::Client::new(&env, &cfg.token)
+        .transfer(&funder, &env.current_contract_address(), &amount);
+
+    let pool: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::AdminCompensation)
+        .unwrap_or(0i128);
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminCompensation, &(pool + amount));
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cmp_fund")),
+        (funder, amount, env.ledger().timestamp()),
+    );
+
+    Ok(())
+}
+
+/// Claim admin compensation.
+///
+/// Each admin receives an equal pro-rata share of
+/// `pool_balance * admin_compensation_bps / 10_000` split across all admins.
+/// No more than once per 24 hours per admin (enforced via `AdminLastClaim`).
+pub fn claim_admin_compensation(env: Env, admin: Address) -> Result<i128, ContractError> {
+    admin.require_auth();
+
+    if !is_admin(&env, &admin) {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let cfg = config(&env);
+    if cfg.admin_compensation_bps == 0 {
+        return Err(ContractError::InvalidAmount);
+    }
+
+    let now = env.ledger().timestamp();
+    if let Some(last_claim) = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::AdminLastClaim(admin.clone()))
+    {
+        if now.saturating_sub(last_claim) < 24 * 60 * 60 {
+            return Err(ContractError::VouchCooldownActive);
+        }
+    }
+
+    let pool: i128 = env
+        .storage()
+        .instance()
+        .get(&DataKey::AdminCompensation)
+        .unwrap_or(0i128);
+
+    if pool == 0 {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    let num_admins = cfg.admins.len() as i128;
+    let total_payout = pool * cfg.admin_compensation_bps as i128 / 10_000;
+    let share = total_payout / num_admins;
+
+    if share <= 0 {
+        return Err(ContractError::InsufficientFunds);
+    }
+
+    let new_pool = pool - share;
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminCompensation, &new_pool);
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminLastClaim(admin.clone()), &now);
+
+    soroban_sdk::token::Client::new(&env, &cfg.token)
+        .transfer(&env.current_contract_address(), &admin, &share);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("cmp_clm")),
+        (admin, share, env.ledger().timestamp()),
+    );
+
+    Ok(share)
+}
+
+/// Return the current admin compensation rate in basis points.
+pub fn get_admin_compensation_bps(env: Env) -> u32 {
+    config(&env).admin_compensation_bps
+}
+
+/// Return the current balance of the admin compensation pool, in stroops.
+pub fn get_admin_compensation_pool(env: Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::AdminCompensation)
+        .unwrap_or(0i128)
+}
+
+/// Set the governance removal vote threshold for admin removal (#687).
+pub fn set_removal_vote_threshold(
+    env: Env,
+    admin_signers: Vec<Address>,
+    threshold: u32,
+) {
+    require_admin_approval(&env, &admin_signers);
+
+    let mut cfg = config(&env);
+    cfg.removal_vote_threshold = threshold;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("rmv_thr")),
+        (admin_signers.get(0).unwrap(), threshold, env.ledger().timestamp()),
+    );
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -71,6 +71,15 @@ impl QuorumCreditContract {
                 voting_period_seconds: crate::types::DEFAULT_VOTING_PERIOD_SECONDS,
                 slash_cooldown_seconds: 0,
                 emergency_pause_enabled: false,
+                early_repayment_discount_bps: 0,
+                oracle_address: None,
+                slash_delay_seconds: DEFAULT_SLASH_DELAY_SECONDS,
+                confirmation_required: DEFAULT_CONFIRMATION_REQUIRED,
+                dynamic_slash_threshold: DEFAULT_DYNAMIC_SLASH_THRESHOLD,
+                loan_size_slash_enabled: DEFAULT_LOAN_SIZE_SLASH_ENABLED,
+                loan_size_slash_max_bps: DEFAULT_LOAN_SIZE_SLASH_MAX_BPS,
+                removal_vote_threshold: 0,
+                admin_compensation_bps: 0,
             },
         );
 
@@ -1759,5 +1768,103 @@ impl QuorumCreditContract {
     /// Get the current insurance coverage cap in basis points.
     pub fn get_insurance_coverage_bps(env: Env) -> u32 {
         insurance::get_insurance_coverage_bps_pub(env)
+    }
+
+    // ── Issue #687: Governance-based admin removal ────────────────────────────
+
+    /// Propose removing a compromised admin via governance vote.
+    ///
+    /// Any governance participant (active voucher or admin) may call this.
+    /// Requires `Config.removal_vote_threshold > 0`.
+    pub fn propose_admin_removal(
+        env: Env,
+        proposer: Address,
+        admin_to_remove: Address,
+    ) -> Result<u64, ContractError> {
+        governance::propose_admin_removal(env, proposer, admin_to_remove)
+    }
+
+    /// Vote on an admin removal proposal.
+    ///
+    /// Any governance participant may vote once per proposal.
+    pub fn vote_admin_removal(
+        env: Env,
+        voter: Address,
+        proposal_id: u64,
+        approve: bool,
+    ) -> Result<(), ContractError> {
+        governance::vote_admin_removal(env, voter, proposal_id, approve)
+    }
+
+    /// Finalize an admin removal proposal once the vote threshold is met.
+    ///
+    /// Removes the targeted admin from `Config.admins` on success.
+    pub fn finalize_admin_removal(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+        governance::finalize_admin_removal(env, proposal_id)
+    }
+
+    /// Return an admin removal proposal by ID.
+    pub fn get_admin_removal_proposal(
+        env: Env,
+        proposal_id: u64,
+    ) -> Option<AdminRemovalProposal> {
+        governance::get_admin_removal_proposal(env, proposal_id)
+    }
+
+    /// Set the minimum number of governance votes needed to remove an admin.
+    ///
+    /// 0 disables governance removal (admins can only be removed via multi-sig).
+    pub fn set_removal_vote_threshold(
+        env: Env,
+        admin_signers: Vec<Address>,
+        threshold: u32,
+    ) {
+        admin::set_removal_vote_threshold(env, admin_signers, threshold)
+    }
+
+    // ── Issue #686: Admin compensation ───────────────────────────────────────
+
+    /// Set the admin compensation rate in basis points.
+    ///
+    /// Controls what fraction of the compensation pool each admin earns per claim.
+    /// 0 disables admin compensation.
+    pub fn set_admin_compensation_bps(
+        env: Env,
+        admin_signers: Vec<Address>,
+        compensation_bps: u32,
+    ) {
+        admin::set_admin_compensation_bps(env, admin_signers, compensation_bps)
+    }
+
+    /// Add funds to the admin compensation pool.
+    ///
+    /// The `funder` transfers `amount` tokens to the contract's compensation pool.
+    /// These funds are later claimed by admins via `claim_admin_compensation`.
+    pub fn fund_admin_compensation(
+        env: Env,
+        funder: Address,
+        amount: i128,
+    ) -> Result<(), ContractError> {
+        admin::fund_admin_compensation(env, funder, amount)
+    }
+
+    /// Claim admin compensation.
+    ///
+    /// The calling admin receives their pro-rata share of
+    /// `pool * admin_compensation_bps / 10_000 / num_admins`.
+    /// Limited to once per 24 hours per admin.
+    /// Returns the amount claimed, in stroops.
+    pub fn claim_admin_compensation(env: Env, admin: Address) -> Result<i128, ContractError> {
+        admin::claim_admin_compensation(env, admin)
+    }
+
+    /// Return the current admin compensation rate in basis points.
+    pub fn get_admin_compensation_bps(env: Env) -> u32 {
+        admin::get_admin_compensation_bps(env)
+    }
+
+    /// Return the current balance of the admin compensation pool, in stroops.
+    pub fn get_admin_compensation_pool(env: Env) -> i128 {
+        admin::get_admin_compensation_pool(env)
     }
 }

--- a/src/governance.rs
+++ b/src/governance.rs
@@ -4,8 +4,9 @@ use crate::helpers::{
     require_admin_approval, require_governance_participant, require_not_paused,
 };
 use crate::types::{
-    DataKey, LoanStatus, PendingSlashRecord, SlashAppealRecord, SlashThresholdProposal,
-    SlashVoteRecord, TimelockAction, TimelockProposal, VouchRecord, BPS_DENOMINATOR,
+    AdminRemovalProposal, DataKey, LoanStatus, PendingSlashRecord, SlashAppealRecord,
+    SlashThresholdProposal, SlashVoteRecord, TimelockAction, TimelockProposal, VouchRecord,
+    BPS_DENOMINATOR,
 };
 use soroban_sdk::{panic_with_error, symbol_short, Address, Env, Vec};
 
@@ -982,4 +983,168 @@ pub fn get_slashing_report(env: Env, month_id: u64) -> Option<SlashingReportReco
     env.storage()
         .persistent()
         .get(&DataKey::SlashingReport(month_id))
+}
+
+// ── Issue #687: Governance-based admin removal ────────────────────────────────
+
+/// Propose removing a compromised admin via governance vote.
+///
+/// Any governance participant (active voucher or admin) may call this.
+/// The proposal passes once `approve_votes >= Config.removal_vote_threshold`.
+pub fn propose_admin_removal(
+    env: Env,
+    proposer: Address,
+    admin_to_remove: Address,
+) -> Result<u64, ContractError> {
+    proposer.require_auth();
+    require_not_paused(&env)?;
+    require_governance_participant(&env, &proposer)?;
+
+    let cfg = config(&env);
+
+    if cfg.removal_vote_threshold == 0 {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    if !cfg.admins.iter().any(|a| a == admin_to_remove) {
+        return Err(ContractError::UnauthorizedCaller);
+    }
+
+    let proposal_id: u64 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u64>(&DataKey::AdminRemovalProposalCounter)
+        .unwrap_or(0u64)
+        .checked_add(1)
+        .expect("proposal id overflow");
+
+    let proposal = AdminRemovalProposal {
+        id: proposal_id,
+        admin_to_remove: admin_to_remove.clone(),
+        proposer: proposer.clone(),
+        approve_votes: 0,
+        reject_votes: 0,
+        voters: Vec::new(&env),
+        proposed_at: env.ledger().timestamp(),
+        finalized: false,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminRemovalProposal(proposal_id), &proposal);
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminRemovalProposalCounter, &proposal_id);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("rm_prop")),
+        (proposal_id, proposer, admin_to_remove),
+    );
+
+    Ok(proposal_id)
+}
+
+/// Cast a vote on an admin removal proposal.
+///
+/// Any governance participant may vote once per proposal.
+/// Voting closes once the proposal is finalized.
+pub fn vote_admin_removal(
+    env: Env,
+    voter: Address,
+    proposal_id: u64,
+    approve: bool,
+) -> Result<(), ContractError> {
+    voter.require_auth();
+    require_not_paused(&env)?;
+    require_governance_participant(&env, &voter)?;
+
+    let mut proposal: AdminRemovalProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::AdminRemovalProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.finalized {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    if proposal.voters.iter().any(|v| v == voter) {
+        return Err(ContractError::AlreadyVoted);
+    }
+
+    if approve {
+        proposal.approve_votes += 1;
+    } else {
+        proposal.reject_votes += 1;
+    }
+    proposal.voters.push_back(voter.clone());
+
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminRemovalProposal(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("rm_vote")),
+        (proposal_id, voter, approve),
+    );
+
+    Ok(())
+}
+
+/// Finalize an admin removal proposal.
+///
+/// Succeeds once `approve_votes >= Config.removal_vote_threshold`.
+/// On success, the targeted admin is removed from `Config.admins`.
+/// Fails if the removal would drop the admin count below `admin_threshold`.
+pub fn finalize_admin_removal(env: Env, proposal_id: u64) -> Result<(), ContractError> {
+    require_not_paused(&env)?;
+
+    let mut proposal: AdminRemovalProposal = env
+        .storage()
+        .instance()
+        .get(&DataKey::AdminRemovalProposal(proposal_id))
+        .ok_or(ContractError::ProposalNotFound)?;
+
+    if proposal.finalized {
+        return Err(ContractError::ProposalAlreadyFinalized);
+    }
+
+    let mut cfg = config(&env);
+
+    if proposal.approve_votes < cfg.removal_vote_threshold {
+        return Err(ContractError::QuorumNotMet);
+    }
+
+    let idx = cfg
+        .admins
+        .iter()
+        .position(|a| a == proposal.admin_to_remove)
+        .ok_or(ContractError::UnauthorizedCaller)? as u32;
+
+    cfg.admins.remove(idx);
+
+    if cfg.admins.len() < cfg.admin_threshold {
+        return Err(ContractError::InvalidAdminThreshold);
+    }
+
+    env.storage().instance().set(&DataKey::Config, &cfg);
+
+    proposal.finalized = true;
+    env.storage()
+        .instance()
+        .set(&DataKey::AdminRemovalProposal(proposal_id), &proposal);
+
+    env.events().publish(
+        (symbol_short!("gov"), symbol_short!("rm_done")),
+        (proposal_id, proposal.admin_to_remove.clone()),
+    );
+
+    Ok(())
+}
+
+/// Return a governance admin-removal proposal by ID.
+pub fn get_admin_removal_proposal(env: Env, proposal_id: u64) -> Option<AdminRemovalProposal> {
+    env.storage()
+        .instance()
+        .get(&DataKey::AdminRemovalProposal(proposal_id))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,16 @@ impl QuorumCreditContract {
                 early_repayment_discount_bps: 0,
                 oracle_address: None,
                 slash_delay_seconds: 0,
+                confirmation_required: DEFAULT_CONFIRMATION_REQUIRED,
+                redistribution_rule: RedistributionRule::Treasury,
+                recovery_percentage: 0,
+                immunity_period_seconds: 0,
+                insurance_premium_bps: 0,
+                dynamic_slash_threshold: DEFAULT_DYNAMIC_SLASH_THRESHOLD,
+                loan_size_slash_enabled: DEFAULT_LOAN_SIZE_SLASH_ENABLED,
+                loan_size_slash_max_bps: DEFAULT_LOAN_SIZE_SLASH_MAX_BPS,
+                removal_vote_threshold: 0,
+                admin_compensation_bps: 0,
             },
         );
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -292,6 +292,14 @@ pub enum DataKey {
     VoucherInsurance(Address, Address),
     /// Cross-chain bridge validation status: (voucher, chain_id) → bool.
     BridgeValidated(Address, u32),
+    /// Issue #687: admin removal proposal id → AdminRemovalProposal
+    AdminRemovalProposal(u64),
+    /// Issue #687: monotonically increasing admin removal proposal counter
+    AdminRemovalProposalCounter,
+    /// Issue #686: accumulated admin compensation pool balance (i128 stroops)
+    AdminCompensation,
+    /// Issue #686: last compensation claim timestamp per admin address
+    AdminLastClaim(Address),
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -390,6 +398,28 @@ pub struct Config {
     pub oracle_address: Option<soroban_sdk::Address>,
     /// Delay (in seconds) after a slash vote reaches quorum before it can be executed (0 = immediate).
     pub slash_delay_seconds: u64,
+    /// When true, each repayment must be preceded by a `confirm_repayment` call from the borrower.
+    pub confirmation_required: bool,
+    /// Controls where redistributable slash funds flow after insurance allocation.
+    pub redistribution_rule: RedistributionRule,
+    /// Fraction of slash proceeds returned to the borrower on full repayment, in basis points.
+    pub recovery_percentage: u32,
+    /// Seconds a borrower is immune from re-slashing after a reversal (0 = no immunity).
+    pub immunity_period_seconds: u64,
+    /// Protocol fee charged on disbursement and routed to the insurance pool, in basis points.
+    pub insurance_premium_bps: u32,
+    /// When true, the slash threshold adjusts dynamically based on protocol health.
+    pub dynamic_slash_threshold: bool,
+    /// When true, slash penalty scales linearly with loan size relative to total staked collateral.
+    pub loan_size_slash_enabled: bool,
+    /// Maximum slash rate applied to the largest loans when loan-size scaling is enabled, in bps.
+    pub loan_size_slash_max_bps: i128,
+    /// Issue #687: Minimum number of governance votes required to remove a compromised admin.
+    /// 0 means governance removal is disabled (admins can only be removed via multi-sig).
+    pub removal_vote_threshold: u32,
+    /// Issue #686: Fraction of the admin compensation pool each admin earns per epoch, in bps.
+    /// 0 means admin compensation is disabled.
+    pub admin_compensation_bps: u32,
 }
 
 // ── Data Types ────────────────────────────────────────────────────────────────
@@ -676,6 +706,28 @@ pub struct AdminActionProposal {
     pub approvals: Vec<Address>,
     pub created_at: u64,
     pub executed: bool,
+}
+
+/// Issue #687: Governance proposal to remove a compromised admin address.
+/// Passes when `approve_votes >= Config.removal_vote_threshold`.
+#[contracttype]
+#[derive(Clone)]
+pub struct AdminRemovalProposal {
+    pub id: u64,
+    /// Admin address to be removed if the proposal passes.
+    pub admin_to_remove: Address,
+    /// Address that created the proposal (must be a governance participant).
+    pub proposer: Address,
+    /// Number of approve votes cast so far.
+    pub approve_votes: u32,
+    /// Number of reject votes cast so far.
+    pub reject_votes: u32,
+    /// Addresses that have already voted (prevent double-voting).
+    pub voters: Vec<Address>,
+    /// Ledger timestamp when the proposal was created.
+    pub proposed_at: u64,
+    /// True once the proposal has been finalized (admin removed or rejected).
+    pub finalized: bool,
 }
 
 // ── Pagination ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#686 Add Admin Compensation**: New `admin_compensation_bps` Config field + `fund_admin_compensation`, `claim_admin_compensation`, `set_admin_compensation_bps`, `get_admin_compensation_bps`, `get_admin_compensation_pool` functions. Admins split the compensation pool pro-rata; limited to one claim per 24 hours per admin.
- **#687 Implement Admin Removal**: New `removal_vote_threshold` Config field + `propose_admin_removal`, `vote_admin_removal`, `finalize_admin_removal`, `get_admin_removal_proposal`, `set_removal_vote_threshold` functions. Any governance participant can propose/vote; removal executes once approve votes ≥ threshold.
- Also fixes `Config` initializers in `contract.rs` and `lib.rs` that were missing fields added by earlier PRs (`dynamic_slash_threshold`, `loan_size_slash_*`, `confirmation_required`, `redistribution_rule`, `recovery_percentage`, `immunity_period_seconds`, `insurance_premium_bps`), reducing compile errors from 79 → 72.

## Test plan

- [ ] Deploy contract, call `fund_admin_compensation` with a token amount, then `claim_admin_compensation` as each admin — verify pro-rata payouts
- [ ] Verify `claim_admin_compensation` fails a second time within 24 hours
- [ ] Set `removal_vote_threshold`, call `propose_admin_removal` as a voucher, cast votes, call `finalize_admin_removal` once threshold is met — verify admin removed from `Config.admins`
- [ ] Verify `finalize_admin_removal` fails if remaining admins would drop below `admin_threshold`
- [ ] Verify `propose_admin_removal` fails when `removal_vote_threshold == 0`

Closes #686
Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)