### PR TITLE
feat: Add Pause-Thaw State Machine for Safe Recovery

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -268,11 +268,55 @@ pub fn upgrade(env: Env, admin_signers: Vec<Address>, new_wasm_hash: BytesN<32>)
 
 pub fn pause(env: Env, admin_signers: Vec<Address>) {
     require_admin_approval(&env, &admin_signers);
+    let now = env.ledger().timestamp();
     env.storage().instance().set(&DataKey::Paused, &true);
     env.storage().instance().set(&DataKey::PauseMode, &crate::types::PauseMode::Paused);
+    // Record the pause timestamp so begin_thaw() can reference it.
+    // ThawState is written with thaw_start_timestamp = 0 (thaw not yet started).
+    env.storage().instance().set(
+        &DataKey::ThawState,
+        &crate::types::ThawState {
+            pause_timestamp: now,
+            thaw_duration: crate::types::THAW_DURATION_SECS,
+            thaw_start_timestamp: 0,
+        },
+    );
     env.events().publish(
         (symbol_short!("admin"), symbol_short!("pause")),
-        (admin_signers.get(0).unwrap(), env.ledger().timestamp()),
+        (admin_signers.get(0).unwrap(), now),
+    );
+}
+
+/// Transition from `Paused` → `Thawing`.
+/// Only reads and withdrawals are allowed during the thaw window (24 h).
+/// After the window elapses the contract auto-transitions back to `Normal`.
+pub fn begin_thaw(env: Env, admin_signers: Vec<Address>) {
+    require_admin_approval(&env, &admin_signers);
+    let mode: crate::types::PauseMode = env
+        .storage()
+        .instance()
+        .get(&DataKey::PauseMode)
+        .unwrap_or(crate::types::PauseMode::None);
+    assert!(
+        mode == crate::types::PauseMode::Paused,
+        "begin_thaw requires contract to be in Paused state"
+    );
+
+    let now = env.ledger().timestamp();
+    // Update existing ThawState with the actual thaw start timestamp.
+    let mut thaw: crate::types::ThawState = env
+        .storage()
+        .instance()
+        .get(&DataKey::ThawState)
+        .expect("pause state not found");
+    thaw.thaw_start_timestamp = now;
+
+    env.storage().instance().set(&DataKey::PauseMode, &crate::types::PauseMode::Thawing);
+    env.storage().instance().set(&DataKey::ThawState, &thaw);
+
+    env.events().publish(
+        (symbol_short!("admin"), symbol_short!("beg_thaw")),
+        (admin_signers.get(0).unwrap(), now, thaw.thaw_duration),
     );
 }
 
@@ -287,11 +331,12 @@ pub fn unpause(env: Env, admin_signers: Vec<Address>) {
     );
 }
 
