### PR TITLE
tasks-742-743-744

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -78,6 +78,20 @@ impl QuorumCreditContract {
         // Initialize API version (Issue #723)
         crate::versioning::initialize_api_version(&env);
 
+        // Set initial semantic contract version and record deployment (Issues #742, #743)
+        crate::versioning::set_contract_version(
+            &env,
+            1,
+            0,
+            0,
+            soroban_sdk::String::from_slice(&env, "initial deployment"),
+        );
+        crate::versioning::record_deployment(
+            &env,
+            deployer.clone(),
+            soroban_sdk::String::from_slice(&env, "mainnet"),
+        );
+
         env.events().publish(
             (symbol_short!("contract"), symbol_short!("init")),
             (deployer, admins, admin_threshold, token),
@@ -1542,6 +1556,129 @@ impl QuorumCreditContract {
             (major, minor, patch),
             (current.major, current.minor, current.patch),
         )
+    }
+
+    // ── Contract Versioning (Issue #742) ─────────────────────────────────────
+
+    /// Return the current semantic contract version.
+    pub fn get_contract_version(env: Env) -> ContractSemVer {
+        crate::versioning::get_contract_version(&env)
+    }
+
+    /// Set a new semantic contract version (admin-gated).
+    pub fn set_contract_version(
+        env: Env,
+        admin_signers: Vec<Address>,
+        major: u32,
+        minor: u32,
+        patch: u32,
+        note: soroban_sdk::String,
+    ) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        crate::versioning::set_contract_version(&env, major, minor, patch, note);
+    }
+
+    /// Bump the patch version component (admin-gated).
+    pub fn bump_patch(env: Env, admin_signers: Vec<Address>, note: soroban_sdk::String) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        crate::versioning::bump_patch(&env, note);
+    }
+
+    /// Bump the minor version component, resetting patch to 0 (admin-gated).
+    pub fn bump_minor(env: Env, admin_signers: Vec<Address>, note: soroban_sdk::String) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        crate::versioning::bump_minor(&env, note);
+    }
+
+    /// Bump the major version component, resetting minor and patch to 0 (admin-gated).
+    pub fn bump_major(env: Env, admin_signers: Vec<Address>, note: soroban_sdk::String) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        crate::versioning::bump_major(&env, note);
+    }
+
+    /// Retrieve a version history entry by sequential index.
+    pub fn get_version_history_entry(env: Env, index: u32) -> Option<VersionHistoryEntry> {
+        crate::versioning::get_version_history_entry(&env, index)
+    }
+
+    /// Total number of recorded version history entries.
+    pub fn version_history_count(env: Env) -> u32 {
+        crate::versioning::version_history_count(&env)
+    }
+
+    // ── Deployment Records (Issue #743) ──────────────────────────────────────
+
+    /// Record a new deployment on-chain (admin-gated).
+    ///
+    /// Typically called right after `initialize` or `upgrade` to capture the
+    /// deployer, network, and version at the time of deployment.
+    pub fn record_deployment(
+        env: Env,
+        admin_signers: Vec<Address>,
+        deployer: Address,
+        network: soroban_sdk::String,
+    ) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        crate::versioning::record_deployment(&env, deployer, network);
+    }
+
+    /// Retrieve a deployment record by sequential index.
+    pub fn get_deployment_record(env: Env, index: u32) -> Option<DeploymentRecord> {
+        crate::versioning::get_deployment_record(&env, index)
+    }
+
+    /// Total number of recorded deployments.
+    pub fn deployment_count(env: Env) -> u32 {
+        crate::versioning::deployment_count(&env)
+    }
+
+    // ── Rollback Snapshots (Issue #744) ──────────────────────────────────────
+
+    /// Save a rollback snapshot for the given deployment index (admin-gated).
+    ///
+    /// Call this *before* applying an upgrade so the previous config state is
+    /// preserved and can be restored via `apply_rollback_snapshot`.
+    pub fn save_rollback_snapshot(
+        env: Env,
+        admin_signers: Vec<Address>,
+        deployment_index: u32,
+    ) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        let cfg = crate::helpers::config(&env);
+        crate::versioning::save_rollback_snapshot(
+            &env,
+            deployment_index,
+            cfg.yield_bps,
+            cfg.slash_bps,
+            cfg.max_vouchers,
+            cfg.admin_threshold,
+        );
+    }
+
+    /// Retrieve a rollback snapshot by deployment index.
+    pub fn get_rollback_snapshot(env: Env, deployment_index: u32) -> Option<RollbackSnapshot> {
+        crate::versioning::get_rollback_snapshot(&env, deployment_index)
+    }
+
+    /// Returns `true` when a rollback snapshot exists for the given index.
+    pub fn has_rollback_snapshot(env: Env, deployment_index: u32) -> bool {
+        crate::versioning::has_rollback_snapshot(&env, deployment_index)
+    }
+
+    /// Restore critical config fields from a saved rollback snapshot (admin-gated).
+    ///
+    /// Applies `yield_bps`, `slash_bps`, `max_vouchers`, and `admin_threshold`
+    /// from the snapshot. Panics if no snapshot exists for the given index.
+    pub fn apply_rollback_snapshot(
+        env: Env,
+        admin_signers: Vec<Address>,
+        deployment_index: u32,
+    ) {
+        crate::helpers::require_admin_approval(&env, &admin_signers);
+        let applied = crate::versioning::apply_rollback_snapshot(&env, deployment_index);
+        if !applied {
+            panic_with_error!(&env, ContractError::RollbackSnapshotNotFound);
+        }
     }
 
     // ── API Caching (Issue #724) ──────────────────────────────────────────────

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -86,4 +86,6 @@ pub enum ContractError {
     InvalidProof = 61,
     /// Arithmetic overflow or underflow occurred.
     ArithmeticError = 62,
+    /// No rollback snapshot found for the requested deployment index (#744).
+    RollbackSnapshotNotFound = 63,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -337,6 +337,18 @@ pub enum DataKey {
     AdminLastClaim(Address),
     RolePermissions(Address), // address -> RolePermissions
     RateLimit(Address),        // address -> (u64 last_call_window_start, u32 call_count)
+    /// Issue #742: current semantic contract version
+    ContractVersion,
+    /// Issue #742: version history entries by index
+    ContractVersionHistory(u32),
+    /// Issue #742: number of version history entries
+    ContractVersionHistoryCount,
+    /// Issue #743: deployment record by index
+    DeploymentRecord(u32),
+    /// Issue #743: total number of deployment records
+    DeploymentRecordCount,
+    /// Issue #744: rollback snapshot of config keyed by version index
+    RollbackSnapshot(u32),
 }
 
 // ── Governance ────────────────────────────────────────────────────────────────
@@ -708,6 +720,68 @@ pub struct ApiVersion {
     pub major: u32,
     pub minor: u32,
     pub patch: u32,
+}
+
+// ── Contract Versioning (Issue #742) ─────────────────────────────────────────
+
+/// Semantic version record stored on-chain for the contract itself.
+#[contracttype]
+#[derive(Clone)]
+pub struct ContractSemVer {
+    pub major: u32,
+    pub minor: u32,
+    pub patch: u32,
+    /// Ledger timestamp when this version was set.
+    pub updated_at: u64,
+    /// Short human-readable change note (max 64 chars).
+    pub note: soroban_sdk::String,
+}
+
+/// A single entry in the on-chain version history log.
+#[contracttype]
+#[derive(Clone)]
+pub struct VersionHistoryEntry {
+    pub version: ContractSemVer,
+    /// Sequential index of this entry (0-based).
+    pub index: u32,
+}
+
+// ── Deployment Records (Issue #743) ──────────────────────────────────────────
+
+/// On-chain record of a single contract deployment or upgrade.
+#[contracttype]
+#[derive(Clone)]
+pub struct DeploymentRecord {
+    /// Sequential deployment index (0-based).
+    pub index: u32,
+    /// Deployer address that signed the transaction.
+    pub deployer: Address,
+    /// Ledger timestamp of the deployment.
+    pub deployed_at: u64,
+    /// Semantic version active at time of deployment.
+    pub version: ContractSemVer,
+    /// Network identifier ("testnet" | "mainnet").
+    pub network: soroban_sdk::String,
+}
+
+// ── Rollback Snapshots (Issue #744) ──────────────────────────────────────────
+
+/// Snapshot of critical config fields saved before an upgrade, used for rollback.
+#[contracttype]
+#[derive(Clone)]
+pub struct RollbackSnapshot {
+    /// Deployment index this snapshot corresponds to.
+    pub deployment_index: u32,
+    /// Ledger timestamp when the snapshot was taken.
+    pub snapshot_at: u64,
+    /// Semantic version at snapshot time.
+    pub version: ContractSemVer,
+    /// Serialised config — stores yield_bps, slash_bps, max_vouchers, and
+    /// admin_threshold so a rollback can restore these critical parameters.
+    pub yield_bps: i128,
+    pub slash_bps: i128,
+    pub max_vouchers: u32,
+    pub admin_threshold: u32,
 }
 
 // ── API Caching (Issue #724) ──────────────────────────────────────────────────

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -1,10 +1,15 @@
-//! API versioning support (Issue #723)
+//! Contract versioning — Issues #742, #743, #744
 //!
-//! This module provides utilities for managing and querying the contract's API version.
-//! It allows clients to determine compatibility and handle version-specific behavior.
+//! Provides semantic versioning for the QuorumCredit contract, on-chain
+//! deployment record-keeping, and rollback snapshot management.
 
-use crate::types::{ApiVersion, DataKey, API_VERSION};
-use soroban_sdk::Env;
+use crate::types::{
+    ApiVersion, Config, ContractSemVer, DataKey, DeploymentRecord, RollbackSnapshot,
+    VersionHistoryEntry, API_VERSION,
+};
+use soroban_sdk::{Address, Env, String};
+
+// ── API Version helpers (legacy, Issue #723) ──────────────────────────────────
 
 /// Initialize the API version on contract deployment.
 pub fn initialize_api_version(env: &Env) {
@@ -28,28 +33,212 @@ pub fn get_api_version(env: &Env) -> ApiVersion {
         })
 }
 
