### PR TITLE
feat: build real-time loan status dashboard with WebSocket integration 

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,9 +8,12 @@
       "name": "quorum-credit-dashboard",
       "version": "1.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.12.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "recharts": "^2.13.0"
+        "react-redux": "^9.3.0",
+        "recharts": "^2.13.0",
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -19,8 +22,10 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/socket.io-client": "^1.4.36",
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^26.1.0",
+        "tailwindcss": "^4.3.1",
         "typescript": "^5.7.3",
         "vite": "^6.0.7",
         "vitest": "^3.1.4"
@@ -85,7 +90,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -434,7 +438,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -458,7 +461,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -955,6 +957,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1312,13 +1340,30 @@
         "win32"
       ]
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1556,16 +1601,15 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1577,10 +1621,22 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/socket.io-client": {
+      "version": "1.4.36",
+      "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.36.tgz",
+      "integrity": "sha512-ZJWjtFBeBy1kRSYpVbeGYTElf6BqPQUkXDlHHD4k/42byCN5Rh027f4yARHCink9sKAkbtGZXEAmR0ZCnc2/Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1804,7 +1860,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2059,7 +2114,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2129,6 +2183,28 @@
       "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -2334,6 +2410,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2372,7 +2458,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -2502,7 +2587,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2593,7 +2677,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2684,7 +2767,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2697,7 +2779,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2711,6 +2792,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2799,6 +2903,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.62.2",
@@ -2898,6 +3023,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2959,6 +3112,13 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3120,6 +3280,15 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
       "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
@@ -3148,7 +3317,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3396,7 +3564,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -3430,6 +3597,14 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,9 +9,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.12.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "recharts": "^2.13.0"
+    "react-redux": "^9.3.0",
+    "recharts": "^2.13.0",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -20,8 +23,10 @@
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/socket.io-client": "^1.4.36",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^26.1.0",
+    "tailwindcss": "^4.3.1",
     "typescript": "^5.7.3",
     "vite": "^6.0.7",
     "vitest": "^3.1.4"

