### PR TITLE
Add CI/CD Pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,26 @@
-# Require review from core maintainers for changes to the contract source
-src/lib.rs @QuorumCredit/core-maintainers
+# CODEOWNERS — reviewers are automatically requested for matching paths.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+# Contract source (root workspace)
+src/ @QuorumCredit/core-maintainers
+
+# Contract source (QuorumCredit crate)
+QuorumCredit/src/ @QuorumCredit/core-maintainers
+
+# API service
+api/ @QuorumCredit/core-maintainers
+
+# CI/CD pipeline — changes require maintainer review
+.github/ @QuorumCredit/core-maintainers
+
+# Deployment scripts
+scripts/ @QuorumCredit/core-maintainers
+
+# SDK changes
+sdk/ @QuorumCredit/core-maintainers
+
+# Security-sensitive files
+SECURITY.md @QuorumCredit/core-maintainers
+docs/threat-model.md @QuorumCredit/core-maintainers
+docs/security-audit-checklist.md @QuorumCredit/core-maintainers
+docs/security-best-practices.md @QuorumCredit/core-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,42 @@
 version: 2
 
 updates:
+  # Rust workspace (root)
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+
+  # Rust (QuorumCredit crate)
+  - package-ecosystem: "cargo"
+    directory: "/QuorumCredit"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  # TypeScript SDK
+  - package-ecosystem: "npm"
+    directory: "/sdk/typescript"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  # Python SDK
+  - package-ecosystem: "pip"
+    directory: "/sdk/python"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,7 +3,7 @@ branches:
     protection:
       # Prevent force pushes to the protected branch
       allow_force_pushes: false
-      
+
       # Enforce rules for repository administrators as well
       enforce_admins: true
 
@@ -13,7 +13,7 @@ branches:
         dismiss_stale_reviews: true
         require_code_owner_reviews: true
 
-      # Require CI to pass before merging
+      # Require all CI jobs to pass before merging
       required_status_checks:
         strict: true
         contexts:
@@ -21,4 +21,6 @@ branches:
           - "Clippy"
           - "Cargo Check (wasm32)"
           - "Tests"
-          - "Deploy to Testnet"
+          - "Security Audit"
+          - "SDK / TypeScript"
+          - "SDK / Python"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,89 +2,202 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+  workflow_call: {}
 
 env:
   CARGO_TERM_COLOR: always
 
+# Cancel in-progress runs for the same branch/PR to save CI minutes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
-    name: Test
+  # ── Rust: format check ──────────────────────────────────────────────────────
+  fmt:
+    name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-      
-      - name: Cache cargo registry
-        uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Run tests
-        run: cargo test --verbose
+          components: rustfmt
+
+      - name: Check formatting (workspace root)
+        run: cargo fmt --all -- --check
+
+      - name: Check formatting (QuorumCredit)
+        run: cargo fmt --all -- --check
         working-directory: QuorumCredit
 
+  # ── Rust: clippy lint ───────────────────────────────────────────────────────
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      
-      - name: Cache cargo registry
+
+      - name: Cache Cargo
         uses: actions/cache@v4
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Cache target directory
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
-      
-      - name: Run clippy
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-clippy-
+
+      - name: Clippy (workspace root)
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Clippy (QuorumCredit)
         run: cargo clippy --all-targets --all-features -- -D warnings
         working-directory: QuorumCredit
 
-  fmt:
-    name: Format
+  # ── Rust: cargo check (native + WASM) ──────────────────────────────────────
+  check:
+    name: Cargo Check (wasm32)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Install Rust
+
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
-      
-      - name: Check formatting
-        run: cargo fmt --all -- --check
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-check-
+
+      - name: cargo check (native, workspace root)
+        run: cargo check --all-targets
+
+      - name: cargo check (WASM, workspace root)
+        run: cargo check --target wasm32-unknown-unknown
+
+      - name: cargo check (native, QuorumCredit)
+        run: cargo check --all-targets
         working-directory: QuorumCredit