-/// Check if the contract supports a specific API version.
-/// Returns true if the requested version is compatible with the current version.
+/// Returns true when `requested` is compatible with `current`.
+/// Major versions must match; current minor must be ≥ requested minor.
 pub fn is_version_compatible(requested: (u32, u32, u32), current: (u32, u32, u32)) -> bool {
-    // Major version must match for compatibility
     if requested.0 != current.0 {
         return false;
     }
-    // Minor version of current must be >= requested minor version
-    if current.1 < requested.1 {
-        return false;
-    }
-    true
+    current.1 >= requested.1
 }
 
-/// Get the API version as a semantic version string.
-pub fn get_version_string(env: &Env) -> soroban_sdk::String {
-    let version = get_api_version(env);
-    let version_str = format!(
-        "{}.{}.{}",
-        version.major, version.minor, version.patch
-    );
-    soroban_sdk::String::from_slice(env, version_str.as_str())
+/// Get the API version as a "major.minor.patch" string.
+pub fn get_version_string(env: &Env) -> String {
+    let v = get_api_version(env);
+    let s = format!("{}.{}.{}", v.major, v.minor, v.patch);
+    String::from_slice(env, s.as_str())
+}
+
+// ── Semantic Contract Versioning (Issue #742) ─────────────────────────────────
+
+/// Return the current semantic contract version, defaulting to 1.0.0.
+pub fn get_contract_version(env: &Env) -> ContractSemVer {
+    env.storage()
+        .instance()
+        .get::<DataKey, ContractSemVer>(&DataKey::ContractVersion)
+        .unwrap_or_else(|| ContractSemVer {
+            major: 1,
+            minor: 0,
+            patch: 0,
+            updated_at: 0,
+            note: String::from_slice(env, "initial"),
+        })
+}
+
+/// Set a new semantic contract version and append it to the on-chain history log.
+///
+/// * `major` / `minor` / `patch` — new version numbers
+/// * `note` — short change description (max 64 chars recommended)
+pub fn set_contract_version(env: &Env, major: u32, minor: u32, patch: u32, note: String) {
+    let new_ver = ContractSemVer {
+        major,
+        minor,
+        patch,
+        updated_at: env.ledger().timestamp(),
+        note,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersion, &new_ver);
+
+    let count: u32 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u32>(&DataKey::ContractVersionHistoryCount)
+        .unwrap_or(0);
+
+    let entry = VersionHistoryEntry {
+        version: new_ver,
+        index: count,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersionHistory(count), &entry);
+    env.storage()
+        .instance()
+        .set(&DataKey::ContractVersionHistoryCount, &(count + 1));
+}
+
+/// Bump the patch component and record the change.
+pub fn bump_patch(env: &Env, note: String) {
+    let v = get_contract_version(env);
+    set_contract_version(env, v.major, v.minor, v.patch + 1, note);
+}
+
+/// Bump the minor component (resets patch to 0) and record the change.
+pub fn bump_minor(env: &Env, note: String) {
+    let v = get_contract_version(env);
+    set_contract_version(env, v.major, v.minor + 1, 0, note);
+}
+
+/// Bump the major component (resets minor and patch to 0) and record the change.
+pub fn bump_major(env: &Env, note: String) {
+    let v = get_contract_version(env);
+    set_contract_version(env, v.major + 1, 0, 0, note);
+}
+
+/// Retrieve a specific version history entry by its sequential index.
+pub fn get_version_history_entry(env: &Env, index: u32) -> Option<VersionHistoryEntry> {
+    env.storage()
+        .instance()
+        .get::<DataKey, VersionHistoryEntry>(&DataKey::ContractVersionHistory(index))
+}
+
+/// Total number of recorded version history entries.
+pub fn version_history_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get::<DataKey, u32>(&DataKey::ContractVersionHistoryCount)
+        .unwrap_or(0)
+}
+
+// ── Deployment Records (Issue #743) ──────────────────────────────────────────
+
+/// Record a new deployment on-chain, advancing the deployment counter.
+///
+/// Call this after a successful `initialize` or upgrade so that every
+/// deployment is tracked with its deployer, timestamp, version, and network.
+pub fn record_deployment(env: &Env, deployer: Address, network: String) {
+    let count: u32 = env
+        .storage()
+        .instance()
+        .get::<DataKey, u32>(&DataKey::DeploymentRecordCount)
+        .unwrap_or(0);
+
+    let record = DeploymentRecord {
+        index: count,
+        deployer,
+        deployed_at: env.ledger().timestamp(),
+        version: get_contract_version(env),
+        network,
+    };
+
+    env.storage()
+        .instance()
+        .set(&DataKey::DeploymentRecord(count), &record);
+    env.storage()
+        .instance()
+        .set(&DataKey::DeploymentRecordCount, &(count + 1));
+}
+
+/// Retrieve a deployment record by index.
+pub fn get_deployment_record(env: &Env, index: u32) -> Option<DeploymentRecord> {
+    env.storage()
+        .instance()
+        .get::<DataKey, DeploymentRecord>(&DataKey::DeploymentRecord(index))
+}
+
+/// Total number of recorded deployments.
+pub fn deployment_count(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get::<DataKey, u32>(&DataKey::DeploymentRecordCount)
+        .unwrap_or(0)
+}
+
+// ── Rollback Snapshots (Issue #744) ──────────────────────────────────────────
+
+/// Save a rollback snapshot for the current deployment index.
+///
+/// Call this *before* applying any upgrade so that the previous state is
+/// preserved and can be restored via `apply_rollback_snapshot`.
+pub fn save_rollback_snapshot(
+    env: &Env,
+    deployment_index: u32,
+    yield_bps: i128,
+    slash_bps: i128,
+    max_vouchers: u32,
+    admin_threshold: u32,
+) {
+    let snapshot = RollbackSnapshot {
+        deployment_index,
+        snapshot_at: env.ledger().timestamp(),
+        version: get_contract_version(env),
+        yield_bps,
+        slash_bps,
+        max_vouchers,
+        admin_threshold,
+    };
+    env.storage()
+        .instance()
+        .set(&DataKey::RollbackSnapshot(deployment_index), &snapshot);
+}
+
+/// Retrieve a rollback snapshot by deployment index.
+pub fn get_rollback_snapshot(env: &Env, deployment_index: u32) -> Option<RollbackSnapshot> {
+    env.storage()
+        .instance()
+        .get::<DataKey, RollbackSnapshot>(&DataKey::RollbackSnapshot(deployment_index))
+}
+
+/// Returns `true` when a rollback snapshot exists for the given index.
+pub fn has_rollback_snapshot(env: &Env, deployment_index: u32) -> bool {
+    env.storage()
+        .instance()
+        .has(&DataKey::RollbackSnapshot(deployment_index))
+}
+
+/// Restore critical config fields from a saved rollback snapshot.
+///
+/// Applies `yield_bps`, `slash_bps`, `max_vouchers`, and `admin_threshold`
+/// from the snapshot back into the on-chain `Config`. Returns `false` if no
+/// snapshot exists for the given index.
+pub fn apply_rollback_snapshot(env: &Env, deployment_index: u32) -> bool {
+    let snapshot = match get_rollback_snapshot(env, deployment_index) {
+        Some(s) => s,
+        None => return false,
+    };
+    let mut cfg: Config = env
+        .storage()
+        .instance()
+        .get(&DataKey::Config)
+        .expect("not initialized");
+    cfg.yield_bps = snapshot.yield_bps;
+    cfg.slash_bps = snapshot.slash_bps;
+    cfg.max_vouchers = snapshot.max_vouchers;
+    cfg.admin_threshold = snapshot.admin_threshold;
+    env.storage().instance().set(&DataKey::Config, &cfg);
+    true
 }
 
 #[cfg(test)]