-/// Pause the contract with a gradual thaw period allowing emergency withdrawals
+/// Pause the contract and immediately enter Thawing (combined one-step operation).
+/// Writes are blocked immediately; reads and withdrawals allowed for `thaw_duration` seconds.
 pub fn pause_with_thaw(env: Env, admin_signers: Vec<Address>, thaw_duration: u64) {
     require_admin_approval(&env, &admin_signers);
     let now = env.ledger().timestamp();
-    
+
     env.storage().instance().set(&DataKey::Paused, &true);
     env.storage().instance().set(&DataKey::PauseMode, &crate::types::PauseMode::Thawing);
     env.storage().instance().set(
@@ -302,7 +347,7 @@ pub fn pause_with_thaw(env: Env, admin_signers: Vec<Address>, thaw_duration: u64
             thaw_start_timestamp: now,
         },
     );
-    
+
     env.events().publish(
         (symbol_short!("admin"), symbol_short!("pse_thaw")),
         (admin_signers.get(0).unwrap(), now, thaw_duration),
@@ -314,7 +359,7 @@ pub fn is_in_thaw_period(env: &Env) -> bool {
     if let Some(thaw_state) = env.storage().instance().get::<_, crate::types::ThawState>(&DataKey::ThawState) {
         let now = env.ledger().timestamp();
         let thaw_end = thaw_state.thaw_start_timestamp + thaw_state.thaw_duration;
-        now <= thaw_end
+        thaw_state.thaw_start_timestamp > 0 && now <= thaw_end
     } else {
         false
     }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -668,6 +668,20 @@ impl QuorumCreditContract {
         admin::pause_with_thaw(env, admin_signers, thaw_duration)
     }
 
+    /// Transition the contract from `Paused` to `Thawing`.
+    /// During the 24-hour thaw window only reads and withdrawals are allowed.
+    /// The contract auto-transitions back to `Normal` once the window elapses.
+    ///
+    /// # Arguments
+    /// * `admin_signers` - Vector of admin addresses (must meet threshold)
+    ///
+    /// # Panics
+    /// * If admin approval is insufficient
+    /// * If the contract is not currently in the `Paused` state
+    pub fn begin_thaw(env: Env, admin_signers: Vec<Address>) {
+        admin::begin_thaw(env, admin_signers)
+    }
+
     /// Blacklist a borrower (prevents them from requesting loans).
     ///
     /// # Arguments
@@ -1037,6 +1051,19 @@ impl QuorumCreditContract {
             .instance()
             .get(&DataKey::Paused)
             .unwrap_or(false)
+    }
+
+    /// Get the current pause state of the contract.
+    ///
+    /// Returns the [`PauseMode`] reflecting the live state:
+    /// - `None`    — contract is operating normally
+    /// - `Paused`  — all writes are blocked
+    /// - `Thawing` — only reads and withdrawals are allowed (auto-clears after 24 h)
+    ///
+    /// This function also performs the automatic `Thawing → None` transition if
+    /// the 24-hour thaw window has elapsed.
+    pub fn get_pause_state(env: Env) -> PauseMode {
+        helpers::get_pause_mode(&env)
     }
 
     /// Get the loan status for a borrower.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -120,4 +120,7 @@ pub enum ContractError {
     CreditScoreNotFound = 114,
     /// Credit score configuration is invalid.
     InvalidCreditConfig = 115,
+    /// A write operation was attempted while the contract is in the Thawing state.
+    /// Only reads and withdrawals are permitted during a thaw period.
+    ContractThawing = 116,
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::errors::ContractError;
 use crate::types::{
-    Config, DataKey, LoanRecord, LoanStatus,
+    Config, DataKey, LoanRecord, LoanStatus, PauseMode, ThawState,
     MIN_DYNAMIC_SLASH_BPS, MAX_DYNAMIC_SLASH_BPS, HEALTH_THRESHOLD_BPS, BPS_DENOMINATOR,
 };
 use soroban_sdk::{token, Address, Env, String, Vec};
@@ -29,20 +29,75 @@ pub fn release_lock(env: &Env) {
 
 // ── Pause Check ───────────────────────────────────────────────────────────────
 
-pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
-    let paused: bool = env
+/// Returns the current [`PauseMode`], automatically transitioning from `Thawing`
+/// to `None` if the thaw window has expired.
+pub fn get_pause_mode(env: &Env) -> PauseMode {
+    let mode: PauseMode = env
         .storage()
         .instance()
-        .get(&DataKey::Paused)
-        .unwrap_or(false);
-    if paused {
-        return Err(ContractError::ContractPaused);
+        .get(&DataKey::PauseMode)
+        .unwrap_or(PauseMode::None);
+
+    if mode == PauseMode::Thawing {
+        // Auto-transition: if thaw window has elapsed, clear thaw state.
+        if let Some(thaw) = env
+            .storage()
+            .instance()
+            .get::<_, ThawState>(&DataKey::ThawState)
+        {
+            let now = env.ledger().timestamp();
+            if now >= thaw.thaw_start_timestamp + thaw.thaw_duration {
+                env.storage()
+                    .instance()
+                    .set(&DataKey::PauseMode, &PauseMode::None);
+                env.storage()
+                    .instance()
+                    .set(&DataKey::Paused, &false);
+                env.storage()
+                    .instance()
+                    .remove(&DataKey::ThawState);
+                return PauseMode::None;
+            }
+        }
     }
+
+    mode
+}
+
+/// Blocks all write operations when `Paused`, `Thawing`, or emergency-paused.
+/// This is the standard guard — call it in every state-mutating function.
+pub fn require_not_paused(env: &Env) -> Result<(), ContractError> {
     let cfg = config(env);
     if cfg.emergency_pause_enabled {
         return Err(ContractError::ContractPaused);
     }
-    Ok(())
+
+    match get_pause_mode(env) {
+        PauseMode::Paused => Err(ContractError::ContractPaused),
+        PauseMode::Thawing => Err(ContractError::ContractThawing),
+        PauseMode::None => Ok(()),
+    }
+}
+
+/// Lenient guard for read-friendly operations (e.g., `withdraw_vouch`).
+/// Blocks when `Paused` or emergency-paused, but passes through during `Thawing`.
+pub fn require_reads_allowed(env: &Env) -> Result<(), ContractError> {
+    let cfg = config(env);
+    if cfg.emergency_pause_enabled {
+        return Err(ContractError::ContractPaused);
+    }
+
+    match get_pause_mode(env) {
+        PauseMode::Paused => Err(ContractError::ContractPaused),
+        PauseMode::Thawing | PauseMode::None => Ok(()),
+    }
+}
+
+/// Alias kept for call-sites already updated to use the explicit thaw-blocking name.
+/// Identical to `require_not_paused`.
+#[inline]
+pub fn require_not_thawing(env: &Env) -> Result<(), ContractError> {
+    require_not_paused(env)
 }
 
 pub fn require_positive_amount(_env: &Env, amount: i128) -> Result<(), ContractError> {
@@ -308,9 +363,8 @@ pub fn calculate_protocol_health_score(env: &Env) -> i128 {
     }
 
     // 30%: not paused
-    let paused: bool = env.storage().instance().get(&DataKey::Paused).unwrap_or(false);
     let cfg = config(env);
-    if !paused && !cfg.emergency_pause_enabled {
+    if get_pause_mode(env) == PauseMode::None && !cfg.emergency_pause_enabled {
         score += 3_000;
     }
 

--- a/src/loan.rs
+++ b/src/loan.rs
@@ -2,7 +2,7 @@ use crate::errors::ContractError;
 use crate::helpers::{
     config, deduct_slash_balance, get_active_loan_record, get_latest_loan_record,
     has_active_loan, next_loan_id, register_borrower_if_needed, require_allowed_token,
-    require_not_paused, require_admin_approval,
+    require_not_paused, require_not_thawing, require_admin_approval,
 };
 use crate::reputation::ReputationNftExternalClient;
 use crate::types::{
@@ -77,7 +77,7 @@ pub fn request_loan(
     token_addr: Address,
 ) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     crate::helpers::check_rate_limit(&env, &borrower)?;
     crate::helpers::check_permission(&env, &borrower, |p| p.can_request_loan)?;
     register_borrower_if_needed(&env, &borrower);
@@ -232,7 +232,7 @@ pub fn apply_slash_recovery(env: &Env, borrower: &Address) -> Result<(), Contrac
 /// Repay loan (active or defaulted).
 pub fn repay(env: Env, borrower: Address, payment: i128) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     crate::helpers::check_rate_limit(&env, &borrower)?;
     crate::helpers::check_permission(&env, &borrower, |p| p.can_repay)?;
 
@@ -428,7 +428,7 @@ pub fn repay_partial(
     token: Address,
 ) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     crate::helpers::check_rate_limit(&env, &borrower)?;
     crate::helpers::check_permission(&env, &borrower, |p| p.can_repay)?;
 
@@ -642,7 +642,7 @@ pub fn get_extension_request(
 
 pub fn defer_payment(env: Env, borrower: Address) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     Err(ContractError::InvalidStateTransition)
 }
 
@@ -690,7 +690,7 @@ pub fn set_loan_guarantor(
     guarantor: Address,
 ) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     let mut loan = get_active_loan_record(&env, &borrower)?;
 
@@ -714,7 +714,7 @@ pub fn set_loan_guarantor(
 
 pub fn remove_loan_guarantor(env: Env, borrower: Address) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     let mut loan = get_active_loan_record(&env, &borrower)?;
     loan.guarantor = None;
@@ -734,7 +734,7 @@ pub fn set_buyback_price(
     price: i128,
 ) -> Result<(), ContractError> {
     borrower.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     let mut loan = get_active_loan_record(&env, &borrower)?;
 

--- a/src/paused_state_test.rs
+++ b/src/paused_state_test.rs
@@ -433,3 +433,94 @@ fn test_all_fund_moving_functions_respect_pause() {
         Err(Ok(ContractError::ContractPaused))
     );
 }
+
+// ── Thaw-State Tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_state_is_paused_after_pause() {
+    let (env, client, admin, _voucher, _borrower, _token_addr, _token_client) = setup_test_env();
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+
+    assert_eq!(client.get_pause_state(), crate::types::PauseMode::Paused);
+}
+
+#[test]
+fn test_begin_thaw_transitions_to_thawing() {
+    let (env, client, admin, _voucher, _borrower, _token_addr, _token_client) = setup_test_env();
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+    client.begin_thaw(&admin_signers);
+
+    assert_eq!(client.get_pause_state(), crate::types::PauseMode::Thawing);
+    // get_paused should still return true during thaw
+    assert_eq!(client.get_paused(), true);
+}
+
+#[test]
+fn test_vouch_blocked_during_thaw() {
+    let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+    client.begin_thaw(&admin_signers);
+
+    // Writes (vouch) must be blocked during thaw
+    let result = client.try_vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
+    assert_eq!(result, Err(Ok(ContractError::ContractThawing)));
+}
+
+#[test]
+fn test_withdrawal_allowed_during_thaw() {
+    let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
+
+    // Create a vouch while normal
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+    client.begin_thaw(&admin_signers);
+
+    // Withdraw vouch should succeed during thaw (reads + withdrawals allowed)
+    client.withdraw_vouch(&voucher, &borrower);
+    assert!(!client.vouch_exists(&voucher, &borrower));
+}
+
+#[test]
+fn test_auto_thaw_after_24h() {
+    let (env, client, admin, voucher, borrower, token_addr, _token_client) = setup_test_env();
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+    client.begin_thaw(&admin_signers);
+
+    // Advance time past 24-hour thaw window
+    env.ledger().with_mut(|li| li.timestamp = 86_401);
+
+    // State should auto-transition to Normal
+    assert_eq!(client.get_pause_state(), crate::types::PauseMode::None);
+
+    // Writes are now allowed again
+    client.vouch(&voucher, &borrower, &1_000_000, &token_addr, &None);
+    assert!(client.vouch_exists(&voucher, &borrower));
+}
+
+#[test]
+fn test_unpause_directly_from_paused() {
+    let (env, client, admin, _voucher, _borrower, _token_addr, _token_client) = setup_test_env();
+
+    let admin_signers = Vec::from_array(&env, [admin.clone()]);
+    client.pause(&admin_signers);
+    client.unpause(&admin_signers);
+
+    assert_eq!(client.get_pause_state(), crate::types::PauseMode::None);
+    assert_eq!(client.get_paused(), false);
+}
+
+#[test]
+fn test_normal_state_at_startup() {
+    let (_, client, _, _, _, _, _) = setup_test_env();
+    assert_eq!(client.get_pause_state(), crate::types::PauseMode::None);
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -249,6 +249,36 @@ pub enum RateType {
     Variable,
 }
 
+// ── Pause State Machine ───────────────────────────────────────────────────────
+
+/// Contract pause state for the Normal → Paused → Thawing → Normal state machine.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PauseMode {
+    /// Contract is operating normally.
+    None,
+    /// Contract is fully paused — all writes are blocked.
+    Paused,
+    /// Contract is thawing — only reads and withdrawals are allowed.
+    /// Automatically transitions to `None` after `thaw_duration` seconds.
+    Thawing,
+}
+
+/// Timestamps recorded when the contract enters or exits a thaw period.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThawState {
+    /// Ledger timestamp when `pause()` was called.
+    pub pause_timestamp: u64,
+    /// Duration of the thaw window in seconds (default 24 h = 86_400).
+    pub thaw_duration: u64,
+    /// Ledger timestamp when `begin_thaw()` was called.
+    pub thaw_start_timestamp: u64,
+}
+
+/// Duration of the thaw period in seconds (24 hours).
+pub const THAW_DURATION_SECS: u64 = 24 * 60 * 60;
+
 // ── Storage Keys ──────────────────────────────────────────────────────────────
 
 #[contracttype]

--- a/src/vouch.rs
+++ b/src/vouch.rs
@@ -2,7 +2,8 @@ extern crate alloc;
 
 use crate::errors::ContractError;
 use crate::helpers::{
-    has_active_loan, require_admin_approval, require_allowed_token, require_not_paused, require_positive_amount,
+    has_active_loan, require_admin_approval, require_allowed_token, require_not_paused,
+    require_not_thawing, require_reads_allowed, require_positive_amount,
 };
 use crate::types::{
     BridgeRecord, DataKey, QueuedWithdrawal, VouchHistoryEntry, VouchRecord,
@@ -90,7 +91,7 @@ fn vouch_with_chain(
     chain_id: u32,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     // Bridge validation: non-native chain vouches require prior bridge validation
     if chain_id != 0 {
@@ -303,7 +304,7 @@ pub fn batch_vouch(
     chain_id: Option<u32>,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     if borrowers.is_empty() || borrowers.len() != stakes.len() {
         return Err(ContractError::InsufficientFunds);
@@ -341,7 +342,7 @@ pub fn increase_stake(
     additional: i128,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     require_positive_amount(&env, additional)?;
 
     let mut vouches: Vec<VouchRecord> = env
@@ -402,7 +403,7 @@ pub fn decrease_stake(
     amount: i128,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
     require_positive_amount(&env, amount)?;
 
     let vouches: Vec<VouchRecord> = env
@@ -462,7 +463,7 @@ pub fn withdraw_vouch(
     borrower: Address,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_reads_allowed(&env)?;
 
     let vouches: Vec<VouchRecord> = env
         .storage()
@@ -512,7 +513,7 @@ pub fn request_withdrawal(
     priority_fee: i128,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     if priority_fee < 0 {
         return Err(ContractError::InvalidAmount);
@@ -565,7 +566,7 @@ pub fn partial_withdraw(
     borrower: Address,
 ) -> Result<(), ContractError> {
     voucher.require_auth();
-    require_not_paused(&env)?;
+    require_not_thawing(&env)?;
 
     let mut vouches: Vec<VouchRecord> = env
         .storage()


### PR DESCRIPTION
## Summary

Implements a 24-hour thaw state after pause, enabling safe recovery without abrupt shutdowns.

**State machine:** Normal → Paused → Thawing(24h) → Normal

During **Thawing**, only reads and withdrawals are allowed. All writes are re-enabled automatically after the 24-hour window elapses.

## Changes

| File | Change |
|------|--------|
| `types.rs` | `PauseMode` enum (`None`, `Paused`, `Thawing`), `ThawState` struct, `THAW_DURATION_SECS` constant |
| `errors.rs` | `ContractThawing = 116` — returned when writes are attempted during thaw |
| `helpers.rs` | `get_pause_mode()` with auto-transition logic; `require_not_paused()` now blocks thaw; `require_reads_allowed()` passes during thaw (for withdrawals) |
| `admin.rs` | `pause()` records `ThawState`; new `begin_thaw()` transitions Paused→Thawing; `pause_with_thaw()` one-step entry |
| `contract.rs` | Exposes `begin_thaw()` and `get_pause_state()` endpoints |
| `vouch.rs` | `withdraw_vouch` uses `require_reads_allowed` (passes during Thawing) |
| `loan.rs` | Write functions block during thaw via `require_not_paused` |
| `paused_state_test.rs` | 7 new tests covering all state transitions |

## Tests Added
- `test_pause_state_is_paused_after_pause`
- `test_begin_thaw_transitions_to_thawing`
- `test_vouch_blocked_during_thaw` (returns `ContractThawing`)
- `test_withdrawal_allowed_during_thaw`
- `test_auto_thaw_after_24h`
- `test_unpause_directly_from_paused`
- `test_normal_state_at_startup`

Closes #840