+
+      - name: cargo check (WASM, QuorumCredit)
+        run: cargo check --target wasm32-unknown-unknown
+        working-directory: QuorumCredit
+
+  # ── Rust: unit tests ────────────────────────────────────────────────────────
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-test-
+
+      - name: Run tests (workspace root)
+        run: cargo test --verbose
+
+      - name: Run tests (QuorumCredit)
+        run: cargo test --verbose
+        working-directory: QuorumCredit
+
+      - name: Run tests (api)
+        run: cargo test --verbose
+        working-directory: api
+
+  # ── Rust: dependency security audit ────────────────────────────────────────
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      - name: Audit dependencies (workspace root)
+        run: cargo audit
+
+      - name: Audit dependencies (QuorumCredit)
+        run: cargo audit
+        working-directory: QuorumCredit
+
+  # ── TypeScript SDK ──────────────────────────────────────────────────────────
+  sdk-typescript:
+    name: SDK / TypeScript
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: sdk/typescript/package.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+  # ── Python SDK ──────────────────────────────────────────────────────────────
+  sdk-python:
+    name: SDK / Python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: sdk/python/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install package in editable mode
+        run: pip install -e .
+
+      - name: Lint with ruff
+        run: |
+          pip install ruff==0.4.4
+          ruff check quorum_credit/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,23 +6,56 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  CARGO_TERM_COLOR: always
+
+# Cancel in-progress runs for the same branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
+    name: Code Coverage
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-coverage-
 
-      - name: Run coverage
-        run: cargo tarpaulin --out Xml --output-dir coverage
+      - name: Install cargo-tarpaulin
+        run: cargo install --locked cargo-tarpaulin
+
+      - name: Run coverage (workspace root)
+        run: |
+          cargo tarpaulin \
+            --out Xml \
+            --output-dir coverage \
+            --all-features \
+            --workspace \
+            --timeout 120
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v4
         with:
           files: coverage/cobertura.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ github.run_id }}
+          path: coverage/
+          if-no-files-found: warn

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -2,16 +2,38 @@ name: Deploy Testnet Preview
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [main]
+
+# Only one testnet deployment at a time; cancel queued runs but not in-progress
+concurrency:
+  group: deploy-testnet
+  cancel-in-progress: false
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  deploy:
-    name: Deploy to Testnet
+  # ── Gate: CI must pass before deploying ────────────────────────────────────
+  ci-gate:
+    name: Wait for CI
     runs-on: ubuntu-latest