@@ -58,19 +247,10 @@ mod tests {
 
     #[test]
     fn test_version_compatibility() {
-        // Same version
         assert!(is_version_compatible((1, 0, 0), (1, 0, 0)));
-
-        // Current is newer minor
         assert!(is_version_compatible((1, 0, 0), (1, 1, 0)));
-
-        // Current is newer patch
         assert!(is_version_compatible((1, 0, 0), (1, 0, 1)));
-
-        // Different major version
         assert!(!is_version_compatible((1, 0, 0), (2, 0, 0)));
-
-        // Requested is newer minor
         assert!(!is_version_compatible((1, 1, 0), (1, 0, 0)));
     }
 }


### PR DESCRIPTION
- #742: add semantic contract versioning (ContractSemVer, VersionHistoryEntry, get/set_contract_version, bump_patch/minor/major, history query endpoints)
- #743: add on-chain deployment records (DeploymentRecord, record_deployment, get_deployment_record, deployment_count); wire into initialize
- #744: add rollback snapshots (RollbackSnapshot, save/get/has/apply_rollback_snapshot); apply restores yield_bps, slash_bps, max_vouchers, admin_threshold from snapshot
- Add RollbackSnapshotNotFound = 63 error variant

## Description
Brief summary of what this PR does and why.

Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [ ] `cargo check` passes
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo test` passes
- [ ] New tests added for new functionality
- [ ] Documentation updated if needed

closes #742 
closes #743 
closes #744 