--- a/dashboard/src/LoanCard.tsx
+++ b/dashboard/src/LoanCard.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { stroopsToXlm } from "./stroops";
+import type { LoanRecord, LoanStatus } from "./loanSlice";
+
+interface LoanCardProps {
+  loan: LoanRecord;
+}
+
+const STATUS_STYLES: Record<LoanStatus, { bg: string; text: string; label: string }> = {
+  Active:   { bg: "#eff6ff", text: "#1d4ed8", label: "Active" },
+  Repaid:   { bg: "#f0fdf4", text: "#15803d", label: "Repaid" },
+  Defaulted:{ bg: "#fef2f2", text: "#dc2626", label: "Defaulted" },
+  None:     { bg: "#f8fafc", text: "#64748b", label: "None" },
+};
+
+function repaidPct(loan: LoanRecord): number {
+  if (loan.amount === 0) return 0;
+  return Math.min(100, (loan.amount_repaid / loan.amount) * 100);
+}
+
+/**
+ * LoanCard — displays a single loan record with borrower, principal, repaid %,
+ * yield earned, and repayment deadline. Mobile-responsive via inline flex.
+ */
+const LoanCard: React.FC<LoanCardProps> = ({ loan }) => {
+  const style = STATUS_STYLES[loan.status] ?? STATUS_STYLES.None;
+  const pct = repaidPct(loan);
+  const deadline = new Date(loan.deadline * 1000).toLocaleDateString();
+  const principal = stroopsToXlm(loan.amount);
+  const yieldEarned = stroopsToXlm(loan.total_yield);
+
+  return (
+    <article
+      aria-label={`Loan ${loan.id}`}
+      style={{
+        background: style.bg,
+        border: `1px solid ${style.text}33`,
+        borderRadius: 10,
+        padding: "16px 20px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      {/* Header row */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 4 }}>
+        <span style={{ fontWeight: 700, fontSize: 14, color: "#0f172a", wordBreak: "break-all" }}>
+          {loan.borrower}
+        </span>
+        <span
+          aria-label={`Status: ${style.label}`}
+          style={{
+            background: style.text + "1a",
+            color: style.text,
+            fontSize: 12,
+            fontWeight: 600,
+            borderRadius: 999,
+            padding: "2px 10px",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {style.label}
+        </span>
+      </div>
+
+      {/* Purpose */}
+      {loan.loan_purpose && (
+        <p style={{ margin: 0, fontSize: 13, color: "#475569" }}>{loan.loan_purpose}</p>
+      )}
+
+      {/* Principal / Yield row */}
+      <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontSize: 11, color: "#64748b" }}>Principal</div>
+          <div style={{ fontWeight: 600, fontSize: 16 }}>{principal} XLM</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: "#64748b" }}>Yield</div>
+          <div style={{ fontWeight: 600, fontSize: 16, color: "#15803d" }}>{yieldEarned} XLM</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 11, color: "#64748b" }}>Deadline</div>
+          <div style={{ fontWeight: 600, fontSize: 14 }}>{deadline}</div>
+        </div>
+      </div>
+
+      {/* Repayment progress bar */}
+      <div>
+        <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, color: "#64748b", marginBottom: 4 }}>
+          <span>Repaid</span>
+          <span aria-label={`Repaid ${pct.toFixed(1)}%`}>{pct.toFixed(1)}%</span>
+        </div>
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label="Repayment progress"
+          style={{ height: 6, background: "#e2e8f0", borderRadius: 999, overflow: "hidden" }}
+        >
+          <div
+            style={{
+              height: "100%",
+              width: `${pct}%`,
+              background: loan.status === "Defaulted" ? "#ef4444" : style.text,
+              borderRadius: 999,
+              transition: "width 0.3s ease",
+            }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default LoanCard;

--- a/dashboard/src/LoanStatusDashboard.tsx
+++ b/dashboard/src/LoanStatusDashboard.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { Provider, useSelector } from "react-redux";
+import { store, RootState } from "./store";
+import { useLoanSocket } from "./useLoanSocket";
+import LoanCard from "./LoanCard";
+
+// ---------------------------------------------------------------------------
+// Inner component — must be inside Provider
+// ---------------------------------------------------------------------------
+
+interface DashboardInnerProps {
+  borrower: string;
+  wsUrl: string;
+  apiKey?: string;
+}
+
+const DashboardInner: React.FC<DashboardInnerProps> = ({ borrower, wsUrl, apiKey }) => {
+  useLoanSocket({ url: wsUrl, borrower, apiKey });
+
+  const { loans, reputation, connected, lastUpdated } = useSelector(
+    (state: RootState) => state.loans
+  );
+
+  const activeLoans = loans.filter((l) => l.status === "Active");
+  const closedLoans = loans.filter((l) => l.status !== "Active");
+
+  return (
+    <div
+      aria-label="Loan Status Dashboard"
+      style={{ fontFamily: "system-ui", padding: 24, maxWidth: 900, margin: "0 auto" }}
+    >
+      {/* Header */}
+      <header style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 20, flexWrap: "wrap" }}>
+        <h1 style={{ margin: 0, fontSize: 22, color: "#0f172a" }}>Loan Status Dashboard</h1>
+        <span
+          aria-label={connected ? "WebSocket connected" : "WebSocket disconnected"}
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            background: connected ? "#22c55e" : "#ef4444",
+            display: "inline-block",
+          }}
+        />
+        <span style={{ fontSize: 12, color: "#6b7280" }}>{connected ? "Live" : "Disconnected"}</span>
+        {lastUpdated && (
+          <span style={{ fontSize: 11, color: "#94a3b8", marginLeft: "auto" }}>
+            Updated {new Date(lastUpdated).toLocaleTimeString()}
+          </span>
+        )}
+      </header>
+
+      {/* Reputation */}
+      {reputation && (
+        <section
+          aria-label="Reputation"
+          style={{
+            background: "#f8fafc",
+            border: "1px solid #e2e8f0",
+            borderRadius: 10,
+            padding: "12px 20px",
+            marginBottom: 20,
+            display: "flex",
+            gap: 32,
+            flexWrap: "wrap",
+          }}
+        >
+          <div>
+            <div style={{ fontSize: 11, color: "#64748b" }}>Reputation Tier</div>
+            <div style={{ fontWeight: 700, fontSize: 18, color: "#6366f1" }}>{reputation.tier}</div>
+          </div>
+          <div>
+            <div style={{ fontSize: 11, color: "#64748b" }}>Score</div>
+            <div style={{ fontWeight: 700, fontSize: 18 }}>{reputation.score}</div>
+          </div>
+        </section>
+      )}
+
+      {/* Active Loans */}
+      <section aria-label="Active Loans" style={{ marginBottom: 24 }}>
+        <h2 style={{ fontSize: 16, color: "#1d4ed8", marginBottom: 12 }}>
+          Active Loans ({activeLoans.length})
+        </h2>
+        {activeLoans.length === 0 ? (
+          <p style={{ color: "#94a3b8", fontSize: 14 }}>No active loans.</p>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {activeLoans.map((loan) => (
+              <LoanCard key={loan.id} loan={loan} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Closed Loans */}
+      {closedLoans.length > 0 && (
+        <section aria-label="Closed Loans">
+          <h2 style={{ fontSize: 16, color: "#64748b", marginBottom: 12 }}>
+            Closed Loans ({closedLoans.length})
+          </h2>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {closedLoans.map((loan) => (
+              <LoanCard key={loan.id} loan={loan} />
+            ))}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public component — wraps in its own Redux Provider
+// ---------------------------------------------------------------------------
+
+export interface LoanStatusDashboardProps {
+  /** Borrower address to display loans for */
+  borrower: string;
+  /** socket.io server URL */
+  wsUrl: string;
+  /** Optional API key for socket auth */
+  apiKey?: string;
+}
+
+/**
+ * LoanStatusDashboard — self-contained component that connects to a socket.io
+ * server, displays active/closed loans with real-time updates, repayment
+ * progress, yield earned, and borrower reputation tier.
+ *
+ * Props:
+ * - borrower: Stellar address of the borrower
+ * - wsUrl: socket.io server base URL
+ * - apiKey: optional API key for socket auth header
+ */
+const LoanStatusDashboard: React.FC<LoanStatusDashboardProps> = (props) => (
+  <Provider store={store}>
+    <DashboardInner {...props} />
+  </Provider>
+);
+
+export default LoanStatusDashboard;

--- a/dashboard/src/__tests__/loanDashboard.test.tsx
+++ b/dashboard/src/__tests__/loanDashboard.test.tsx
@@ -1,0 +1,335 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+
+import { stroopsToXlm, xlmToStroops, STROOPS_PER_XLM } from "../stroops";
+import loanReducer, {
+  setConnected,
+  upsertLoan,
+  setLoans,
+  setReputation,
+  type LoanRecord,
+} from "../loanSlice";
+import LoanCard from "../LoanCard";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStore() {
+  return configureStore({ reducer: { loans: loanReducer } });
+}
+
+const activeLoan: LoanRecord = {
+  id: 1,
+  borrower: "GABC1234BORROWER",
+  amount: 10_000_000,       // 1 XLM
+  amount_repaid: 5_000_000, // 0.5 XLM repaid → 50%
+  total_yield: 200_000,     // 0.02 XLM
+  status: "Active",
+  created_at: 1700000000,
+  deadline: 1710000000,
+  loan_purpose: "Business expansion",
+  vouchers: [],
+};
+
+// ---------------------------------------------------------------------------
+// socket.io-client mock — must be at module scope so vi.mock hoisting works.
+// We use a stable object and mutate its methods in beforeEach.
+// ---------------------------------------------------------------------------
+
+type MockHandler = (data?: unknown) => void;
+
+const mockSocket = {
+  emit: vi.fn(),
+  disconnect: vi.fn(),
+  handlers: {} as Record<string, MockHandler>,
+  on(event: string, handler: MockHandler) {
+    // Capture handlers so tests can trigger them
+    this.handlers[event] = handler;
+  },
+};
+
+vi.mock("socket.io-client", () => ({
+  io: vi.fn(() => mockSocket),
+}));
+
+// ---------------------------------------------------------------------------
+// stroopsToXlm — unit tests
+// ---------------------------------------------------------------------------
+
+describe("stroopsToXlm", () => {
+  it("converts 10_000_000 stroops to 1.0000000 XLM", () => {
+    expect(stroopsToXlm(10_000_000)).toBe("1.0000000");
+  });
+
+  it("converts 0 stroops to 0.0000000", () => {
+    expect(stroopsToXlm(0)).toBe("0.0000000");
+  });
+
+  it("produces exactly 7 decimal places", () => {
+    const result = stroopsToXlm(1);
+    expect(result.split(".")[1]).toHaveLength(7);
+  });
+
+  it("converts 1 stroop to 0.0000001 XLM", () => {
+    expect(stroopsToXlm(1)).toBe("0.0000001");
+  });
+
+  it("converts large value: 1_000_000_000 stroops → 100.0000000 XLM", () => {
+    expect(stroopsToXlm(1_000_000_000)).toBe("100.0000000");
+  });
+
+  it("converts bigint input correctly", () => {
+    expect(stroopsToXlm(BigInt(10_000_000))).toBe("1.0000000");
+  });
+
+  it("handles negative stroops", () => {
+    expect(stroopsToXlm(-10_000_000)).toBe("-1.0000000");
+  });
+
+  it("STROOPS_PER_XLM constant equals 10_000_000", () => {
+    expect(STROOPS_PER_XLM).toBe(10_000_000);
+  });
+});
+
+describe("xlmToStroops", () => {
+  it("converts 1 XLM to 10_000_000 stroops", () => {
+    expect(xlmToStroops(1)).toBe(10_000_000);
+  });
+
+  it("converts 0 XLM to 0", () => {
+    expect(xlmToStroops(0)).toBe(0);
+  });
+
+  it("rounds fractional stroops", () => {
+    expect(xlmToStroops(0.00000015)).toBe(2); // 1.5 → rounds to 2
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Redux slice — unit tests
+// ---------------------------------------------------------------------------
+
+describe("loanSlice", () => {
+  it("setConnected sets connected flag", () => {
+    const store = makeStore();
+    store.dispatch(setConnected(true));
+    expect(store.getState().loans.connected).toBe(true);
+  });
+
+  it("upsertLoan adds a new loan", () => {
+    const store = makeStore();
+    store.dispatch(upsertLoan(activeLoan));
+    expect(store.getState().loans.loans).toHaveLength(1);
+    expect(store.getState().loans.loans[0].id).toBe(1);
+  });
+
+  it("upsertLoan updates existing loan by id", () => {
+    const store = makeStore();
+    store.dispatch(upsertLoan(activeLoan));
+    const updated = { ...activeLoan, amount_repaid: 10_000_000 };
+    store.dispatch(upsertLoan(updated));
+    expect(store.getState().loans.loans).toHaveLength(1);
+    expect(store.getState().loans.loans[0].amount_repaid).toBe(10_000_000);
+  });
+
+  it("setLoans replaces all loans", () => {
+    const store = makeStore();
+    store.dispatch(upsertLoan(activeLoan));
+    const loan2: LoanRecord = { ...activeLoan, id: 2, status: "Repaid" };
+    store.dispatch(setLoans([loan2]));
+    expect(store.getState().loans.loans).toHaveLength(1);
+    expect(store.getState().loans.loans[0].id).toBe(2);
+  });
+
+  it("setReputation stores reputation info", () => {
+    const store = makeStore();
+    store.dispatch(setReputation({ tier: "Gold", score: 90 }));
+    expect(store.getState().loans.reputation?.tier).toBe("Gold");
+    expect(store.getState().loans.reputation?.score).toBe(90);
+  });
+
+  it("lastUpdated is set after upsertLoan", () => {
+    const store = makeStore();
+    expect(store.getState().loans.lastUpdated).toBeNull();
+    store.dispatch(upsertLoan(activeLoan));
+    expect(store.getState().loans.lastUpdated).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useLoanSocket — WebSocket integration tests
+// ---------------------------------------------------------------------------
+
+describe("useLoanSocket via LoanStatusDashboard", () => {
+  beforeEach(() => {
+    // Reset the stable mock socket between tests
+    mockSocket.emit = vi.fn();
+    mockSocket.disconnect = vi.fn();
+    mockSocket.handlers = {};
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("dispatches setConnected(true) on connect event", async () => {
+    const { useLoanSocket } = await import("../useLoanSocket");
+    const testStore = makeStore();
+    function TestHook() {
+      useLoanSocket({ url: "http://localhost:3000", borrower: "GABC" });
+      return null;
+    }
+    // Render so useEffect fires and registers handlers
+    await act(async () => {
+      render(<Provider store={testStore}><TestHook /></Provider>);
+    });
+    // Now trigger the event
+    await act(async () => {
+      mockSocket.handlers["connect"]?.();
+    });
+    expect(testStore.getState().loans.connected).toBe(true);
+  });
+
+  it("dispatches setConnected(false) on disconnect", async () => {
+    const { useLoanSocket } = await import("../useLoanSocket");
+    const testStore = makeStore();
+    testStore.dispatch(setConnected(true));
+    function TestHook() {
+      useLoanSocket({ url: "http://localhost:3000", borrower: "GABC" });
+      return null;
+    }
+    await act(async () => {
+      render(<Provider store={testStore}><TestHook /></Provider>);
+    });
+    await act(async () => {
+      mockSocket.handlers["disconnect"]?.();
+    });
+    expect(testStore.getState().loans.connected).toBe(false);
+  });
+
+  it("dispatches upsertLoan on loan:update event", async () => {
+    const { useLoanSocket } = await import("../useLoanSocket");
+    const testStore = makeStore();
+    function TestHook() {
+      useLoanSocket({ url: "http://localhost:3000", borrower: "GABC" });
+      return null;
+    }
+    await act(async () => {
+      render(<Provider store={testStore}><TestHook /></Provider>);
+    });
+    await act(async () => {
+      mockSocket.handlers["loan:update"]?.(activeLoan);
+    });
+    expect(testStore.getState().loans.loans).toHaveLength(1);
+    expect(testStore.getState().loans.loans[0].id).toBe(1);
+  });
+
+  it("dispatches setLoans on loan:list event", async () => {
+    const { useLoanSocket } = await import("../useLoanSocket");
+    const testStore = makeStore();
+    function TestHook() {
+      useLoanSocket({ url: "http://localhost:3000", borrower: "GABC" });
+      return null;
+    }
+    await act(async () => {
+      render(<Provider store={testStore}><TestHook /></Provider>);
+    });
+    await act(async () => {
+      mockSocket.handlers["loan:list"]?.([activeLoan]);
+    });
+    expect(testStore.getState().loans.loans).toHaveLength(1);
+  });
+
+  it("emits subscribe with borrower on connect", async () => {
+    const { useLoanSocket } = await import("../useLoanSocket");
+    const testStore = makeStore();
+    function TestHook() {
+      useLoanSocket({ url: "http://localhost:3000", borrower: "GABC_ADDR" });
+      return null;
+    }
+    await act(async () => {
+      render(<Provider store={testStore}><TestHook /></Provider>);
+    });
+    expect(mockSocket.emit).toHaveBeenCalledWith("subscribe", { borrower: "GABC_ADDR" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LoanCard — component rendering tests
+// ---------------------------------------------------------------------------
+
+describe("LoanCard", () => {
+  function renderCard(loan: LoanRecord) {
+    const testStore = makeStore();
+    return render(
+      <Provider store={testStore}>
+        <LoanCard loan={loan} />
+      </Provider>
+    );
+  }
+
+  it("renders borrower address", () => {
+    renderCard(activeLoan);
+    expect(screen.getByText("GABC1234BORROWER")).toBeInTheDocument();
+  });
+
+  it("renders loan purpose", () => {
+    renderCard(activeLoan);
+    expect(screen.getByText("Business expansion")).toBeInTheDocument();
+  });
+
+  it("renders principal in XLM (7 decimal places)", () => {
+    renderCard(activeLoan);
+    // 10_000_000 stroops = 1.0000000 XLM
+    expect(screen.getByText("1.0000000 XLM")).toBeInTheDocument();
+  });
+
+  it("renders yield in XLM", () => {
+    renderCard(activeLoan);
+    // 200_000 stroops = 0.0200000 XLM
+    expect(screen.getByText("0.0200000 XLM")).toBeInTheDocument();
+  });
+
+  it("shows Active status badge", () => {
+    renderCard(activeLoan);
+    expect(screen.getByLabelText("Status: Active")).toBeInTheDocument();
+  });
+
+  it("shows Repaid status badge", () => {
+    renderCard({ ...activeLoan, status: "Repaid" });
+    expect(screen.getByLabelText("Status: Repaid")).toBeInTheDocument();
+  });
+
+  it("shows Defaulted status badge", () => {
+    renderCard({ ...activeLoan, status: "Defaulted" });
+    expect(screen.getByLabelText("Status: Defaulted")).toBeInTheDocument();
+  });
+
+  it("shows repayment progress bar with correct percentage", () => {
+    renderCard(activeLoan);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toBeInTheDocument();
+    expect(bar).toHaveAttribute("aria-valuenow", "50");
+  });
+
+  it("shows 0% repayment when amount_repaid is 0", () => {
+    renderCard({ ...activeLoan, amount_repaid: 0 });
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("caps repayment percentage at 100%", () => {
+    renderCard({ ...activeLoan, amount_repaid: 20_000_000 }); // overpayment
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "100");
+  });
+
+  it("renders article with accessible label", () => {
+    renderCard(activeLoan);
+    expect(screen.getByRole("article", { name: "Loan 1" })).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/loanSlice.ts
+++ b/dashboard/src/loanSlice.ts
@@ -1,0 +1,70 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type LoanStatus = "Active" | "Repaid" | "Defaulted" | "None";
+
+export interface VouchRecord {
+  voucher: string;
+  stake: number;
+  vouch_timestamp: number;
+}
+
+export interface LoanRecord {
+  id: number;
+  borrower: string;
+  amount: number;           // stroops
+  amount_repaid: number;    // stroops
+  total_yield: number;      // stroops
+  status: LoanStatus;
+  created_at: number;       // unix timestamp
+  deadline: number;         // unix timestamp
+  loan_purpose: string;
+  vouchers: VouchRecord[];
+}
+
+export interface ReputationInfo {
+  tier: string;
+  score: number;
+}
+
+export interface LoanState {
+  loans: LoanRecord[];
+  reputation: ReputationInfo | null;
+  connected: boolean;
+  lastUpdated: number | null;
+}
+
+const initialState: LoanState = {
+  loans: [],
+  reputation: null,
+  connected: false,
+  lastUpdated: null,
+};
+
+const loanSlice = createSlice({
+  name: "loans",
+  initialState,
+  reducers: {
+    setConnected(state, action: PayloadAction<boolean>) {
+      state.connected = action.payload;
+    },
+    upsertLoan(state, action: PayloadAction<LoanRecord>) {
+      const idx = state.loans.findIndex((l) => l.id === action.payload.id);
+      if (idx >= 0) {
+        state.loans[idx] = action.payload;
+      } else {
+        state.loans.push(action.payload);
+      }
+      state.lastUpdated = Date.now();
+    },
+    setLoans(state, action: PayloadAction<LoanRecord[]>) {
+      state.loans = action.payload;
+      state.lastUpdated = Date.now();
+    },
+    setReputation(state, action: PayloadAction<ReputationInfo>) {
+      state.reputation = action.payload;
+    },
+  },
+});
+
+export const { setConnected, upsertLoan, setLoans, setReputation } = loanSlice.actions;
+export default loanSlice.reducer;

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -1,0 +1,9 @@
+import { configureStore } from "@reduxjs/toolkit";
+import loanReducer from "./loanSlice";
+
+export const store = configureStore({
+  reducer: { loans: loanReducer },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/dashboard/src/stroops.ts
+++ b/dashboard/src/stroops.ts
@@ -1,0 +1,26 @@
+/**
+ * Stellar stroop conversion utilities.
+ * 1 XLM = 10,000,000 stroops (10^7).
+ * All monetary amounts from the contract are denominated in stroops (i128).
+ */
+
+export const STROOPS_PER_XLM = 10_000_000;
+
+/**
+ * Convert stroops to XLM with 7 decimal precision.
+ * Handles 0, negative values, and large integers safely.
+ *
+ * @param stroops - Amount in stroops (number or bigint)
+ * @returns XLM value as a string with 7 decimal places
+ */
+export function stroopsToXlm(stroops: number | bigint): string {
+  const n = typeof stroops === "bigint" ? Number(stroops) : stroops;
+  return (n / STROOPS_PER_XLM).toFixed(7);
+}
+
+/**
+ * Convert XLM to stroops (rounds to nearest integer).
+ */
+export function xlmToStroops(xlm: number): number {
+  return Math.round(xlm * STROOPS_PER_XLM);
+}

--- a/dashboard/src/useLoanSocket.ts
+++ b/dashboard/src/useLoanSocket.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { useDispatch } from "react-redux";
+import { io, Socket } from "socket.io-client";
+import { AppDispatch } from "./store";
+import { setConnected, upsertLoan, setLoans, setReputation } from "./loanSlice";
+import type { LoanRecord, ReputationInfo } from "./loanSlice";
+
+export interface UseLoanSocketOptions {
+  /** socket.io server URL, e.g. "http://localhost:3000" */
+  url: string;
+  /** Borrower address to subscribe to */
+  borrower: string;
+  /** API key sent in socket auth header */
+  apiKey?: string;
+}
+
+/**
+ * Opens a socket.io connection to the loan-status server and dispatches
+ * Redux actions as the server pushes events.
+ *
+ * Events handled:
+ *  - "loan:update"    → upsertLoan
+ *  - "loan:list"      → setLoans
+ *  - "reputation"     → setReputation
+ */
+export function useLoanSocket({ url, borrower, apiKey }: UseLoanSocketOptions): void {
+  const dispatch = useDispatch<AppDispatch>();
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    const socket = io(url, {
+      auth: apiKey ? { key: apiKey } : undefined,
+      transports: ["websocket"],
+    });
+
+    socketRef.current = socket;
+
+    socket.on("connect", () => dispatch(setConnected(true)));
+    socket.on("disconnect", () => dispatch(setConnected(false)));
+
+    // Subscribe to this borrower's updates
+    socket.emit("subscribe", { borrower });
+
+    socket.on("loan:update", (loan: LoanRecord) => dispatch(upsertLoan(loan)));
+    socket.on("loan:list", (loans: LoanRecord[]) => dispatch(setLoans(loans)));
+    socket.on("reputation", (rep: ReputationInfo) => dispatch(setReputation(rep)));
+
+    return () => {
+      socket.disconnect();
+      dispatch(setConnected(false));
+    };
+  }, [url, borrower, apiKey, dispatch]);
+}


### PR DESCRIPTION
Closes #834 

## Summary
Implements a fully functional real-time loan status dashboard for borrowers, displaying active loans, repayment progress, yield earned, and reputation tier with live updates streamed over socket.io WebSocket.

## New Files

### dashboard/src/stroops.ts
- Exports `stroopsToXlm(stroops)` — converts stroop amounts (number | bigint) to XLM string with exactly 7 decimal places (e.g. 10_000_000 → "1.0000000")
- Exports `xlmToStroops(xlm)` — converts XLM float to stroops integer (rounded)
- Exports `STROOPS_PER_XLM = 10_000_000` constant
- Handles 0, negative, large integers, and bigint inputs safely

### dashboard/src/loanSlice.ts
- Redux Toolkit slice for loan state management
- Types: `LoanRecord`, `VouchRecord`, `ReputationInfo`, `LoanStatus`
- Actions: `upsertLoan` (add or update by id), `setLoans` (replace all), `setReputation`, `setConnected`, with `lastUpdated` timestamp tracking

### dashboard/src/store.ts
- Configures Redux store with `loanReducer`
- Exports `RootState` and `AppDispatch` types

### dashboard/src/useLoanSocket.ts
- React hook using socket.io-client to connect to the loan-status server
- Dispatches Redux actions on socket events:
  - `connect` → `setConnected(true)`
  - `disconnect` → `setConnected(false)`
  - `loan:update` → `upsertLoan`
  - `loan:list` → `setLoans`
  - `reputation` → `setReputation`
- Emits `subscribe` with borrower address on mount
- Supports optional `apiKey` in socket auth header
- Cleans up and dispatches `setConnected(false)` on unmount

### dashboard/src/LoanCard.tsx
- Displays a single `LoanRecord` with:
  - Borrower address, loan purpose
  - Principal and yield amounts converted from stroops to XLM (7 d.p.)
  - Repayment deadline
  - Status badge (Active / Repaid / Defaulted) with colour coding
  - Animated repayment progress bar capped at 100%
- Fully accessible: `role="article"`, `role="progressbar"` with `aria-valuenow/min/max`, `aria-label` on status badge
- Mobile-responsive flex layout

### dashboard/src/LoanStatusDashboard.tsx
- Top-level component wrapping its own Redux `Provider`
- Props: `borrower`, `wsUrl`, optional `apiKey`
- Sections: live indicator, reputation tier/score, active loans, closed loans
- Shows "Updated HH:MM:SS" timestamp from `lastUpdated`
- Delegates WebSocket lifecycle to `useLoanSocket`

### dashboard/src/__tests__/loanDashboard.test.tsx
- 33 tests across 4 suites (all passing):
  - `stroopsToXlm` — 8 cases: zero, one stroop, large value, bigint, negative, 7 d.p. precision, constant value, XLM-to-stroops rounding
  - `loanSlice` — 6 cases: setConnected, upsertLoan (add + update), setLoans, setReputation, lastUpdated tracking
  - `useLoanSocket` — 5 cases: connect/disconnect dispatch, loan:update, loan:list, subscribe emit; uses module-level vi.mock for socket.io-client
  - `LoanCard` — 11 cases: borrower, purpose, principal XLM, yield XLM, Active/Repaid/Defaulted badges, progress bar value, 0% edge, 100% cap, accessible article label

## Dependencies Added
- socket.io-client — WebSocket client for real-time loan updates
- @reduxjs/toolkit + react-redux — state management for loan data
- tailwindcss — CSS utility framework (available for future Tailwind usage)
- @types/socket.io-client — TypeScript types

## Test Results
63 tests passing (33 new + 12 AnalyticsDashboard + 18 analytics), 0 failing