+    steps:
+      - name: Check CI workflow status
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.sha }}
+          check-name: "Tests"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+
+  # ── Build WASM artifact ─────────────────────────────────────────────────────
+  build:
+    name: Build WASM
+    needs: ci-gate
+    runs-on: ubuntu-latest
+    outputs:
+      wasm-artifact: ${{ steps.upload.outputs.artifact-id }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -30,15 +52,53 @@ jobs:
             ~/.cargo/bin
             target
           key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-deploy-
+          restore-keys: ${{ runner.os }}-cargo-deploy-
+
+      - name: Build WASM (release)
+        run: cargo build --release --target wasm32-unknown-unknown
+
+      - name: Upload WASM artifact
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: quorum-credit-wasm-${{ github.sha }}
+          path: target/wasm32-unknown-unknown/release/quorum_credit.wasm
+          retention-days: 7
+
+  # ── Deploy to testnet ───────────────────────────────────────────────────────
+  deploy:
+    name: Deploy to Testnet
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testnet
+    outputs:
+      contract_id: ${{ steps.deploy.outputs.contract_id }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+            target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-deploy-
 
       - name: Install Stellar CLI
         run: |
           if ! command -v stellar &> /dev/null; then
             cargo install --locked stellar-cli
           else
-            echo "Stellar CLI already installed."
+            echo "Stellar CLI already installed: $(stellar --version)"
           fi
 
       - name: Deploy Contract
@@ -50,28 +110,24 @@ jobs:
             echo "::error::DEPLOYER_SECRET_KEY secret is missing. Please add it to GitHub Repository Secrets."
             exit 1
           fi
-          
+
           chmod +x ./scripts/deploy.sh
-          
-          # Run the script and save the output
           ./scripts/deploy.sh --network testnet > deploy_output.txt
           cat deploy_output.txt
-          
-          # Extract the CONTRACT_ID from the output
+
           CONTRACT_ID=$(grep "^CONTRACT_ID=" deploy_output.txt | cut -d'=' -f2)
-          
           if [ -z "$CONTRACT_ID" ]; then
-            echo "::error::Failed to extract CONTRACT_ID from output."
+            echo "::error::Failed to extract CONTRACT_ID from deploy output."
             exit 1
           fi
-          
-          echo "contract_id=$CONTRACT_ID" >> $GITHUB_OUTPUT
+
+          echo "contract_id=$CONTRACT_ID" >> "$GITHUB_OUTPUT"
           echo "$CONTRACT_ID" > contract_id.txt
 
       - name: Store Contract ID as Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: testnet-contract-id
+          name: testnet-contract-id-${{ github.run_id }}
           path: contract_id.txt
 
       - name: Notify Team via Commit Comment
@@ -82,7 +138,9 @@ jobs:
             ### 🚀 Testnet Deployment Preview
             **Contract ID:** `${{ steps.deploy.outputs.contract_id }}`
             **Network:** `testnet`
+            **Commit:** `${{ github.sha }}`
 
+  # ── Run integration tests against the fresh deployment ─────────────────────
   integration-tests:
     name: Run Integration Tests
     needs: deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,33 +2,63 @@ name: Docs
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
 
+# Only one docs deployment at a time
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
 jobs:
-  build-and-deploy:
-    name: Build and deploy Rust docs to GitHub Pages
+  build:
+    name: Build Rust Docs
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-docs-
+
       - name: Generate workspace documentation
         run: cargo doc --workspace --no-deps
+
+      - name: Add redirect index
+        run: |
+          echo '<meta http-equiv="refresh" content="0; url=quorum_credit/index.html">' \
+            > target/doc/index.html
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v4
 
-      - name: Upload docs to GitHub Pages
-        uses: actions/upload-pages-artifact@v1
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: target/doc
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,37 +3,48 @@ name: Release WASM Artifact
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
+
+permissions:
+  contents: write
 
 jobs:
-  build-and-release:
-    name: Build WASM and publish release
-    runs-on: ubuntu-latest
+  # ── Run full CI before releasing ────────────────────────────────────────────
+  ci:
+    name: Pre-release CI
+    uses: ./.github/workflows/ci.yml
 
+  # ── Build WASM and publish GitHub Release ───────────────────────────────────
+  build-and-release:
+    name: Build WASM and Publish Release
+    needs: ci
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install git-cliff
-        run: cargo install --locked git-cliff-cli
-
-      - name: Generate changelog
-        run: git cliff -o CHANGELOG.md
-
-      - name: Cache Cargo registry
+      - name: Cache Cargo
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-
+
+      - name: Install git-cliff
+        run: cargo install --locked git-cliff-cli
+
+      - name: Generate changelog
+        run: git cliff --current -o CHANGELOG.md
 
       - name: Build WASM (release)
         run: cargo build --release --target wasm32-unknown-unknown
@@ -52,20 +63,70 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           name: QuorumCredit ${{ github.ref_name }}
-          body: |
-            ## QuorumCredit ${{ github.ref_name }}
-
-            ### Assets
-            - `quorum_credit_${{ github.ref_name }}.wasm` — compiled CosmWasm contract
-            - `quorum_credit_${{ github.ref_name }}.wasm.sha256` — SHA256 checksum
-
-            ### Verify checksum
-            ```bash
-            sha256sum -c quorum_credit_${{ github.ref_name }}.wasm.sha256
-            ```
+          body_path: CHANGELOG.md
           files: |
             quorum_credit_${{ github.ref_name }}.wasm
             quorum_credit_${{ github.ref_name }}.wasm.sha256
             CHANGELOG.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ── Publish TypeScript SDK to npm ───────────────────────────────────────────
+  publish-sdk-typescript:
+    name: Publish TypeScript SDK
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/typescript
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Only publish if NPM_TOKEN is configured; skip otherwise
+        if: ${{ secrets.NPM_TOKEN != '' }}
+
+  # ── Publish Python SDK to PyPI ───────────────────────────────────────────────
+  publish-sdk-python:
+    name: Publish Python SDK
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/python
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build twine
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        # Only publish if PYPI_TOKEN is configured; skip otherwise
+        if: ${{ secrets.PYPI_TOKEN != '' }}


### PR DESCRIPTION
Closes #741  Add CI/CD Pipeline
- Expand ci.yml from 3 to 7 jobs: fmt, clippy, check (native+WASM), test, audit, sdk-typescript, sdk-python
- Add workflow_call trigger to ci.yml for reuse by release workflow
- Add concurrency groups to cancel redundant runs
- Fix coverage.yml to run workspace-wide with --all-features
- Fix docs.yml: add missing deploy-pages step and index redirect
- Gate deploy-testnet.yml on CI passing before deploying
- Gate release.yml on full CI before publishing; add npm/PyPI SDK publish
- Expand CODEOWNERS to cover src/, api/, .github/, scripts/, sdk/
- Update settings.yml required status checks to match new job names
- Add npm, pip, and github-actions ecosystems to dependabot.yml

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed
